### PR TITLE
Updated swagger2markup version

### DIFF
--- a/springfox-staticdocs/build.gradle
+++ b/springfox-staticdocs/build.gradle
@@ -26,7 +26,7 @@ sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
 dependencies {
-  compile "io.github.robwin:swagger2markup:0.6.1"
+  compile "io.github.robwin:swagger2markup:0.6.2"
   provided "org.springframework:spring-test:${spring}"
   provided libs.clientProvided
   provided libs.springProvided


### PR DESCRIPTION
New feature: swagger2markup includes the curl http request example from spring-restdocs now.