### PR TITLE
Changes to allow for readOnly property in swagger 2

### DIFF
--- a/springfox-core/src/main/java/springfox/documentation/builders/ModelPropertyBuilder.java
+++ b/springfox-core/src/main/java/springfox/documentation/builders/ModelPropertyBuilder.java
@@ -32,6 +32,7 @@ public class ModelPropertyBuilder {
   private String qualifiedType;
   private int position;
   private Boolean required;
+  private Boolean readOnly;
   private String description;
   private AllowableValues allowableValues;
   private String name;
@@ -62,6 +63,11 @@ public class ModelPropertyBuilder {
     return this;
   }
 
+  public ModelPropertyBuilder readOnly(boolean readOnly) {
+    this.readOnly = readOnly;
+    return this;
+  }
+
   public ModelPropertyBuilder description(String description) {
     this.description = defaultIfAbsent(description, this.description);
     return this;
@@ -85,6 +91,6 @@ public class ModelPropertyBuilder {
   }
 
   public ModelProperty build() {
-    return new ModelProperty(name, type, qualifiedType, position, required, isHidden, description, allowableValues);
+    return new ModelProperty(name, type, qualifiedType, position, required, isHidden, readOnly, description, allowableValues);
   }
 }

--- a/springfox-core/src/main/java/springfox/documentation/schema/ModelProperty.java
+++ b/springfox-core/src/main/java/springfox/documentation/schema/ModelProperty.java
@@ -30,12 +30,13 @@ public class ModelProperty {
   private final int position;
   private final Boolean required;
   private final boolean isHidden;
+  private final Boolean readOnly;
   private final String description;
   private final AllowableValues allowableValues;
   private ModelRef modelRef;
 
   public ModelProperty(String name, ResolvedType type, String qualifiedType,
-                       int position, Boolean required, boolean isHidden, String description,
+                       int position, Boolean required, boolean isHidden, Boolean readOnly, String description,
                        AllowableValues allowableValues) {
     this.name = name;
     this.type = type;
@@ -43,6 +44,7 @@ public class ModelProperty {
     this.position = position;
     this.required = required;
     this.isHidden = isHidden;
+    this.readOnly = readOnly;
     this.description = description;
     this.allowableValues = allowableValues;
   }
@@ -65,6 +67,10 @@ public class ModelProperty {
 
   public Boolean isRequired() {
     return required;
+  }
+
+  public Boolean isReadOnly() {
+    return readOnly;
   }
 
   public String getDescription() {

--- a/springfox-core/src/test/groovy/springfox/documentation/builders/ModelPropertyBuilderSpec.groovy
+++ b/springfox-core/src/test/groovy/springfox/documentation/builders/ModelPropertyBuilderSpec.groovy
@@ -41,6 +41,7 @@ class ModelPropertyBuilderSpec extends Specification {
       'qualifiedType'     | 'com.Model1'                          | 'qualifiedType'
       'description'       | 'model1 desc'                         | 'description'
       'required'          | true                                  | 'required'
+      'readOnly'          | true                                  | 'readOnly'
       'allowableValues'   | new AllowableListValues(['a'], "LIST")| 'allowableValues'
   }
 

--- a/springfox-schema/src/main/java/springfox/documentation/schema/DefaultModelProvider.java
+++ b/springfox-schema/src/main/java/springfox/documentation/schema/DefaultModelProvider.java
@@ -102,12 +102,15 @@ public class DefaultModelProvider implements ModelProvider {
     ModelProperty merged = Iterables.getFirst(propertyVariants, null);
     for (ModelProperty each : Iterables.skip(propertyVariants, 1)) {
       boolean required = Optional.fromNullable(each.isRequired()).or(false) | merged.isRequired();
-      merged = new ModelProperty(defaultIfAbsent(each.getName(), merged.getName()),
+      boolean readOnly = Optional.fromNullable(each.isReadOnly()).or(false) | merged.isReadOnly();
+
+        merged = new ModelProperty(defaultIfAbsent(each.getName(), merged.getName()),
           defaultIfAbsent(each.getType(), merged.getType()),
           defaultIfAbsent(emptyToNull(each.getQualifiedType()), merged.getQualifiedType()),
           each.getPosition() > 0 ? each.getPosition() : merged.getPosition(),
           required,
           each.isHidden() | merged.isHidden(),
+          readOnly,
           defaultIfAbsent(emptyToNull(each.getDescription()), merged.getDescription()),
           defaultIfAbsent(each.getAllowableValues(), merged.getAllowableValues()));
       merged.updateModelRef(forSupplier(ofInstance(defaultIfAbsent(each.getModelRef(), merged.getModelRef()))));

--- a/springfox-schema/src/main/java/springfox/documentation/schema/DefaultModelProvider.java
+++ b/springfox-schema/src/main/java/springfox/documentation/schema/DefaultModelProvider.java
@@ -102,7 +102,7 @@ public class DefaultModelProvider implements ModelProvider {
     ModelProperty merged = Iterables.getFirst(propertyVariants, null);
     for (ModelProperty each : Iterables.skip(propertyVariants, 1)) {
       boolean required = Optional.fromNullable(each.isRequired()).or(false) | merged.isRequired();
-      boolean readOnly = Optional.fromNullable(each.isReadOnly()).or(false) | merged.isReadOnly();
+      boolean readOnly = Optional.fromNullable(each.isReadOnly()).orNull() | merged.isReadOnly();
 
         merged = new ModelProperty(defaultIfAbsent(each.getName(), merged.getName()),
           defaultIfAbsent(each.getType(), merged.getType()),

--- a/springfox-schema/src/main/java/springfox/documentation/schema/property/BaseModelProperty.java
+++ b/springfox-schema/src/main/java/springfox/documentation/schema/property/BaseModelProperty.java
@@ -73,6 +73,10 @@ public abstract class BaseModelProperty implements ModelProperty {
     return false;
   }
 
+  @Override
+  public boolean isReadOnly() {
+    return false;
+  }
 
   @Override
   public String propertyDescription() {

--- a/springfox-schema/src/main/java/springfox/documentation/schema/property/ModelProperty.java
+++ b/springfox-schema/src/main/java/springfox/documentation/schema/property/ModelProperty.java
@@ -35,5 +35,7 @@ public interface ModelProperty {
 
   boolean isRequired();
 
+  boolean isReadOnly();
+
   int position();
 }

--- a/springfox-schema/src/main/java/springfox/documentation/schema/property/bean/BeanModelPropertyProvider.java
+++ b/springfox-schema/src/main/java/springfox/documentation/schema/property/bean/BeanModelPropertyProvider.java
@@ -179,6 +179,7 @@ public class BeanModelPropertyProvider implements ModelPropertiesProvider {
         .qualifiedType(beanModelProperty.qualifiedTypeName())
         .position(beanModelProperty.position())
         .required(beanModelProperty.isRequired())
+        .readOnly(beanModelProperty.isReadOnly())
         .isHidden(false)
         .description(beanModelProperty.propertyDescription())
         .allowableValues(beanModelProperty.allowableValues());

--- a/springfox-schema/src/main/java/springfox/documentation/schema/property/field/FieldModelPropertyProvider.java
+++ b/springfox-schema/src/main/java/springfox/documentation/schema/property/field/FieldModelPropertyProvider.java
@@ -103,6 +103,7 @@ public class FieldModelPropertyProvider implements ModelPropertiesProvider {
         .type(fieldModelProperty.getType())
         .qualifiedType(fieldModelProperty.qualifiedTypeName())
         .position(fieldModelProperty.position())
+        .readOnly(fieldModelProperty.isReadOnly())
         .required(fieldModelProperty.isRequired())
         .description(fieldModelProperty.propertyDescription())
         .allowableValues(fieldModelProperty.allowableValues());

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/parameter/ModelAttributeParameterExpanderSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/parameter/ModelAttributeParameterExpanderSpec.groovy
@@ -48,7 +48,7 @@ class ModelAttributeParameterExpanderSpec extends DocumentationContextSpec {
     when:
       sut.expand("", Example, parameters, context());
     then:
-      parameters.size() == 8
+      parameters.size() == 9
       parameters.find { it.name == 'parentBeanProperty' }
       parameters.find { it.name == 'foo' }
       parameters.find { it.name == 'bar' }
@@ -63,7 +63,7 @@ class ModelAttributeParameterExpanderSpec extends DocumentationContextSpec {
     when:
       sut.expand("parent", Example, parameters, context());
     then:
-      parameters.size() == 8
+      parameters.size() == 9
       parameters.find { it.name == 'parent.parentBeanProperty' }
       parameters.find { it.name == 'parent.foo' }
       parameters.find { it.name == 'parent.bar' }

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/parameter/OperationParameterReaderSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/parameter/OperationParameterReaderSpec.groovy
@@ -107,7 +107,7 @@ class OperationParameterReaderSpec extends DocumentationContextSpec {
       def operation = operationContext.operationBuilder().build()
 
     then:
-      operation.parameters.size() == 8
+      operation.parameters.size() == 9
 
       Parameter annotatedFooParam = operation.parameters.find { it.name == "foo" }
       annotatedFooParam != null

--- a/springfox-spring-web/src/test/java/springfox/documentation/spring/web/dummy/models/Example.java
+++ b/springfox-spring-web/src/test/java/springfox/documentation/spring/web/dummy/models/Example.java
@@ -38,6 +38,9 @@ public class Example extends Parent implements Serializable {
 
   private EnumType enumType;
 
+  @ApiModelProperty(value = "A read only string", readOnly = true)
+  private String readOnlyString;
+
   @ApiParam(value = "description of annotatedEnumType", required = false)
   private EnumType annotatedEnumType;
 
@@ -124,6 +127,14 @@ public class Example extends Parent implements Serializable {
 
   public void setLocalDateTime(LocalDateTime localDateTime) {
     this.localDateTime = localDateTime;
+  }
+
+  public String getReadOnlyString() {
+    return readOnlyString;
+  }
+
+  public void setReadOnlyString(String readOnlyString) {
+    this.readOnlyString = readOnlyString;
   }
 }
 

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/schema/ApiModelProperties.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/schema/ApiModelProperties.java
@@ -81,6 +81,15 @@ public final class ApiModelProperties {
     };
   }
 
+  public static Function<ApiModelProperty, Boolean> toIsReadOnly() {
+    return new Function<ApiModelProperty, Boolean>() {
+      @Override
+      public Boolean apply(ApiModelProperty annotation) {
+        return annotation.readOnly();
+      }
+    };
+  }
+
   public static Function<ApiModelProperty, String> toDescription() {
     return new Function<ApiModelProperty, String>() {
       @Override

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/schema/ApiModelPropertyPropertyBuilder.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/schema/ApiModelPropertyPropertyBuilder.java
@@ -49,6 +49,7 @@ public class ApiModelPropertyPropertyBuilder implements ModelPropertyBuilderPlug
       context.getBuilder()
               .allowableValues(annotation.transform(toAllowableValues()).orNull())
               .required(annotation.transform(toIsRequired()).or(false))
+              .readOnly(annotation.transform(toIsReadOnly()).or(false))
               .description(annotation.transform(toDescription()).orNull())
               .isHidden(annotation.transform(toHidden()).or(false))
               .type(annotation.transform(toType(context.getResolver())).orNull());

--- a/springfox-swagger1/src/test/groovy/springfox/documentation/swagger1/readers/parameter/OperationParameterReaderSpec.groovy
+++ b/springfox-swagger1/src/test/groovy/springfox/documentation/swagger1/readers/parameter/OperationParameterReaderSpec.groovy
@@ -122,7 +122,7 @@ class OperationParameterReaderSpec extends DocumentationContextSpec {
       def operation = operationContext.operationBuilder().build()
 
     then:
-      operation.parameters.size() == 8
+      operation.parameters.size() == 9
 
       Parameter annotatedFooParam = operation.parameters.find { it.name == "foo" }
       annotatedFooParam != null

--- a/springfox-swagger1/src/test/groovy/springfox/documentation/swagger1/schema/ApiModelPropertyPropertyBuilderPluginSpec.groovy
+++ b/springfox-swagger1/src/test/groovy/springfox/documentation/swagger1/schema/ApiModelPropertyPropertyBuilderPluginSpec.groovy
@@ -64,12 +64,14 @@ class ApiModelPropertyPropertyBuilderPluginSpec extends Specification {
       enriched.allowableValues?.values == allowableValues
       enriched.isRequired() == required
       enriched.description == description
+      enriched.readOnly == readOnly
       !enriched.isHidden()
     where:
-      property    | required | description              | allowableValues
-      "intProp"   | true     | "int Property Field"     | null
-      "boolProp"  | false    | "bool Property Getter"   | null
-      "enumProp"  | true     | "enum Prop Getter value" | ["ONE"]
+      property    | required | description              | allowableValues | readOnly
+      "intProp"   | true     | "int Property Field"     | null            | false
+      "boolProp"  | false    | "bool Property Getter"   | null            | false
+      "enumProp"  | true     | "enum Prop Getter value" | ["ONE"]         | false
+      "readOnlyProp" | false    | "readOnly property getter" | null          | true
   }
 
   def "ApiModelProperty annotated models get enriched with additional info given an annotated element" (){
@@ -87,12 +89,15 @@ class ApiModelPropertyPropertyBuilderPluginSpec extends Specification {
       enriched.allowableValues?.values == allowableValues
       enriched.isRequired() == required
       enriched.description == description
+      enriched.readOnly == readOnly
       !enriched.isHidden()
     where:
-      property    | required | description              | allowableValues
-      "intProp"   | null     | null                     | null
-      "boolProp"  | false    | "bool Property Getter"   | null
-      "enumProp"  | true     | "enum Prop Getter value" | ["ONE"]
+      property    | required | description              | allowableValues | readOnly
+      "intProp"   | null     | null                     | null            | null
+      "boolProp"  | false    | "bool Property Getter"   | null            | false
+      "enumProp"  | true     | "enum Prop Getter value" | ["ONE"]         | false
+      "readOnlyProp" | false    | "readOnly property getter" | null          | true
+
   }
 
   def "ApiModelProperties marked as hidden properties are respected" (){

--- a/springfox-swagger1/src/test/java/springfox/documentation/schema/TypeWithAnnotatedGettersAndSetters.java
+++ b/springfox-swagger1/src/test/java/springfox/documentation/schema/TypeWithAnnotatedGettersAndSetters.java
@@ -31,6 +31,7 @@ public class TypeWithAnnotatedGettersAndSetters {
   private int hiddenProp;
   private LocalDate validOverride;
   private LocalDate invalidOverride;
+  private int readOnlyProp;
 
   public int getIntProp() {
     return intProp;
@@ -64,7 +65,7 @@ public class TypeWithAnnotatedGettersAndSetters {
     return 0;
   }
 
-  @ApiModelProperty(value = "enum Prop Getter value", notes = "enum note", allowableValues = "ONE", required = true)
+  @ApiModelProperty(value = "enum Prop Getter value", notes = "enum note", allowableValues = "ONE", required = true, readOnly = false)
   public ExampleEnum getEnumProp() {
     return enumProp;
   }
@@ -76,6 +77,11 @@ public class TypeWithAnnotatedGettersAndSetters {
   @ApiModelProperty(hidden = true)
   public int getHiddenProp() {
     return hiddenProp;
+  }
+
+  @ApiModelProperty(value = "readOnly property getter", readOnly = true)
+  public int getReadOnlyProp() {
+    return readOnlyProp;
   }
 
   @ApiModelProperty(dataType = "UnknownType")

--- a/springfox-swagger2/src/main/java/springfox/documentation/swagger2/mappers/ModelMapper.java
+++ b/springfox-swagger2/src/main/java/springfox/documentation/swagger2/mappers/ModelMapper.java
@@ -119,6 +119,7 @@ public abstract class ModelMapper {
       property.setDescription(source.getDescription());
       property.setName(source.getName());
       property.setRequired(source.isRequired());
+      property.setReadOnly(source.isReadOnly());
     }
     return property;
   }

--- a/swagger-contract-tests/src/test/resources/contract/swagger/declaration-controller-with-no-request-mapping-service.json
+++ b/swagger-contract-tests/src/test/resources/contract/swagger/declaration-controller-with-no-request-mapping-service.json
@@ -227,6 +227,11 @@
                 "propertyWithNoGetterMethod": {
                     "required": false,
                     "type": "string"
+                },
+                "readOnlyString":{
+                    "description": "A read only string",
+                    "required": false,
+                    "type": "string"
                 }
             }
         },

--- a/swagger-contract-tests/src/test/resources/contract/swagger/declaration-feature-demonstration-service.json
+++ b/swagger-contract-tests/src/test/resources/contract/swagger/declaration-feature-demonstration-service.json
@@ -1225,6 +1225,11 @@
                 "propertyWithNoGetterMethod": {
                     "required": false,
                     "type": "string"
+                },
+                "readOnlyString":{
+                    "description": "A read only string",
+                    "required": false,
+                    "type": "string"
                 }
             }
         },

--- a/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-feature-demonstration-service-codeGen.json
+++ b/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-feature-demonstration-service-codeGen.json
@@ -517,6 +517,11 @@
                 },
                 "propertyWithNoGetterMethod": {
                     "type": "string"
+                },
+                "readOnlyString": {
+                    "type": "string",
+                    "description": "A read only string",
+                    "readOnly": true
                 }
             }
         },

--- a/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-feature-demonstration-service.json
+++ b/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-feature-demonstration-service.json
@@ -517,6 +517,11 @@
                 },
                 "propertyWithNoGetterMethod": {
                     "type": "string"
+                },
+                "readOnlyString": {
+                    "type": "string",
+                    "description": "A read only string",
+                    "readOnly": true
                 }
             }
         },


### PR DESCRIPTION
Changes added to process @ApiModelProperty(readonly=true).

Altered model tests, and propery spec test to ensure new flag was set correctly.