### PR TITLE
Sort model properties

### DIFF
--- a/swagger-models/src/main/java/com/mangofactory/swagger/models/DefaultModelProvider.java
+++ b/swagger-models/src/main/java/com/mangofactory/swagger/models/DefaultModelProvider.java
@@ -49,7 +49,7 @@ public class DefaultModelProvider implements ModelProvider {
             || Types.isBaseType(Types.typeNameFor(propertiesHost.getErasedType()))) {
       return Optional.absent();
     }
-    Map<String, ModelProperty> properties = newLinkedHashMap();
+    Map<String, ModelProperty> properties = newTreeMap();
 
     for (com.mangofactory.swagger.models.property.ModelProperty each : properties(modelContext, propertiesHost)) {
       properties.put(each.getName(),


### PR DESCRIPTION
Hi,

Given a ReSTful Webservices API written in Java using Spring MVC and documented with Swagger and Swagger-SpringMVC,
As a consumer of that ReST API,
When I'm using Swagger-UI to know how the API works and what are the data structure involved,
I find hard to look at model's properties that are neither alphabetically sorted nor in same order as written in Java class source file.

For human documentation purpose, what do you think about keeping an order to the model properties ?
It was hard to me to keep the same order as written by the model's authors but here is a tiny contribution to always alphabetically sort model's properties.

Best regards,
Guillaume Wallet
