### PR TITLE
Enum parser retains whitespace and brackets

### DIFF
--- a/swagger-models/src/main/java/com/mangofactory/swagger/models/property/ApiModelProperties.java
+++ b/swagger-models/src/main/java/com/mangofactory/swagger/models/property/ApiModelProperties.java
@@ -5,6 +5,7 @@ import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.wordnik.swagger.annotations.ApiModelProperty;
 import com.mangofactory.swagger.models.dto.AllowableListValues;
+import com.google.common.base.CharMatcher;
 
 import java.util.List;
 
@@ -22,7 +23,7 @@ public final class ApiModelProperties {
       @Override
       public AllowableListValues apply(ApiModelProperty annotation) {
         List<String> allowableValues
-                = Splitter.on(',').omitEmptyStrings().splitToList(nullToEmpty(annotation.allowableValues()));
+                = Splitter.on(CharMatcher.anyOf("[, ]")).omitEmptyStrings().splitToList(nullToEmpty(annotation.allowableValues()));
         return new AllowableListValues(allowableValues, "LIST");
       }
     };


### PR DESCRIPTION
Having allowableValues="[Polygon, Point]" results in enum: ["[Polygon", " Point]"]. I was expecting ["Polygon", "Point"].

Probably the simplest - but not necessarily 100% correct - way to fix this is to handle also space, [ and ] as delimiters to split on.

(Sorry about the hasty pull request. Should I try again according to the guidelines?)