### PR TITLE
added support for java.util.Collection and recursive alternate type substitution

### DIFF
--- a/swagger-models/src/main/java/com/mangofactory/swagger/models/Collections.java
+++ b/swagger-models/src/main/java/com/mangofactory/swagger/models/Collections.java
@@ -17,10 +17,12 @@ public class Collections {
   }
 
   public static ResolvedType collectionElementType(ResolvedType type) {
-    if (List.class.isAssignableFrom(type.getErasedType()) || Collection.class.isAssignableFrom(type.getErasedType())) {
-      return Collections.elementType(type, List.class);
-    } else if (Set.class.isAssignableFrom(type.getErasedType())) {
+    if (Set.class.isAssignableFrom(type.getErasedType())) {
       return Collections.elementType(type, Set.class);
+    } else if (List.class.isAssignableFrom(type.getErasedType())) {
+      return Collections.elementType(type, List.class);
+    } else if (Collection.class.isAssignableFrom(type.getErasedType())) {
+      return Collections.elementType(type, Collection.class);
     } else if (type.isArray()) {
       return type.getArrayElementType();
     } else {
@@ -29,21 +31,20 @@ public class Collections {
   }
 
   public static boolean isContainerType(ResolvedType type) {
-    if (Collection.class.isAssignableFrom(type.getErasedType()) || List.class.isAssignableFrom(type.getErasedType()) ||
-            Set.class.isAssignableFrom(type.getErasedType()) ||
-            type.isArray()) {
+    if (List.class.isAssignableFrom(type.getErasedType()) || Set.class.isAssignableFrom(type.getErasedType()) ||
+            Collection.class.isAssignableFrom(type.getErasedType()) || type.isArray()) {
       return true;
     }
     return false;
   }
 
   public static String containerType(ResolvedType type) {
-    if (Collection.class.isAssignableFrom(type.getErasedType())) {
-      return "Collection";
-    } else if (List.class.isAssignableFrom(type.getErasedType())) {
+    if (List.class.isAssignableFrom(type.getErasedType())) {
       return "List";
     } else if (Set.class.isAssignableFrom(type.getErasedType())) {
       return "Set";
+    } else if (Collection.class.isAssignableFrom(type.getErasedType())) {
+      return "Collection";
     } else if (type.isArray()) {
       return "Array";
     } else {
@@ -52,11 +53,11 @@ public class Collections {
   }
 
   public static String propertyContainerType(ResolvedType type) {
-    if (Collection.class.isAssignableFrom(type.getErasedType()) || List.class.isAssignableFrom(type.getErasedType())
+    if (Set.class.isAssignableFrom(type.getErasedType())) {
+      return "set";
+    } else if (Collection.class.isAssignableFrom(type.getErasedType()) || List.class.isAssignableFrom(type.getErasedType())
             || type.isArray()) {
       return "array";
-    } else if (Set.class.isAssignableFrom(type.getErasedType())) {
-      return "set";
     } else {
       throw new UnsupportedOperationException(String.format("Type is not collection type %s", type));
     }

--- a/swagger-models/src/main/java/com/mangofactory/swagger/models/Collections.java
+++ b/swagger-models/src/main/java/com/mangofactory/swagger/models/Collections.java
@@ -17,7 +17,7 @@ public class Collections {
   }
 
   public static ResolvedType collectionElementType(ResolvedType type) {
-    if (List.class.isAssignableFrom(type.getErasedType())) {
+    if (List.class.isAssignableFrom(type.getErasedType()) || Collection.class.isAssignableFrom(type.getErasedType())) {
       return Collections.elementType(type, List.class);
     } else if (Set.class.isAssignableFrom(type.getErasedType())) {
       return Collections.elementType(type, Set.class);
@@ -29,7 +29,7 @@ public class Collections {
   }
 
   public static boolean isContainerType(ResolvedType type) {
-    if (List.class.isAssignableFrom(type.getErasedType()) ||
+    if (Collection.class.isAssignableFrom(type.getErasedType()) || List.class.isAssignableFrom(type.getErasedType()) ||
             Set.class.isAssignableFrom(type.getErasedType()) ||
             type.isArray()) {
       return true;
@@ -38,7 +38,9 @@ public class Collections {
   }
 
   public static String containerType(ResolvedType type) {
-    if (List.class.isAssignableFrom(type.getErasedType())) {
+    if (Collection.class.isAssignableFrom(type.getErasedType())) {
+      return "Collection";
+    } else if (List.class.isAssignableFrom(type.getErasedType())) {
       return "List";
     } else if (Set.class.isAssignableFrom(type.getErasedType())) {
       return "Set";
@@ -50,7 +52,7 @@ public class Collections {
   }
 
   public static String propertyContainerType(ResolvedType type) {
-    if (List.class.isAssignableFrom(type.getErasedType())
+    if (Collection.class.isAssignableFrom(type.getErasedType()) || List.class.isAssignableFrom(type.getErasedType())
             || type.isArray()) {
       return "array";
     } else if (Set.class.isAssignableFrom(type.getErasedType())) {

--- a/swagger-springmvc/src/main/java/com/mangofactory/swagger/readers/ApiModelReader.java
+++ b/swagger-springmvc/src/main/java/com/mangofactory/swagger/readers/ApiModelReader.java
@@ -57,7 +57,11 @@ public class ApiModelReader implements Command<RequestMappingContext> {
     HandlerMethodResolver handlerMethodResolver
             = new HandlerMethodResolver(swaggerGlobalSettings.getTypeResolver());
     ResolvedType modelType = ModelUtils.handlerReturnType(swaggerGlobalSettings.getTypeResolver(), handlerMethod);
-    modelType = swaggerGlobalSettings.getAlternateTypeProvider().alternateFor(modelType);
+    ResolvedType alternateModelType = swaggerGlobalSettings.getAlternateTypeProvider().alternateFor(modelType);
+    while (!alternateModelType.equals(modelType)) {
+      modelType = alternateModelType;
+      alternateModelType = swaggerGlobalSettings.getAlternateTypeProvider().alternateFor(modelType);
+    }
 
     ApiOperation apiOperationAnnotation = handlerMethod.getMethodAnnotation(ApiOperation.class);
     if (null != apiOperationAnnotation && Void.class != apiOperationAnnotation.response()) {


### PR DESCRIPTION
These changes fix issue #526 providing a representation for `java.util.Collection`, represented as lists and arrays.

At the same time I added recursive resolution of alternate types, so that if we have a return value of type `ResponseEntity<Resource<MyClass>>` and both `ResponseEntity` and `Resource` have been configured as `genericModelSubstitutes` then the documentation will report a response of type `MyClass`.

Without the recursive search, only the outer class would be replaced, resulting in a return value of type `Resource<MyClass>`.