### PR TITLE
Improvements of #353

### DIFF
--- a/swagger-springmvc/src/main/java/com/mangofactory/swagger/readers/operation/OperationImplicitParameterReader.java
+++ b/swagger-springmvc/src/main/java/com/mangofactory/swagger/readers/operation/OperationImplicitParameterReader.java
@@ -5,6 +5,7 @@ import com.mangofactory.swagger.readers.operation.parameter.ParameterAllowableRe
 import com.mangofactory.swagger.scanners.RequestMappingContext;
 import com.wordnik.swagger.annotations.ApiImplicitParam;
 import com.wordnik.swagger.model.Parameter;
+import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.web.method.HandlerMethod;
 
 import java.lang.reflect.Method;
@@ -18,16 +19,15 @@ public class OperationImplicitParameterReader implements Command<RequestMappingC
    public void execute(RequestMappingContext context) {
       HandlerMethod handlerMethod = context.getHandlerMethod();
       Method method = handlerMethod.getMethod();
-      if (!method.isAnnotationPresent(ApiImplicitParam.class)) {
-         return;
+      ApiImplicitParam annotation = AnnotationUtils.findAnnotation(method, ApiImplicitParam.class);
+      if (null != annotation) {
+         List<Parameter> parameters = (List<Parameter>) context.get("parameters");
+         if (parameters == null) {
+            parameters = newArrayList();
+         }
+         parameters.add(OperationImplicitParameterReader.getImplicitParameter(annotation));
+         context.put("parameters", parameters);
       }
-      ApiImplicitParam annotation = method.getAnnotation(ApiImplicitParam.class);
-      List<Parameter> parameters = (List<Parameter>) context.get("parameters");
-      if (parameters == null) {
-         parameters = newArrayList();
-      }
-      parameters.add(OperationImplicitParameterReader.getImplicitParameter(annotation));
-      context.put("parameters", parameters);
    }
 
    public static Parameter getImplicitParameter(ApiImplicitParam param) {

--- a/swagger-springmvc/src/main/java/com/mangofactory/swagger/readers/operation/OperationImplicitParametersReader.java
+++ b/swagger-springmvc/src/main/java/com/mangofactory/swagger/readers/operation/OperationImplicitParametersReader.java
@@ -5,6 +5,7 @@ import com.mangofactory.swagger.scanners.RequestMappingContext;
 import com.wordnik.swagger.annotations.ApiImplicitParam;
 import com.wordnik.swagger.annotations.ApiImplicitParams;
 import com.wordnik.swagger.model.Parameter;
+import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.web.method.HandlerMethod;
 
 import java.lang.reflect.Method;
@@ -17,17 +18,16 @@ public class OperationImplicitParametersReader implements Command<RequestMapping
    public void execute(RequestMappingContext context) {
       HandlerMethod handlerMethod = context.getHandlerMethod();
       Method method = handlerMethod.getMethod();
-      if (!method.isAnnotationPresent(ApiImplicitParams.class)) {
-         return;
+      ApiImplicitParams annotation = AnnotationUtils.findAnnotation(method, ApiImplicitParams.class);
+      if (null != annotation) {
+         List<Parameter> parameters = (List<Parameter>) context.get("parameters");
+         if (parameters == null) {
+            parameters = newArrayList();
+         }
+         for (ApiImplicitParam param : annotation.value()) {
+            parameters.add(OperationImplicitParameterReader.getImplicitParameter(param));
+         }
+         context.put("parameters", parameters);
       }
-      ApiImplicitParams annotation = method.getAnnotation(ApiImplicitParams.class);
-      List<Parameter> parameters = (List<Parameter>) context.get("parameters");
-      if (parameters == null) {
-         parameters = newArrayList();
-      }
-      for (ApiImplicitParam param: annotation.value()) {
-         parameters.add(OperationImplicitParameterReader.getImplicitParameter(param));
-      }
-      context.put("parameters", parameters);
    }
 }

--- a/swagger-springmvc/src/test/groovy/com/mangofactory/swagger/mixins/RequestMappingSupport.groovy
+++ b/swagger-springmvc/src/test/groovy/com/mangofactory/swagger/mixins/RequestMappingSupport.groovy
@@ -67,6 +67,10 @@ class RequestMappingSupport {
     return new DummyClass.ApiIgnorableClass().getClass()
   }
 
+  def apiImplicitParamsClass() {
+    return DummyClass.ApiImplicitParamsClass.class;
+  }
+
   def ignorableHandlerMethod() {
     def clazz = new DummyClass.ApiIgnorableClass()
     Class c = clazz.getClass();

--- a/swagger-springmvc/src/test/groovy/com/mangofactory/swagger/readers/operation/OperationImplicitParamsReaderSpec.groovy
+++ b/swagger-springmvc/src/test/groovy/com/mangofactory/swagger/readers/operation/OperationImplicitParamsReaderSpec.groovy
@@ -44,5 +44,6 @@ class OperationImplicitParamsReaderSpec extends Specification {
       dummyHandlerMethod('methodWithApiImplicitParam')                          | 1
       dummyHandlerMethod('methodWithApiImplicitParamAndInteger', Integer.class) | 2
       dummyHandlerMethod('methodWithApiImplicitParams', Integer.class)          | 3
+      handlerMethodIn(apiImplicitParamsClass(), 'methodWithApiImplicitParam')   | 2
   }
 }

--- a/swagger-springmvc/src/test/java/com/mangofactory/swagger/dummy/DummyClass.java
+++ b/swagger-springmvc/src/test/java/com/mangofactory/swagger/dummy/DummyClass.java
@@ -138,6 +138,21 @@ public class DummyClass {
    })
    public void methodWithApiImplicitParams(Integer integer) {}
 
+   public interface ApiImplicitParamsInterface {
+      @ApiImplicitParams({
+              @ApiImplicitParam(name = "lang", dataType = "string", required = true, paramType = "query",
+                      value = "Language", defaultValue = "EN", allowableValues = "EN,FR")
+      })
+      @ApiImplicitParam(name = "Authentication", dataType = "string", required = true, paramType = "header",
+              value="Authentication token")
+      void methodWithApiImplicitParam();
+   }
+
+   public static class ApiImplicitParamsClass implements ApiImplicitParamsInterface {
+      @Override
+      public void methodWithApiImplicitParam() {}
+   }
+
    @ResponseBody
    public DummyModels.BusinessModel methodWithConcreteResponseBody() {
       return null;


### PR DESCRIPTION
@ApiImplicitParams & @ApiImplicitParam are now read on class interfaces
and superclasses using Spring AnnotationUtils.findAnnotation.
This follows the comment of @fgaule on PR #353
