### PR TITLE
Added support for @RequestHeader

### DIFF
--- a/src/main/java/com/mangofactory/swagger/spring/filters/ParameterFilter.java
+++ b/src/main/java/com/mangofactory/swagger/spring/filters/ParameterFilter.java
@@ -13,6 +13,7 @@ import org.springframework.core.MethodParameter;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import static com.google.common.base.Strings.*;
@@ -99,6 +100,10 @@ public class ParameterFilter implements Filter<DocumentationParameter> {
         if (modelAttribute != null) {
             return "body";
         }
+        RequestHeader requestHeader = methodParameter.getParameterAnnotation(RequestHeader.class);
+        if (requestHeader != null) {
+            return "header";
+        }
         if (isPrimitive(parameterType.getErasedType())) {
             return "query";
         }
@@ -117,6 +122,10 @@ public class ParameterFilter implements Filter<DocumentationParameter> {
         RequestParam requestParam = methodParameter.getParameterAnnotation(RequestParam.class);
         if (requestParam != null && !StringUtils.isEmpty(requestParam.value())) {
             return requestParam.value();
+        }
+        RequestHeader requestHeader = methodParameter.getParameterAnnotation(RequestHeader.class);
+        if (requestHeader != null && !StringUtils.isEmpty(requestHeader.value())) {
+            return requestHeader.value();
         }
         if (!isNullOrEmpty(defaultParameterName)) {
             return defaultParameterName;


### PR DESCRIPTION
This PR adds support for another springframework annotation: @RequestHeader

The analogue annotation from jaxrs: @HeaderParam is covered in the original swagger-jaxrs version, cf:
- how it's handled in jaxrs => https://github.com/wordnik/swagger-core/blob/master/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/JaxrsApiReader.scala#L102
- "header" type => https://github.com/wordnik/swagger-core/blob/master/modules/swagger-core/src/main/java/com/wordnik/swagger/core/ApiValues.java#L32

An example of mapping with @RequestHeader:

```
@RequestMapping(.....)
public ResponseEntity<MyDto> doSth(@RequestHeader("Content-Url") String contentUrl, [... other params ...]) {
    // handle
}
```

Tested against my spring-mvc controllers (3.2.2.RELEASE).
