### PR TITLE
Swagger now uses 'message' rather than 'reason' for API error/status codes

### DIFF
--- a/src/main/java/com/mangofactory/swagger/annotations/ApiError.java
+++ b/src/main/java/com/mangofactory/swagger/annotations/ApiError.java
@@ -20,5 +20,5 @@ public @interface ApiError {
 
     int code();
 
-    String reason();
+    String message();
 }

--- a/src/main/java/com/mangofactory/swagger/spring/filters/ErrorsFilter.java
+++ b/src/main/java/com/mangofactory/swagger/spring/filters/ErrorsFilter.java
@@ -39,7 +39,7 @@ public class ErrorsFilter implements Filter<List<DocumentationError>> {
             appendErrorFromClass(errors, exceptionClass);
         }
         for (ApiError apiError : apiErrors.errors()) {
-            errors.add(new DocumentationError(apiError.code(), apiError.reason()));
+            errors.add(new DocumentationError(apiError.code(), apiError.message()));
         }
     }
 
@@ -48,6 +48,6 @@ public class ErrorsFilter implements Filter<List<DocumentationError>> {
         if (apiError == null) {
             return;
         }
-        errors.add(new DocumentationError(apiError.code(), apiError.reason()));
+        errors.add(new DocumentationError(apiError.code(), apiError.message()));
     }
 }

--- a/src/test/java/com/mangofactory/swagger/spring/OperationReaderTest.java
+++ b/src/test/java/com/mangofactory/swagger/spring/OperationReaderTest.java
@@ -241,8 +241,8 @@ public class OperationReaderTest {
         }
 
         @ApiErrors(errors = {
-                @ApiError(code = 302, reason = "Malformed request"),
-                @ApiError(code = 404, reason = "Not found")
+                @ApiError(code = 302, message = "Malformed request"),
+                @ApiError(code = 404, message = "Not found")
         })
         public void exceptionMethodD() {
         }

