### PR TITLE
Reliably obtaining API name from handler

### DIFF
--- a/src/main/java/com/mangofactory/swagger/spring/controller/DocumentationController.java
+++ b/src/main/java/com/mangofactory/swagger/spring/controller/DocumentationController.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -49,11 +50,10 @@ public class DocumentationController implements ServletContextAware {
     public
     @ResponseBody
     ControllerDocumentation getApiDocumentation(HttpServletRequest request) {
-        String fullUrl = String.valueOf(request.getAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE));
-        int indexOfApiName = fullUrl.indexOf("/", 1) + 1;
+        String apiName = extractPathFromPattern(request);
         DocumentationTransformer transformer = swaggerConfiguration.getDocumentationTransformer();
         return (ControllerDocumentation) transformer
-                .applySorting(apiReader.getDocumentation(fullUrl.substring(indexOfApiName)));
+                .applySorting(apiReader.getDocumentation(apiName));
     }
 
     @Override
@@ -61,4 +61,13 @@ public class DocumentationController implements ServletContextAware {
         apiReader = new DocumentationReader(swaggerConfiguration,
                 WebApplicationContextUtils.getWebApplicationContext(servletContext), handlerMappings);
     }
+    
+    private static String extractPathFromPattern(final HttpServletRequest request){
+
+      String path = (String) request.getAttribute(
+              HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE);
+      String bestMatchPattern = (String ) request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
+      
+      return new AntPathMatcher().extractPathWithinPattern(bestMatchPattern, path);
+  }
 }

--- a/src/test/java/com/mangofactory/swagger/spring/DocumentationReaderTest.java
+++ b/src/test/java/com/mangofactory/swagger/spring/DocumentationReaderTest.java
@@ -42,7 +42,8 @@ public class DocumentationReaderTest {
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        when(request.getAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE)).thenReturn("/pets");
+        when(request.getAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE)).thenReturn("//api-docs/pets");
+        when(request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE)).thenReturn("/api-docs/**");
         resourceListing = controller.getResourceListing();
         for (DocumentationEndPoint endPoint : resourceListing.getApis()) {
             if("/api-docs/pets".equals(endPoint.getPath())) {


### PR DESCRIPTION
This fixes an issue when the request provided an URL path with two leading forward slashes (e.g. //api-docs/pets)  to the getApiDocumentation. This happened as the service was behind an Apache load balancing scheme that added an extra leading slash. Fixed by using AntHandlerMatcher to extract API name matched to the *\* wildcard. I expect this to more reliably obtain the API name.
