### PR TITLE
Support for multi segment resource groups (api/v1/businesses)

### DIFF
--- a/swagger-springmvc/src/test/groovy/com/mangofactory/swagger/controllers/DefaultSwaggerControllerSpec.groovy
+++ b/swagger-springmvc/src/test/groovy/com/mangofactory/swagger/controllers/DefaultSwaggerControllerSpec.groovy
@@ -78,11 +78,28 @@ class DefaultSwaggerControllerSpec extends Specification {
     result.getResponse().getStatus() == 200
 
   }
+  
+  def "should respond with api listing for a given multi segment resource group"() {
+    given:
+      SwaggerCache swaggerCache = new SwaggerCache();
+      swaggerCache.swaggerApiListingMap = ['api/v1/businesses': apiListing()]
+      swaggerCache.swaggerApiResourceListingMap = ['some-swagger-group': resourceListing()]
+      controller.swaggerCache = swaggerCache
+        
+    when:
+      MvcResult result = mockMvc.perform(get("/api-docs/api/v1/businesses")).andDo(print()).andReturn()
+      def responseJson = jsonBodyResponse(result)
+      
+    then:
+      result.getResponse().getStatus() == 200
+  
+  }
 
   def "should respond with api listing for a given resource group prefixed with a swagger group"() {
     given:
     SwaggerCache swaggerCache = new SwaggerCache();
     swaggerCache.swaggerApiListingMap = ['businesses': apiListing()]
+    swaggerCache.swaggerApiResourceListingMap = ['some-swagger-group': resourceListing()]
     controller.swaggerCache = swaggerCache
     when:
     MvcResult result = mockMvc.perform(get("/api-docs/some-swagger-group/businesses")).andDo(print()).andReturn()
@@ -93,6 +110,22 @@ class DefaultSwaggerControllerSpec extends Specification {
 
   }
 
+  def "should respond with api listing for a given multi segment resource group prefixed with a swagger group"() {
+	given:
+	  SwaggerCache swaggerCache = new SwaggerCache();
+	  swaggerCache.swaggerApiListingMap = ['api/v1/businesses': apiListing()]
+      swaggerCache.swaggerApiResourceListingMap = ['some-swagger-group': resourceListing()]
+	  controller.swaggerCache = swaggerCache
+	  
+	when:
+	  MvcResult result = mockMvc.perform(get("/api-docs/some-swagger-group/api/v1/businesses")).andDo(print()).andReturn()
+	  def responseJson = jsonBodyResponse(result)
+
+	then:
+	  result.getResponse().getStatus() == 200
+
+  }
+  
   def "should respond with auth included"() {
   given:
     SwaggerCache swaggerCache = new SwaggerCache();

--- a/swagger-springmvc/src/test/groovy/com/mangofactory/swagger/mixins/ApiListingSupport.groovy
+++ b/swagger-springmvc/src/test/groovy/com/mangofactory/swagger/mixins/ApiListingSupport.groovy
@@ -24,7 +24,16 @@ class ApiListingSupport {
               toOption(null),
               1);
    }
-
+   
+   def resourceListing() {
+      new ResourceListing(
+              "apiVersion",
+              "swagger version",
+              emptyScalaList(),
+              emptyScalaList(),
+              toOption(null))
+   }
+   
    def resourceListing(List<OAuth> authorizationTypes) {
       new ResourceListing(
               "apiVersion",


### PR DESCRIPTION
We annotaded controllers as follows:

```
@Controller
@RequestMapping("${api.root}/v1/entity")
@Api(value = "Entity")
public class EntityController {
    @RequestMapping(value = "/{" + ENTITY_ID_PATH_VARIABE + "}", method = RequestMethod.GET)
    @ResponseBody
    @ApiOperation(value = "get a specific Entity", response = Entity.class)
    public Entity getEntityById(@PathVariable(ENTITY_ID_PATH_VARIABE) ResourceId entityId) {}
}
```

This leads to "api/v1/entity" as a resource group. The `DefaultSwaggerController` was not able to match the request for such a resource group since the used `RequestMapping` ignored "`/`".
- updated DefaultSwaggerController to handle resource groups with
  multiple segment path like api/v1/businesses
- added Testcase for multi segment resource groups
