### PR TITLE
Handle handler with no request method specified

### DIFF
--- a/src/main/java/com/mangofactory/swagger/springmvc/MvcApiReader.java
+++ b/src/main/java/com/mangofactory/swagger/springmvc/MvcApiReader.java
@@ -1,5 +1,8 @@
 package com.mangofactory.swagger.springmvc;
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -34,6 +37,9 @@ public class MvcApiReader {
 	
 	private final Map<Class<?>,DocumentationEndPoint> resourceListCache = Maps.newHashMap();
 	private final Map<Class<?>,ControllerDocumentation> apiCache = Maps.newHashMap();
+    
+	private static final List<RequestMethod> allRequestMethods = 
+			Arrays.asList( RequestMethod.GET, RequestMethod.DELETE, RequestMethod.POST, RequestMethod.PUT );
 	
 	public MvcApiReader(WebApplicationContext context, SwaggerConfiguration swaggerConfiguration)
 	{
@@ -109,7 +115,22 @@ public class MvcApiReader {
 	private void appendOperationsToEndpoint(
 			RequestMappingInfo mappingInfo, HandlerMethod handlerMethod, DocumentationEndPoint endPoint) {
 		ApiMethodReader methodDoc = new ApiMethodReader(handlerMethod);
-		for (RequestMethod requestMethod : mappingInfo.getMethodsCondition().getMethods())
+		
+		if (mappingInfo.getMethodsCondition().getMethods().isEmpty())
+		{
+			// no methods have been specified, it means the endpoint is accessible for all methods
+			appendOperationsToEndpoint( methodDoc, endPoint, allRequestMethods );
+		}
+		else
+		{
+			appendOperationsToEndpoint( methodDoc,endPoint, mappingInfo.getMethodsCondition().getMethods() );
+		}
+	}
+	
+	private void appendOperationsToEndpoint(ApiMethodReader methodDoc, DocumentationEndPoint endPoint,
+                                            Collection<RequestMethod> methods)
+	{
+		for (RequestMethod requestMethod : methods)
 		{
 			DocumentationOperation operation = methodDoc.getOperation(requestMethod);
 			endPoint.addOperation(operation);

--- a/src/test/java/com/mangofactory/swagger/springmvc/MvcApiReaderTest.java
+++ b/src/test/java/com/mangofactory/swagger/springmvc/MvcApiReaderTest.java
@@ -46,5 +46,14 @@ public class MvcApiReaderTest {
 		assertThat(operation, is(notNullValue()));
 		assertThat(operation.getParameters(),hasSize(1));
 		DocumentationParameter parameter = operation.getParameters().get(0);
+
+		operation = petsDocumentation.getEndPoint("/pets/allMethodsAllowed", RequestMethod.GET);
+		assertThat(operation, is(notNullValue()));
+		operation = petsDocumentation.getEndPoint("/pets/allMethodsAllowed", RequestMethod.POST);
+		assertThat(operation, is(notNullValue()));
+		operation = petsDocumentation.getEndPoint("/pets/allMethodsAllowed", RequestMethod.DELETE);
+		assertThat(operation, is(notNullValue()));
+		operation = petsDocumentation.getEndPoint("/pets/allMethodsAllowed", RequestMethod.PUT);
+		assertThat(operation, is(notNullValue()));
 	}
 }

--- a/src/test/java/com/mangofactory/swagger/springmvc/test/PetService.java
+++ b/src/test/java/com/mangofactory/swagger/springmvc/test/PetService.java
@@ -65,4 +65,10 @@ public class PetService {
 			@ApiParam(value = "Tags to filter by", required = true, allowMultiple = true) @RequestParam("tags") String tags) {
 		throw new NotImplementedException();
 	}
+	
+	@RequestMapping("/allMethodsAllowed")
+	public void allMethodAllowed() {
+		throw new NotImplementedException();
+	}
+		
 }


### PR DESCRIPTION
A request method is not mandatory in Spring MVC @RequestMapping.
Ommiting request methods means the handler is accessible from all kind
of methods, i.e. GET, POST, PUT and DELETE.
