### PR TITLE
Added path fragment prefix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.mangofactory</groupId>
     <artifactId>swagger-springmvc</artifactId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>0.7.1-SNAPSHOT</version>
     <name>Swagger SpringMVC</name>
     <url>https://github.com/martypitt/swagger-springmvc</url>
     <licenses>

--- a/src/main/java/com/mangofactory/swagger/spring/controller/DocumentationController.java
+++ b/src/main/java/com/mangofactory/swagger/spring/controller/DocumentationController.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.context.ServletContextAware;
 import org.springframework.web.context.support.WebApplicationContextUtils;
@@ -39,8 +40,15 @@ public class DocumentationController implements ServletContextAware {
     @RequestMapping(method = RequestMethod.GET)
     public
     @ResponseBody
-    Documentation getResourceListing() {
-        Documentation documentation = apiReader.getDocumentation();
+    Documentation getResourceListing(@RequestParam(value="path", required = false) String path) {
+        Documentation documentation;
+        
+        if (path != null) {
+            documentation = apiReader.getFragmentDocumentation(path);
+        } else {
+            documentation = apiReader.getDocumentation();
+        }
+
         DocumentationTransformer transformer = swaggerConfiguration.getDocumentationTransformer();
         return transformer.applySorting(transformer.applyTransformation(documentation));
     }

--- a/src/test/java/com/mangofactory/swagger/spring/DocumentationReaderTest.java
+++ b/src/test/java/com/mangofactory/swagger/spring/DocumentationReaderTest.java
@@ -48,7 +48,7 @@ public class DocumentationReaderTest {
     public void setup() {
         MockitoAnnotations.initMocks(this);
         when(request.getAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE)).thenReturn("/pets");
-        resourceListing = controller.getResourceListing();
+        resourceListing = controller.getResourceListing(null);
         for (DocumentationEndPoint endPoint : resourceListing.getApis()) {
             if("/api-docs/pets".equals(endPoint.getPath())) {
                 petsEndpoint = endPoint;
@@ -102,7 +102,7 @@ public class DocumentationReaderTest {
     @Test
     public void shouldLocateDocsOnControllerWithoutTopLevelRequestMapping(){
         when(request.getAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE)).thenReturn("/business-service");
-        resourceListing = controller.getResourceListing();
+        resourceListing = controller.getResourceListing(null);
 
         ControllerDocumentation documentation = controller.getApiDocumentation(request);
         List<DocumentationOperation> endPoint = documentation.getEndPoint("/businesses/{businessId}", RequestMethod.GET);


### PR DESCRIPTION
I really like integrating this into our existing spring project, but one thing I wanted was the ability to filter what's returned depending on the root prefix.

For example, my project might have a versioned root, so I might have "/v1/thing" and "/v2/thing". So what this change does now is it allows you make a request like this: "/api-docs?path=v1", and this will return controllerEndpoints which start with `/v1/`.
