### PR TITLE
Adding the posibility of ignoring an entire controller

### DIFF
--- a/swagger-springmvc/src/main/java/com/mangofactory/swagger/annotations/ApiIgnore.java
+++ b/swagger-springmvc/src/main/java/com/mangofactory/swagger/annotations/ApiIgnore.java
@@ -6,6 +6,6 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.METHOD})
+@Target({ ElementType.METHOD, ElementType.TYPE, ElementType.PARAMETER})
 public @interface ApiIgnore {
 }

--- a/swagger-springmvc/src/main/java/com/mangofactory/swagger/configuration/SpringSwaggerConfig.java
+++ b/swagger-springmvc/src/main/java/com/mangofactory/swagger/configuration/SpringSwaggerConfig.java
@@ -101,6 +101,7 @@ public class SpringSwaggerConfig {
     ignored.add(BindingResult.class);
     ignored.add(ServletContext.class);
     ignored.add(UriComponentsBuilder.class);
+    ignored.add(ApiIgnore.class);
     return ignored;
   }
 

--- a/swagger-springmvc/src/main/java/com/mangofactory/swagger/scanners/ApiListingReferenceScanner.java
+++ b/swagger-springmvc/src/main/java/com/mangofactory/swagger/scanners/ApiListingReferenceScanner.java
@@ -115,7 +115,19 @@ public class ApiListingReferenceScanner {
 
    private boolean shouldIncludeRequestMapping(RequestMappingInfo requestMappingInfo, HandlerMethod handlerMethod) {
       return requestMappingMatchesAnIncludePattern(requestMappingInfo, handlerMethod)
+              && !classHasIgnoredAnnotatedRequestMapping(handlerMethod.getMethod().getDeclaringClass())
               && !hasIgnoredAnnotatedRequestMapping(handlerMethod);
+   }
+   public boolean classHasIgnoredAnnotatedRequestMapping(Class<?> handlerClass) {
+      if (null != excludeAnnotations) {
+         for (Class<? extends Annotation> annotation : excludeAnnotations) {
+            if (handlerClass.isAnnotationPresent(annotation)) {
+               log.info(format("Excluding method as its class is annotated with: %s", annotation));
+               return true;
+            }
+         }
+      }
+      return false;
    }
 
    public boolean hasIgnoredAnnotatedRequestMapping(HandlerMethod handlerMethod) {

--- a/swagger-springmvc/src/test/groovy/com/mangofactory/swagger/mixins/RequestMappingSupport.groovy
+++ b/swagger-springmvc/src/test/groovy/com/mangofactory/swagger/mixins/RequestMappingSupport.groovy
@@ -63,6 +63,10 @@ class RequestMappingSupport {
     new HandlerMethod(clazz, c.getMethod(methodName, parameterTypes))
   }
 
+  def ignorableClass() {
+    return new DummyClass.ApiIgnorableClass().getClass()
+  }
+
   def ignorableHandlerMethod() {
     def clazz = new DummyClass.ApiIgnorableClass()
     Class c = clazz.getClass();

--- a/swagger-springmvc/src/test/groovy/com/mangofactory/swagger/scanners/ApiListingReferenceScannerSpec.groovy
+++ b/swagger-springmvc/src/test/groovy/com/mangofactory/swagger/scanners/ApiListingReferenceScannerSpec.groovy
@@ -63,6 +63,16 @@ class ApiListingReferenceScannerSpec extends Specification {
       false == apiListingReferenceScanner.shouldIncludeRequestMapping(requestMappingInfo("p"), ignorableMethod)
   }
 
+  def "ignore classMapping"() {
+    given:
+      ApiListingReferenceScanner apiListingReferenceScanner = new ApiListingReferenceScanner()
+      apiListingReferenceScanner.setExcludeAnnotations([ApiIgnore])
+      def ignorableClass = ignorableClass()
+
+    expect:
+      true == apiListingReferenceScanner.classHasIgnoredAnnotatedRequestMapping(ignorableClass)
+  }
+
   def "include requestMapping"() {
     given:
       ApiListingReferenceScanner apiListingReferenceScanner = new ApiListingReferenceScanner()

--- a/swagger-springmvc/src/test/java/com/mangofactory/swagger/dummy/DummyClass.java
+++ b/swagger-springmvc/src/test/java/com/mangofactory/swagger/dummy/DummyClass.java
@@ -149,6 +149,8 @@ public class DummyClass {
 
    @ApiResponses({ @ApiResponse(code = 413, message = "a message")})
    public void methodWithApiResponses(){}
+
+   @ApiIgnore
    public static class ApiIgnorableClass {
       @ApiIgnore
       public void dummyMethod() {


### PR DESCRIPTION
- Ingoring all methods of a controller by adding an excluded annotation
  on class level
- @ApiIgnore can now be specified on Type, but also on Parameter and has
  been added to the defaultIgnorableParameterTypes Set
