### PR TITLE
@ModelAttribute flattening should ignore statics

### DIFF
--- a/swagger-springmvc/src/main/java/com/mangofactory/swagger/readers/operation/OperationParameterReader.java
+++ b/swagger-springmvc/src/main/java/com/mangofactory/swagger/readers/operation/OperationParameterReader.java
@@ -23,6 +23,7 @@ import org.springframework.web.method.HandlerMethod;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -98,7 +99,7 @@ public class OperationParameterReader extends SwaggerParameterReader {
       for (int i = 0; i < fields.length; i++) {
           Field field = fields[i];
 
-          if (field.isSynthetic()) {
+          if (Modifier.isStatic(field.getModifiers()) || field.isSynthetic()) {
               continue;
           }
 

--- a/swagger-springmvc/src/test/java/com/mangofactory/swagger/dummy/models/Example.java
+++ b/swagger-springmvc/src/test/java/com/mangofactory/swagger/dummy/models/Example.java
@@ -1,9 +1,13 @@
-package com.mangofactory.swagger.dummy.models;
+package com.mangofactory.swagger.readers.operation;
 
 import com.wordnik.swagger.annotations.ApiParam;
 import com.wordnik.swagger.annotations.ApiModelProperty;
 
-public class Example {
+import java.io.Serializable;
+
+public class Example implements Serializable {
+
+    private static final long serialVersionUID = -8084678021874483017L;
 
     @ApiParam(value="description of foo", required=true,  allowableValues="man,chu")
     private String foo;


### PR DESCRIPTION
- This is the fix for issue #401 (Expanding @ModelAttribute Request Params Should Ignore Static Fields)
- Added fix to ignore static fields when flattening objects
  marked with @ModelAttribute
- Added code coverage to prove the fix works
