### PR TITLE
@ModelAttribute Flattening Improvements

### DIFF
--- a/swagger-springmvc/src/main/java/com/mangofactory/swagger/readers/operation/parameter/ModelAttributeParameterExpander.java
+++ b/swagger-springmvc/src/main/java/com/mangofactory/swagger/readers/operation/parameter/ModelAttributeParameterExpander.java
@@ -2,8 +2,15 @@ package com.mangofactory.swagger.readers.operation.parameter;
 
 import com.wordnik.swagger.model.Parameter;
 
+import java.beans.IntrospectionException;
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
 import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static com.mangofactory.swagger.models.Types.*;
 import static java.lang.reflect.Modifier.*;
@@ -13,10 +20,11 @@ class ModelAttributeParameterExpander {
   public void expand(final String parentName, final Class<?> paramType,
                      final List<Parameter> parameters) {
 
-    Field[] fields = paramType.getDeclaredFields();
+    Set<String> beanPropNames = getBeanPropertyNames(paramType);
+    List<Field> fields = getAllFields(paramType);
 
     for (Field field : fields) {
-      if (isStatic(field.getModifiers()) || field.isSynthetic()) {
+      if (isStatic(field.getModifiers()) || field.isSynthetic() || !beanPropNames.contains(field.getName())) {
         continue;
       }
 
@@ -43,6 +51,40 @@ class ModelAttributeParameterExpander {
 
   private boolean typeBelongsToJavaPackage(Field field) {
     return (field.getType().getPackage() == null || field.getType().getPackage().getName().startsWith("java"));
+  }
+
+  private List<Field> getAllFields(final Class<?> type) {
+
+      List<Field> result = new ArrayList<Field>();
+
+      Class<?> i = type;
+      while (i != null && i != Object.class) {
+          result.addAll(Arrays.asList(i.getDeclaredFields()));
+          i = i.getSuperclass();
+      }
+
+      return result;
+  }
+
+  private Set<String> getBeanPropertyNames(final Class<?> clazz) {
+
+      try {
+          Set<String> beanProps = new HashSet<String>();
+          PropertyDescriptor[] propDescriptors = Introspector.getBeanInfo(clazz).getPropertyDescriptors();
+
+          for (int i = 0; i < propDescriptors.length; i++) {
+
+              if (propDescriptors[i].getReadMethod() != null && propDescriptors[i].getWriteMethod() != null) {
+                  beanProps.add(propDescriptors[i].getName());
+              }
+          }
+
+          return beanProps;
+
+    } catch (IntrospectionException e) {
+        throw new RuntimeException(new StringBuilder("Failed to get bean properties on ").append(clazz).toString(), e);
+    }
+
   }
 
 }

--- a/swagger-springmvc/src/test/groovy/com/mangofactory/swagger/readers/operation/parameter/OperationParameterReaderSpec.groovy
+++ b/swagger-springmvc/src/test/groovy/com/mangofactory/swagger/readers/operation/parameter/OperationParameterReaderSpec.groovy
@@ -94,7 +94,7 @@ class OperationParameterReaderSpec extends Specification {
       Map<String, Object> result = context.getResult()
 
     then:
-      result['parameters'].size == 5
+      result['parameters'].size == 6
       
       Parameter annotatedFooParam = result['parameters'][0]
       annotatedFooParam != null
@@ -126,6 +126,11 @@ class OperationParameterReaderSpec extends Specification {
       unannotatedNestedTypeNameParam != null
       unannotatedNestedTypeNameParam.name == 'nestedType.name'
       unannotatedNestedTypeNameParam.description().isEmpty()
+      
+      Parameter unannotatedParentBeanParam = result['parameters'][5]
+      unannotatedParentBeanParam != null
+      unannotatedParentBeanParam.name == 'parentBeanProperty'
+      unannotatedParentBeanParam.description().isEmpty()
    }
    
   def "Should not expand unannotated request params"() {

--- a/swagger-springmvc/src/test/java/com/mangofactory/swagger/dummy/models/Example.java
+++ b/swagger-springmvc/src/test/java/com/mangofactory/swagger/dummy/models/Example.java
@@ -5,7 +5,7 @@ import com.wordnik.swagger.annotations.ApiParam;
 
 import java.io.Serializable;
 
-public class Example implements Serializable {
+public class Example extends Parent implements Serializable {
 
     private static final long serialVersionUID = -8084678021874483017L;
 
@@ -14,13 +14,16 @@ public class Example implements Serializable {
 
     @ApiModelProperty(value="description of bar", required=false)
     private int bar;
-    
+
     private EnumType enumType;
-    
+
     @ApiParam(value="description of annotatedEnumType", required=false)
     private EnumType annotatedEnumType;
-        
+
     private NestedType nestedType;
+
+    private String propertyWithNoGetterMethod;
+    private String propertyWithNoSetterMethod;
 
     public Example(String foo, int bar, EnumType enumType, NestedType nestedType) {
         this.foo = foo;
@@ -52,7 +55,7 @@ public class Example implements Serializable {
     public void setEnumType(EnumType enumType) {
         this.enumType = enumType;
     }
-    
+
     public EnumType getAnnotatedEnumType() {
         return annotatedEnumType;
     }
@@ -67,6 +70,14 @@ public class Example implements Serializable {
 
     public void setNestedType(NestedType nestedType) {
         this.nestedType = nestedType;
+    }
+
+    public void setPropertyWithNoGetterMethod(String propertyWithNoGetterMethod) {
+        this.propertyWithNoGetterMethod = propertyWithNoGetterMethod;
+    }
+
+    public String getPropertyWithNoSetterMethod() {
+        return this.propertyWithNoSetterMethod;
     }
 }
 

--- a/swagger-springmvc/src/test/java/com/mangofactory/swagger/dummy/models/Parent.java
+++ b/swagger-springmvc/src/test/java/com/mangofactory/swagger/dummy/models/Parent.java
@@ -1,0 +1,16 @@
+//Copyright 2014 Choice Hotels International
+package com.mangofactory.swagger.dummy.models;
+
+public class Parent {
+
+    private String parentBeanProperty;
+
+    public String getParentBeanProperty() {
+        return parentBeanProperty;
+    }
+
+    public void setParentBeanProperty(final String parentBeanProperty) {
+        this.parentBeanProperty = parentBeanProperty;
+    }
+
+}


### PR DESCRIPTION
When complex objects marked with @ModelAttribute in a controller method
are flattened into individual parameters:
1) Only consider properties that have a getter and setter.
This makes it easy for someone to exclude any parameter
that is not supposed to be set by a request param or has
a derived value.
2) Include properties from parent objects so that we
don’t alienate coders who have form beans with an
inheritance hierarchy
