### PR TITLE
Using Spring's AnnotationUtils to support Annotations at interfaces (ResponseMessages, ResponseMessage)

### DIFF
--- a/swagger-springmvc/src/main/java/com/mangofactory/swagger/readers/operation/OperationResponseClassReader.java
+++ b/swagger-springmvc/src/main/java/com/mangofactory/swagger/readers/operation/OperationResponseClassReader.java
@@ -8,6 +8,7 @@ import com.mangofactory.swagger.scanners.RequestMappingContext;
 import com.wordnik.swagger.annotations.ApiOperation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.web.method.HandlerMethod;
 
 import static com.mangofactory.swagger.core.ModelUtils.*;
@@ -19,7 +20,7 @@ public class OperationResponseClassReader implements Command<RequestMappingConte
     public void execute(RequestMappingContext context) {
         SwaggerGlobalSettings swaggerGlobalSettings = (SwaggerGlobalSettings) context.get("swaggerGlobalSettings");
         HandlerMethod handlerMethod = context.getHandlerMethod();
-        ApiOperation methodAnnotation = handlerMethod.getMethodAnnotation(ApiOperation.class);
+        ApiOperation methodAnnotation = AnnotationUtils.findAnnotation(handlerMethod.getMethod(),ApiOperation.class);
         ResolvedType returnType;
         if ((null != methodAnnotation) && Void.class != methodAnnotation.response()) {
             log.debug("Overriding response class with annotated response class");

--- a/swagger-springmvc/src/main/java/com/mangofactory/swagger/readers/operation/OperationResponseMessageReader.java
+++ b/swagger-springmvc/src/main/java/com/mangofactory/swagger/readers/operation/OperationResponseMessageReader.java
@@ -8,12 +8,11 @@ import com.mangofactory.swagger.scanners.RequestMappingContext;
 import com.wordnik.swagger.annotations.ApiResponse;
 import com.wordnik.swagger.annotations.ApiResponses;
 import com.wordnik.swagger.model.ResponseMessage;
+import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.method.HandlerMethod;
 
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Method;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -29,7 +28,7 @@ public class OperationResponseMessageReader implements Command<RequestMappingCon
       RequestMethod currentHttpMethod = (RequestMethod) context.get("currentHttpMethod");
       HandlerMethod handlerMethod = context.getHandlerMethod();
       List<ResponseMessage> responseMessages = newArrayList();
-      ApiResponses apiResponses = getAnnotatedResponseMessages(handlerMethod.getMethod());
+      ApiResponses apiResponses = AnnotationUtils.findAnnotation(handlerMethod.getMethod(), ApiResponses.class);
 
       if (null != apiResponses) {
          ApiResponse[] apiResponseAnnotations = apiResponses.value();
@@ -51,18 +50,6 @@ public class OperationResponseMessageReader implements Command<RequestMappingCon
          }
       }
       context.put("responseMessages", responseMessages);
-   }
-
-   private ApiResponses getAnnotatedResponseMessages(Method method) {
-      Annotation[] methodAnnotations = method.getAnnotations();
-      if (null != methodAnnotations) {
-         for (Annotation annotation : methodAnnotations) {
-            if (annotation instanceof ApiResponses) {
-               return (ApiResponses) annotation;
-            }
-         }
-      }
-      return null;
    }
 
    private void safelyRemoveHttpOkResponse(List<ResponseMessage> responseMessages) {


### PR DESCRIPTION
Following #353 approach. Using Spring's AnnotationUtils now we are able to read annotations of class and interface 
