### PR TITLE
Handle @RequestMapping at method-level only

### DIFF
--- a/src/test/java/com/mangofactory/swagger/springmvc/MvcApiResourceTest.java
+++ b/src/test/java/com/mangofactory/swagger/springmvc/MvcApiResourceTest.java
@@ -1,0 +1,40 @@
+package com.mangofactory.swagger.springmvc;
+
+import lombok.SneakyThrows;
+import org.junit.Test;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.method.HandlerMethod;
+
+import java.lang.reflect.Method;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+public class MvcApiResourceTest
+{
+	class SampleController
+	{
+		@RequestMapping( value = "/no-classlevel-requestmapping", method = RequestMethod.GET )
+		public void sampleMethod()
+		{
+
+		}
+	}
+
+	@Test
+	@SneakyThrows
+	public void assertHandleNoClassLevelRequestMapping()
+	{
+		SampleController sampleController = new SampleController();
+		Method sampleMethod = sampleController.getClass().getMethod("sampleMethod");
+		HandlerMethod handlerMethod = new HandlerMethod(sampleController, sampleMethod);
+
+		MvcApiResource mvcApiResource = new MvcApiResource(handlerMethod, null);
+		String controllerUri = mvcApiResource.getControllerUri();
+
+		assertThat(controllerUri, is(notNullValue()));
+	}
+
+}


### PR DESCRIPTION
@RequestMapping annotation is not mandatory at class-level in Spring
MVC. It can be defined at method-level only.
Swagger-springmvc need to handle such case.
