### PR TITLE
Fixed allowableValues not getting set for enum

### DIFF
--- a/swagger-springmvc/src/main/java/com/mangofactory/swagger/readers/operation/OperationParameterReader.java
+++ b/swagger-springmvc/src/main/java/com/mangofactory/swagger/readers/operation/OperationParameterReader.java
@@ -20,6 +20,7 @@ import com.wordnik.swagger.model.AllowableListValues;
 import com.wordnik.swagger.model.AllowableValues;
 import com.wordnik.swagger.model.Parameter;
 
+import org.apache.commons.lang.StringUtils;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.method.HandlerMethod;
 
@@ -191,7 +192,7 @@ public class OperationParameterReader extends SwaggerParameterReader {
 
       AllowableValues allowable = null;
 
-      if (allowableStr.nonEmpty()) {
+      if (allowableStr.nonEmpty() && StringUtils.isNotBlank(allowableStr.get())) {
 
           allowable = ParameterAllowableReader.getAllowableValueFromString(allowableStr.get());
 

--- a/swagger-springmvc/src/test/groovy/com/mangofactory/swagger/readers/operation/parameter/OperationParameterReaderSpec.groovy
+++ b/swagger-springmvc/src/test/groovy/com/mangofactory/swagger/readers/operation/parameter/OperationParameterReaderSpec.groovy
@@ -95,7 +95,7 @@ class OperationParameterReaderSpec extends Specification {
       Map<String, Object> result = context.getResult()
 
     then:
-      result['parameters'].size == 4
+      result['parameters'].size == 5
       
       Parameter annotatedFooParam = result['parameters'][0]
       annotatedFooParam != null
@@ -117,7 +117,13 @@ class OperationParameterReaderSpec extends Specification {
       unannotatedEnumTypeParam.description().isEmpty()
       unannotatedEnumTypeParam.allowableValues != null
       
-      Parameter unannotatedNestedTypeNameParam = result['parameters'][3]
+      Parameter annotatedEnumTypeParam = result['parameters'][3]
+      annotatedEnumTypeParam != null
+      annotatedEnumTypeParam.name == 'annotatedEnumType'
+      annotatedEnumTypeParam.description().get() == 'description of annotatedEnumType'
+      annotatedEnumTypeParam.allowableValues != null
+      
+      Parameter unannotatedNestedTypeNameParam = result['parameters'][4]
       unannotatedNestedTypeNameParam != null
       unannotatedNestedTypeNameParam.name == 'nestedType.name'
       unannotatedNestedTypeNameParam.description().isEmpty()

--- a/swagger-springmvc/src/test/java/com/mangofactory/swagger/dummy/models/Example.java
+++ b/swagger-springmvc/src/test/java/com/mangofactory/swagger/dummy/models/Example.java
@@ -14,7 +14,12 @@ public class Example implements Serializable {
 
     @ApiModelProperty(value="description of bar", required=false)
     private int bar;
+    
     private EnumType enumType;
+    
+    @ApiParam(value="description of annotatedEnumType", required=false)
+    private EnumType annotatedEnumType;
+        
     private NestedType nestedType;
 
     public Example(String foo, int bar, EnumType enumType, NestedType nestedType) {
@@ -46,6 +51,14 @@ public class Example implements Serializable {
 
     public void setEnumType(EnumType enumType) {
         this.enumType = enumType;
+    }
+    
+    public EnumType getAnnotatedEnumType() {
+        return annotatedEnumType;
+    }
+
+    public void setAnnotatedEnumType(EnumType annotatedEnumType) {
+        this.annotatedEnumType = annotatedEnumType;
     }
 
     public NestedType getNestedType() {


### PR DESCRIPTION
Fixed bug where the allowableValues were not getting
set on enums when the enum property in a container
object had an ApiParam annotation. Apparently, if you
declare an ApiParam and don’t put any configuration in
for the allowableValues, the allowableValues will be a
blank String instead of null. The bug was that the code
was checking for a null allowableValues but not for a
blank String.
