### PR TITLE
Bump swagger-ui zip to version 2.1.1

### DIFF
--- a/springfox-swagger-ui/build.gradle
+++ b/springfox-swagger-ui/build.gradle
@@ -27,7 +27,7 @@ buildscript {
 apply plugin: 'de.undercouch.download'
 
 ext {
-  swaggerUiVersion = '2.1.0'
+  swaggerUiVersion = '2.1.1'
   swaggerUiDist = "build/libs/swagger-ui-dist.zip"
   swaggerUiExplodedDir = "swagger-ui-${swaggerUiVersion}/dist/"
   downloadUrl = "https://github.com/wordnik/swagger-ui/archive/v${swaggerUiVersion}.zip"


### PR DESCRIPTION
It looks like swagger-ui has a [new release.](https://github.com/swagger-api/swagger-ui/releases)

This release pulls in swagger-js-2.1.2