### PR TITLE
Bug when controller instance is proxied

### DIFF
--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/HandlerMethodReturnTypes.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/HandlerMethodReturnTypes.java
@@ -25,6 +25,8 @@ import com.google.common.base.Optional;
 import org.springframework.web.method.HandlerMethod;
 import springfox.documentation.spring.web.readers.operation.HandlerMethodResolver;
 
+import java.lang.reflect.Proxy;
+
 public final class HandlerMethodReturnTypes {
 
   private HandlerMethodReturnTypes() {
@@ -38,6 +40,9 @@ public final class HandlerMethodReturnTypes {
   }
 
   public static Optional<Class> useType(Class beanType) {
+    if (Proxy.class.isAssignableFrom(beanType)) {
+      return Optional.absent();
+    }
     if (Class.class.getName().equals(beanType.getName())) {
       return Optional.absent();
     }

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/HandlerMethodReturnTypesSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/HandlerMethodReturnTypesSpec.groovy
@@ -1,0 +1,72 @@
+package springfox.documentation.spring.web
+
+import com.fasterxml.classmate.TypeResolver
+import com.google.common.base.Optional
+import org.springframework.web.method.HandlerMethod
+import spock.lang.Specification
+import springfox.documentation.spring.web.json.JacksonModuleRegistrar
+
+import java.lang.reflect.InvocationHandler
+import java.lang.reflect.Method
+import java.lang.reflect.Proxy
+
+/**
+ * Created by mtalbot on 17/05/15.
+ */
+class HandlerMethodReturnTypesSpec extends Specification {
+
+    static TypeResolver resolver = new TypeResolver();
+    static def ListOfMapOfStringOfStringType = resolver.resolve(List.class, resolver.resolve(Map.class, String.class, String.class))
+    static def StringType = resolver.resolve(String.class)
+
+    def "Should return absent for type erased classes"() {
+        expect:
+            HandlerMethodReturnTypes.useType(input) == expected
+
+        where:
+        input                         || expected
+        getProxy(test.class).class    || Optional.<Class>absent()
+        Class.class                   || Optional.<Class>absent()
+        String.class                  || Optional.<Class>of(String.class)
+    }
+
+    def "Should return the underlying type even if proxied"() {
+        expect:
+            HandlerMethodReturnTypes.handlerReturnType(resolver, input) == expected
+
+        where:
+        input                                                                             || expected
+        new HandlerMethod(getProxy(test.class), test.class.getMethod("genericReturn"))    || ListOfMapOfStringOfStringType
+        new HandlerMethod(getProxy(test.class), test.class.getMethod("simpleReturn"))     || StringType
+        new HandlerMethod(new testy(), testy.class.getMethod("genericReturn"))            || ListOfMapOfStringOfStringType
+        new HandlerMethod(new testy(), testy.class.getMethod("simpleReturn"))             || StringType
+    }
+
+    def getProxy(Class<?>... interfaces) {
+        return Proxy.newProxyInstance(this.getClass().getClassLoader(), interfaces, new InvocationHandler() {
+            @Override
+            Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+                return null
+            }
+        })
+    }
+
+    protected interface test {
+
+        List<Map<String, String>> genericReturn()
+
+        String simpleReturn()
+    }
+
+    protected class testy implements test {
+        @Override
+        List<Map<String, String>> genericReturn() {
+            return null
+        }
+
+        @Override
+        String simpleReturn() {
+            return null
+        }
+    }
+}


### PR DESCRIPTION
When adding hystrix commands are aop aspects around the services the bean type is a java proxy and so you loose the detailed response type. This causes that to fall back to using the methods return type directly.