### PR TITLE
ModelAttribute expansion for collection extensions

### DIFF
--- a/swagger-springmvc/src/main/java/com/mangofactory/swagger/readers/operation/parameter/ModelAttributeParameterExpander.java
+++ b/swagger-springmvc/src/main/java/com/mangofactory/swagger/readers/operation/parameter/ModelAttributeParameterExpander.java
@@ -8,8 +8,10 @@ import java.beans.PropertyDescriptor;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static com.mangofactory.swagger.models.Types.*;
@@ -50,7 +52,8 @@ class ModelAttributeParameterExpander {
   }
 
   private boolean typeBelongsToJavaPackage(Field field) {
-    return (field.getType().getPackage() == null || field.getType().getPackage().getName().startsWith("java"));
+    return field.getType().getPackage() == null || field.getType().getPackage().getName().startsWith("java")
+      || Collection.class.isAssignableFrom(field.getType()) || Map.class.isAssignableFrom(field.getType());
   }
 
   private List<Field> getAllFields(final Class<?> type) {

--- a/swagger-springmvc/src/test/groovy/com/mangofactory/swagger/readers/operation/parameter/OperationParameterReaderSpec.groovy
+++ b/swagger-springmvc/src/test/groovy/com/mangofactory/swagger/readers/operation/parameter/OperationParameterReaderSpec.groovy
@@ -94,7 +94,7 @@ class OperationParameterReaderSpec extends Specification {
       Map<String, Object> result = context.getResult()
 
     then:
-      result['parameters'].size == 6
+      result['parameters'].size == 7
       
       Parameter annotatedFooParam = result['parameters'][0]
       annotatedFooParam != null
@@ -127,10 +127,17 @@ class OperationParameterReaderSpec extends Specification {
       unannotatedNestedTypeNameParam.name == 'nestedType.name'
       unannotatedNestedTypeNameParam.description().isEmpty()
       
-      Parameter unannotatedParentBeanParam = result['parameters'][5]
+      Parameter annotatedAllCapsSetParam = result['parameters'][5]
+      annotatedAllCapsSetParam != null
+      annotatedAllCapsSetParam.name == 'allCapsSet'
+      annotatedAllCapsSetParam.description().get() == 'description of allCapsSet'
+      !annotatedAllCapsSetParam.required
+      annotatedAllCapsSetParam.allowableValues == null
+      
+      Parameter unannotatedParentBeanParam = result['parameters'][6]
       unannotatedParentBeanParam != null
       unannotatedParentBeanParam.name == 'parentBeanProperty'
-      unannotatedParentBeanParam.description().isEmpty()
+      unannotatedParentBeanParam.description().isEmpty()  
    }
    
   def "Should not expand unannotated request params"() {

--- a/swagger-springmvc/src/test/java/com/mangofactory/swagger/dummy/models/CustomAllCapsStringHashSet.java
+++ b/swagger-springmvc/src/test/java/com/mangofactory/swagger/dummy/models/CustomAllCapsStringHashSet.java
@@ -1,0 +1,30 @@
+//Copyright 2014 Choice Hotels International
+package com.mangofactory.swagger.dummy.models;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Locale;
+
+public class CustomAllCapsStringHashSet extends HashSet<String> {
+
+  private static final long serialVersionUID = -5157313869620411257L;
+  private static final Locale EN_LOCALE = new Locale("en_US");
+
+  @Override
+  public boolean add(final String e) {
+    return super.add(e.toUpperCase(EN_LOCALE));
+  }
+
+  @Override
+  public boolean addAll(final Collection<? extends String> c) {
+
+    boolean isChanged = false;
+
+    for (String value : c) {
+      if (add(value.toUpperCase(EN_LOCALE))) {
+        isChanged = true;
+      }
+    }
+    return isChanged;
+  }
+}

--- a/swagger-springmvc/src/test/java/com/mangofactory/swagger/dummy/models/Example.java
+++ b/swagger-springmvc/src/test/java/com/mangofactory/swagger/dummy/models/Example.java
@@ -25,6 +25,9 @@ public class Example extends Parent implements Serializable {
   private String propertyWithNoGetterMethod;
   private String propertyWithNoSetterMethod;
 
+  @ApiParam(value = "description of allCapsSet", required = false)
+  private CustomAllCapsStringHashSet allCapsSet;
+
   public Example(String foo, int bar, EnumType enumType, NestedType nestedType) {
     this.foo = foo;
     this.bar = bar;
@@ -79,5 +82,14 @@ public class Example extends Parent implements Serializable {
   public String getPropertyWithNoSetterMethod() {
     return this.propertyWithNoSetterMethod;
   }
+
+  public CustomAllCapsStringHashSet getAllCapsSet() {
+    return allCapsSet;
+  }
+
+  public void setAllCapsSet(CustomAllCapsStringHashSet allCapsSet) {
+    this.allCapsSet = allCapsSet;
+  }
+
 }
 


### PR DESCRIPTION
Fixes a bug where ModelAttributeParameterExpander
was incorrectly handling parameters that were extensions
of collections. For example, any custom extension of a HashSet should
be treated as a Set but instead it was being treated as a custom type.
