### PR TITLE
Update transitioning-to-v2.md

### DIFF
--- a/transitioning-to-v2.md
+++ b/transitioning-to-v2.md
@@ -138,6 +138,8 @@ subset of the services to be documented and groups them by name. Significant cha
 to provide an expressive predicate based for api selection.
 
 ```java
+  import static springfox.documentation.builders.PathSelectors.regex;
+  import static com.google.common.base.Predicates.or;
 
   @Bean
   public Docket swaggerSpringMvcPlugin() {


### PR DESCRIPTION
I think the reference to the methods or() and regex() could be clearer. I solved that by adding the static imports.