--- a/src/test/java/com/mangofactory/swagger/spring/test/PetService.java
+++ b/src/test/java/com/mangofactory/swagger/spring/test/PetService.java
@@ -35,7 +35,7 @@ public class PetService {
 
 	@RequestMapping(method=RequestMethod.POST)
 	@ApiOperation(value = "Add a new pet to the store")
-	@ApiErrors(errors = { @ApiError(code = 405, reason = "Invalid input") })
+	@ApiErrors(errors = { @ApiError(code = 405, message = "Invalid input") })
 	public void addPet(
 			@ApiParam(value = "Pet object that needs to be added to the store", required = true) Pet pet) {
 		throw new NotImplementedException();
@@ -43,9 +43,9 @@ public class PetService {
 
 	@RequestMapping(method=RequestMethod.PUT)
 	@ApiOperation(value = "Update an existing pet")
-	@ApiErrors(errors = { @ApiError(code = 400, reason = "Invalid ID supplied"),
-			@ApiError(code = 404, reason = "Pet not found"),
-			@ApiError(code = 405, reason = "Validation exception") })
+	@ApiErrors(errors = { @ApiError(code = 400, message = "Invalid ID supplied"),
+			@ApiError(code = 404, message = "Pet not found"),
+			@ApiError(code = 405, message = "Validation exception") })
 	public void updatePet(
 			@ApiParam(value = "Pet object that needs to be added to the store", required = true) @RequestBody Pet pet) {
 		throw new NotImplementedException();
@@ -53,7 +53,7 @@ public class PetService {
 
 	@RequestMapping(value="/findByStatus",method=RequestMethod.GET)
 	@ApiOperation(value = "Finds Pets by status", notes = "Multiple status values can be provided with comma seperated strings", responseClass = "ccom.mangofactory.swagger.spring.test.Pet", multiValueResponse = true)
-	@ApiErrors(errors = { @ApiError(code = 400, reason = "Invalid status value") })
+	@ApiErrors(errors = { @ApiError(code = 400, message = "Invalid status value") })
 	public void findPetsByStatus(
 			@ApiParam(value = "Status values that need to be considered for filter", required = true, defaultValue = "available", allowableValues = "available,pending,sold", allowMultiple = true) @RequestParam("status") String status) {
 		throw new NotImplementedException();
@@ -61,7 +61,7 @@ public class PetService {
 
 	@RequestMapping(value="/findByTags",method=RequestMethod.GET)
 	@ApiOperation(value = "Finds Pets by tags", notes = "Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 for testing.", responseClass = "ccom.mangofactory.swagger.spring.test.Pet", multiValueResponse = true)
-	@ApiErrors(errors = { @ApiError(code = 400, reason = "Invalid tag value") })
+	@ApiErrors(errors = { @ApiError(code = 400, message = "Invalid tag value") })
 	@Deprecated
 	public void findPetsByTags(
 			@ApiParam(value = "Tags to filter by", required = true, allowMultiple = true) @RequestParam("tags") String tags) {

--- a/src/test/java/com/mangofactory/swagger/spring/test/PetServiceWithAlternativeListingPath.java
+++ b/src/test/java/com/mangofactory/swagger/spring/test/PetServiceWithAlternativeListingPath.java
@@ -32,7 +32,7 @@ public class PetServiceWithAlternativeListingPath {
 
 	@RequestMapping(method=RequestMethod.POST)
 	@ApiOperation(value = "Add a new pet to the store")
-	@ApiErrors(errors = { @ApiError(code = 405, reason = "Invalid input") })
+	@ApiErrors(errors = { @ApiError(code = 405, message = "Invalid input") })
 	public void addPet(
 			@ApiParam(value = "Pet object that needs to be added to the store", required = true) Pet pet) {
 		throw new NotImplementedException();
@@ -40,9 +40,9 @@ public class PetServiceWithAlternativeListingPath {
 
 	@RequestMapping(method=RequestMethod.PUT)
 	@ApiOperation(value = "Update an existing pet")
-	@ApiErrors(errors = { @ApiError(code = 400, reason = "Invalid ID supplied"),
-			@ApiError(code = 404, reason = "Pet not found"),
-			@ApiError(code = 405, reason = "Validation exception") })
+	@ApiErrors(errors = { @ApiError(code = 400, message = "Invalid ID supplied"),
+			@ApiError(code = 404, message = "Pet not found"),
+			@ApiError(code = 405, message = "Validation exception") })
 	public void updatePet(
 			@ApiParam(value = "Pet object that needs to be added to the store", required = true) @RequestBody Pet pet) {
 		throw new NotImplementedException();
@@ -50,7 +50,7 @@ public class PetServiceWithAlternativeListingPath {
 
 	@RequestMapping(value="/findByStatus",method=RequestMethod.GET)
 	@ApiOperation(value = "Finds Pets by status", notes = "Multiple status values can be provided with comma seperated strings", responseClass = "com.mangofactory.swagger.spring.test.Pet", multiValueResponse = true)
-	@ApiErrors(errors = { @ApiError(code = 400, reason = "Invalid status value") })
+	@ApiErrors(errors = { @ApiError(code = 400, message = "Invalid status value") })
 	public void findPetsByStatus(
 			@ApiParam(value = "Status values that need to be considered for filter", required = true, defaultValue = "available", allowableValues = "available,pending,sold", allowMultiple = true) @RequestParam("status") String status) {
 		throw new NotImplementedException();
@@ -58,7 +58,7 @@ public class PetServiceWithAlternativeListingPath {
 
 	@RequestMapping(value="/findByTags",method=RequestMethod.GET)
 	@ApiOperation(value = "Finds Pets by tags", notes = "Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 for testing.", responseClass = "com.mangofactory.swagger.spring.test.Pet", multiValueResponse = true)
-	@ApiErrors(errors = { @ApiError(code = 400, reason = "Invalid tag value") })
+	@ApiErrors(errors = { @ApiError(code = 400, message = "Invalid tag value") })
 	@Deprecated
 	public void findPetsByTags(
 			@ApiParam(value = "Tags to filter by", required = true, allowMultiple = true) @RequestParam("tags") String tags) {

--- a/src/test/java/com/wordnik/swagger/sample/exception/BadRequestException.java
+++ b/src/test/java/com/wordnik/swagger/sample/exception/BadRequestException.java
@@ -18,7 +18,7 @@ package com.wordnik.swagger.sample.exception;
 
 import com.mangofactory.swagger.annotations.ApiError;
 
-@ApiError(code=302,reason="Malformed request")
+@ApiError(code=302,message="Malformed request")
 public class BadRequestException extends ApiException{
 	private int code;
 	public BadRequestException (int code, String msg) {

--- a/src/test/java/com/wordnik/swagger/sample/exception/NotFoundException.java
+++ b/src/test/java/com/wordnik/swagger/sample/exception/NotFoundException.java
@@ -18,7 +18,7 @@ package com.wordnik.swagger.sample.exception;
 
 import com.mangofactory.swagger.annotations.ApiError;
 
-@ApiError(code=404,reason="Invalid ID Supplied")
+@ApiError(code=404,message="Invalid ID Supplied")
 public class NotFoundException extends ApiException {
 	private int code;
 	public NotFoundException (int code, String msg) {


### PR DESCRIPTION
I've noticed that using the latest swagger UI (http://petstore.swagger.wordnik.com/) my HTTP status codes no longer show the explanation text. Taking a quick look through the json, it seems that the petstore example uses the following json object:

```
{
    "code": 400,
    "message": "Invalid username supplied"
}
```

At the moment, swagger-springmvc generates:

```
{
    "code": 400,
    "reason": "Invalid username supplied"
}
```

This should fix that behaviour.
