### PR TITLE
Fix NullPointerException if API Description is not provided.

### DIFF
--- a/swagger-springmvc/src/main/java/com/mangofactory/swagger/core/SwaggerApiResourceListing.java
+++ b/swagger-springmvc/src/main/java/com/mangofactory/swagger/core/SwaggerApiResourceListing.java
@@ -87,7 +87,7 @@ public class SwaggerApiResourceListing {
     log.info("Added a resource listing with ({}) api resources: ", apiListingReferences.size());
     for (ApiListingReference apiListingReference : apiListingReferences) {
       String path = fromOption(apiListingReference.description());
-      String prefix = path.startsWith("http") ? path : DefaultSwaggerController.DOCUMENTATION_BASE_PATH;
+      String prefix = (path != null && path.startsWith("http")) ? path : DefaultSwaggerController.DOCUMENTATION_BASE_PATH;
       log.info("  {} at location: {}{}", path, prefix, apiListingReference.path());
     }
 


### PR DESCRIPTION
If API description is not provided (null). NullPointerException is throwing. Fix the code to check for Null.
