### PR TITLE
Ensured that mapping documentation is built before every GET

### DIFF
--- a/src/main/java/com/mangofactory/swagger/spring/DocumentationReader.java
+++ b/src/main/java/com/mangofactory/swagger/spring/DocumentationReader.java
@@ -132,6 +132,7 @@ public class DocumentationReader {
     }
 
     public ControllerDocumentation getDocumentation(String apiName) {
+        ensureDocumentationReady();
         for (ControllerDocumentation documentation : resourceDocumentationLookup.values()) {
             if (documentation.matchesName(apiName)) {
                 return documentation;
@@ -142,9 +143,13 @@ public class DocumentationReader {
     }
 
     public Documentation getDocumentation() {
+        ensureDocumentationReady();
+        return documentation;
+    }
+
+    private void ensureDocumentationReady() {
         if (!isMappingBuilt) {
             buildMappingDocuments(context);
         }
-        return documentation;
     }
 }


### PR DESCRIPTION
This patch fixes such a minor issue:
- start up the web app
- make sure you _don't_ GET the resource listing (`curl localhost:8080/swagger-springmvc-test/api-docs`)
- instead, do GET the particular documentation resource, e.g. `curl localhost:8080/swagger-springmvc-test/api-docs/api/examples`
- and what you see is an empty response
