### PR TITLE
Check if field is of same type as parent when expanding ModelAttribute

### DIFF
--- a/swagger-springmvc/src/main/java/com/mangofactory/swagger/readers/operation/parameter/ModelAttributeParameterExpander.java
+++ b/swagger-springmvc/src/main/java/com/mangofactory/swagger/readers/operation/parameter/ModelAttributeParameterExpander.java
@@ -28,7 +28,7 @@ class ModelAttributeParameterExpander {
         continue;
       }
 
-      if (!typeBelongsToJavaPackage(field) && !field.getType().isEnum()) {
+      if (!typeBelongsToJavaPackage(field) && !field.getType().isEnum() && !field.getType().equals(paramType)) {
 
         expand(field.getName(), field.getType(), parameters);
         continue;

--- a/swagger-springmvc/src/test/groovy/com/mangofactory/swagger/readers/operation/parameter/OperationParameterReaderSpec.groovy
+++ b/swagger-springmvc/src/test/groovy/com/mangofactory/swagger/readers/operation/parameter/OperationParameterReaderSpec.groovy
@@ -3,6 +3,7 @@ import com.fasterxml.classmate.TypeResolver
 import com.mangofactory.swagger.configuration.SwaggerGlobalSettings
 import com.mangofactory.swagger.dummy.DummyModels
 import com.mangofactory.swagger.dummy.models.Example
+import com.mangofactory.swagger.dummy.models.Treeish
 import com.mangofactory.swagger.mixins.RequestMappingSupport
 import com.mangofactory.swagger.models.configuration.SwaggerModelsConfiguration
 import com.mangofactory.swagger.scanners.RequestMappingContext
@@ -132,7 +133,25 @@ class OperationParameterReaderSpec extends Specification {
       unannotatedParentBeanParam.name == 'parentBeanProperty'
       unannotatedParentBeanParam.description().isEmpty()
    }
-   
+
+   def "Should expand ModelAttribute request param if param has treeish field"() {
+    given:
+      RequestMappingContext context = new RequestMappingContext(requestMappingInfo('/somePath'),
+        dummyHandlerMethod('methodWithTreeishModelAttribute', Treeish.class))
+      context.put("swaggerGlobalSettings", swaggerGlobalSettings)
+    when:
+      OperationParameterReader operationParameterReader = new OperationParameterReader()
+      operationParameterReader.execute(context)
+      Map<String, Object> result = context.getResult()
+
+    then:
+      result['parameters'].size == 1
+
+      Parameter annotatedBarParam = result['parameters'][0]
+      annotatedBarParam != null
+      annotatedBarParam.name == 'example'
+   }
+
   def "Should not expand unannotated request params"() {
     given:
       RequestMappingContext context = new RequestMappingContext(requestMappingInfo('/somePath'), handlerMethod)

--- a/swagger-springmvc/src/test/java/com/mangofactory/swagger/dummy/DummyClass.java
+++ b/swagger-springmvc/src/test/java/com/mangofactory/swagger/dummy/DummyClass.java
@@ -2,6 +2,7 @@ package com.mangofactory.swagger.dummy;
 
 import com.mangofactory.swagger.annotations.ApiIgnore;
 
+import com.mangofactory.swagger.dummy.models.Treeish;
 import com.mangofactory.swagger.dummy.models.Example;
 import com.mangofactory.swagger.dummy.models.FoobarDto;
 import com.wordnik.swagger.annotations.ApiImplicitParam;
@@ -112,6 +113,9 @@ public class DummyClass {
   }
 
   public void methodWithoutModelAttribute(Example example) {
+  }
+
+  public void methodWithTreeishModelAttribute(@ModelAttribute Treeish example) {
   }
 
   @RequestMapping("/businesses/{businessId}")

--- a/swagger-springmvc/src/test/java/com/mangofactory/swagger/dummy/models/Treeish.java
+++ b/swagger-springmvc/src/test/java/com/mangofactory/swagger/dummy/models/Treeish.java
@@ -1,0 +1,17 @@
+package com.mangofactory.swagger.dummy.models;
+
+public class Treeish implements java.io.Serializable {
+  private Treeish example;
+
+  public Treeish getExample() {
+    return example;
+  }
+
+  public void setExample(Treeish example) {
+    this.example = example;
+  }
+
+  public Treeish(Treeish example) {
+    this.example = example;
+  }
+}


### PR DESCRIPTION
To avoid StackOverflowError when expanding ModelAttributes,
skip call to `expand` when a treeish field is encountered. #465
