### PR TITLE
fix request mapping regexp

### DIFF
--- a/src/main/java/com/mangofactory/swagger/core/DefaultSwaggerPathProvider.java
+++ b/src/main/java/com/mangofactory/swagger/core/DefaultSwaggerPathProvider.java
@@ -35,7 +35,7 @@ public class DefaultSwaggerPathProvider implements SwaggerPathProvider {
    public String getRequestMappingEndpoint(String requestMappingPattern) {
       String result = requestMappingPattern;
       //remove regex portion '/{businessId:\\w+}'
-      result = result.replaceAll(":.*?}", "}");
+      result = result.replaceAll("\\{(.*?):.*?\\}", "{$1}");
       return result.isEmpty() ? "/" : result;
    }
 


### PR DESCRIPTION
The old regexp discarded everything after a colon.

This would incorrectly transform URLs like "foo/bar:{baz}" into
"foo/bar}".
