### PR TITLE
Include OSGi headers in the manifest.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
         <spring-hateoas.version>0.10.0.RELEASE</spring-hateoas.version>
         <slf4j-api.version>1.7.5</slf4j-api.version>
         <github.host>me-github</github.host>
+        <maven.bundle.plugin.version>2.3.7</maven.bundle.plugin.version>
     </properties>
     <name>Swagger SpringMVC</name>
     <url>https://github.com/martypitt/swagger-springmvc</url>
@@ -105,6 +106,7 @@
             </build>
         </profile>
     </profiles>
+
     <repositories>
         <repository>
             <id>sonatype</id>
@@ -378,6 +380,17 @@
             </plugin>
 
         </plugins>
+
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.felix</groupId>
+              <artifactId>maven-bundle-plugin</artifactId>
+              <version>${maven.bundle.plugin.version}</version>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+        
     </build>
     <reporting>
         <plugins>

--- a/swagger-models/pom.xml
+++ b/swagger-models/pom.xml
@@ -4,6 +4,7 @@
     <artifactId>swagger-models</artifactId>
     <version>0.8.6-SNAPSHOT</version>
     <groupId>com.mangofactory.swagger</groupId>
+    <packaging>bundle</packaging>
     <name>models</name>
 
     <parent>
@@ -68,4 +69,32 @@
             </exclusions>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                      <Export-Package>
+                        com.mangofactory.swagger.models,
+                        com.mangofactory.swagger.models.configuration,
+                        com.mangofactory.swagger.models.alternates
+                      </Export-Package>
+                      <Import-Package>
+                        org.springframework.beans.factory,
+                        org.springframework.cglib.core,
+                        org.springframework.cglib.proxy,
+                        org.springframework.beans,
+                        org.springframework.cglib.reflect,
+                        *
+                      </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/swagger-springmvc/pom.xml
+++ b/swagger-springmvc/pom.xml
@@ -8,7 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>swagger-springmvc</artifactId>
     <version>0.8.6-SNAPSHOT</version>
-    <packaging>jar</packaging>
+    <packaging>bundle</packaging>
     <name>springmvc</name>
     <dependencies>
         <dependency>
@@ -127,5 +127,32 @@
             </exclusions>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Export-Package>
+                          com.mangofactory.swagger,
+                          com.mangofactory.swagger.configuration,
+                          com.mangofactory.swagger.controllers
+                        </Export-Package>
+                        <Import-Package>
+                          org.springframework.beans.factory,
+                          org.springframework.cglib.core,
+                          org.springframework.cglib.proxy,
+                          org.springframework.beans,
+                          org.springframework.cglib.reflect,
+                          *
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>


### PR DESCRIPTION
This allows the JARs to be used in a OSGi container such as Eclipse Virgo. The new headers should not impact non-OSGi usage in any way.
