### PR TITLE
Updated swagger2markup version

### DIFF
--- a/springfox-staticdocs/build.gradle
+++ b/springfox-staticdocs/build.gradle
@@ -26,7 +26,7 @@ sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
 dependencies {
-  compile "io.github.robwin:swagger2markup:0.7.0"
+  compile "io.github.robwin:swagger2markup:0.7.1"
   provided "org.springframework:spring-test:${spring}"
   provided libs.clientProvided
   provided libs.springProvided


### PR DESCRIPTION
Updated Swagger2Markup dependency from 0.7.0 to 0.7.1

Workaround: If the type of a BodyParameter is String and not a Model, the schema is null and lost. Therefore the fallback type of a BodyParameter is String now.