### PR TITLE
Read descriptions from annotation

### DIFF
--- a/swagger-springmvc/src/main/java/com/mangofactory/swagger/core/ClassOrApiAnnotationResourceGrouping.java
+++ b/swagger-springmvc/src/main/java/com/mangofactory/swagger/core/ClassOrApiAnnotationResourceGrouping.java
@@ -1,5 +1,6 @@
 package com.mangofactory.swagger.core;
 
+import com.google.common.base.Optional;
 import com.mangofactory.swagger.scanners.ResourceGroup;
 import com.wordnik.swagger.annotations.Api;
 import org.slf4j.Logger;
@@ -13,6 +14,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.Set;
 
+import static com.google.common.base.Strings.*;
 import static com.google.common.collect.Sets.*;
 import static org.apache.commons.lang.StringUtils.*;
 
@@ -26,7 +28,19 @@ public class ClassOrApiAnnotationResourceGrouping implements ResourceGroupingStr
 
    @Override
    public String getResourceDescription(RequestMappingInfo requestMappingInfo, HandlerMethod handlerMethod) {
-      return getClassOrApiAnnotationValue(handlerMethod);
+      Class<?> controllerClass = handlerMethod.getBeanType();
+      String group = controllerClass.getCanonicalName();
+      
+      Api apiAnnotation = AnnotationUtils.findAnnotation(controllerClass, Api.class);
+      if (null != apiAnnotation) {
+          String descriptionFromAnnotation = Optional.fromNullable(emptyToNull(apiAnnotation.description()))
+                  .or(apiAnnotation.value());
+          if (!isNullOrEmpty(descriptionFromAnnotation)) {
+              return descriptionFromAnnotation;
+          }
+      }
+      
+      return group;
    }
 
    @Override

--- a/swagger-springmvc/src/test/groovy/com/mangofactory/swagger/core/ClassOrApiAnnotationResourceGroupingSpec.groovy
+++ b/swagger-springmvc/src/test/groovy/com/mangofactory/swagger/core/ClassOrApiAnnotationResourceGroupingSpec.groovy
@@ -22,6 +22,6 @@ class ClassOrApiAnnotationResourceGroupingSpec extends Specification {
     where:
       handlerMethod                  | groupName                                   | realPath                                     | description
       dummyHandlerMethod()           | "com_mangofactory_swagger_dummy_DummyClass" | "/com_mangofactory_swagger_dummy_DummyClass" |"com.mangofactory.swagger.dummy.DummyClass"
-      dummyControllerHandlerMethod() | "Group+name"                                | "/Group+name"                                | "Group name"
+      dummyControllerHandlerMethod() | "Group+name"                                | "/Group+name"                                | "Group description"
    }
 }

--- a/swagger-springmvc/src/test/java/com/mangofactory/swagger/dummy/DummyController.java
+++ b/swagger-springmvc/src/test/java/com/mangofactory/swagger/dummy/DummyController.java
@@ -4,7 +4,7 @@ import com.wordnik.swagger.annotations.Api;
 import org.springframework.stereotype.Controller;
 
 @Controller
-@Api(value = "Group name")
+@Api(value = "Group name", description="Group description")
 public class DummyController {
 
    public void dummyMethod(){


### PR DESCRIPTION
Hi, here is a small change to read the api description from annotation's description property (as opposed to value currently) when using ClassOrApiAnnotationResourceGrouping.
