### PR TITLE
Update Swagger2Controller.java

### DIFF
--- a/springfox-swagger2/src/main/java/springfox/documentation/swagger2/web/Swagger2Controller.java
+++ b/springfox-swagger2/src/main/java/springfox/documentation/swagger2/web/Swagger2Controller.java
@@ -74,7 +74,12 @@ public class Swagger2Controller {
   private String hostName() {
     if ("DEFAULT".equals(hostNameOverride)) {
       URI uri = linkTo(Swagger2Controller.class).toUri();
-      return String.format("%s:%s", uri.getHost(), uri.getPort());
+      String host = uri.getHost();
+      int port = uri.getPort();
+      if (port > -1) {
+        return String.format("%s:%d", host, port);
+      }
+      return host;
     }
     return hostNameOverride;
   }


### PR DESCRIPTION
uri.getPort() returns -1 if port is not specified.
That's create an error in json spec:
{
"swagger": "2.0",
"info": {
"version": "0.1",
"title": "",
"contact": {},
"license": {}
},
"host": "localhost:-1",
"basePath": "/rest",
......

Which swaggerui doesn't repair and it doesn't work properly.

Sorry, without unit-test