### PR TITLE
Only documents controllers with @RequestMapping and @Api annotations

### DIFF
--- a/src/main/java/com/mangofactory/swagger/springmvc/MvcApiReader.java
+++ b/src/main/java/com/mangofactory/swagger/springmvc/MvcApiReader.java
@@ -86,7 +86,7 @@ public class MvcApiReader {
 			MvcApiResource resource = new MvcApiResource(handlerMethod,config);
 			
 			// Don't document our own controllers
-			if (resource.isInternalResource())
+			if (!resource.isDocumentable())
 				continue;
 			
 			addApiListingIfMissing(resource);

--- a/src/main/java/com/mangofactory/swagger/springmvc/MvcApiResource.java
+++ b/src/main/java/com/mangofactory/swagger/springmvc/MvcApiResource.java
@@ -127,5 +127,8 @@ public class MvcApiResource {
 		return controllerClass == DocumentationController.class;
 	}
 
+    public boolean isDocumentable() {
+        return controllerClass.getAnnotation(Api.class) != null;
+    }
 	
 }


### PR DESCRIPTION
This library shouldn't try to create documentation for controllers that are not annotated with @Api
