### PR TITLE
Fix for methods with the same name under the same controller

### DIFF
--- a/src/main/java/com/mangofactory/swagger/models/ResolvedTypes.java
+++ b/src/main/java/com/mangofactory/swagger/models/ResolvedTypes.java
@@ -125,7 +125,7 @@ public class ResolvedTypes {
                 new Predicate<ResolvedMethod>() {
                     @Override
                     public boolean apply(ResolvedMethod input) {
-                        return input.getRawMember().getName().equals(methodToResolve.getName());
+                        return input.getRawMember().equals(methodToResolve);
                     }
                 });
         return resolveToMethodWithMaxResolvedTypes(filtered);


### PR DESCRIPTION
Untested

I am having problems with overloaded methods in a controller, it seems that the second method has it parameter types populated with the types of the first one when calling to: 

```
methodParameters(configuration.getTypeResolver(), handlerMethod.getMethod());
```

And that get the wrong types due to the filter applied that only checks by name when you have both method values available, so this should fix the bug.
As the name comparison does not seem casual maybe this patch can cause other bug to reproduce, so please check that it does not break anything.
