### PR TITLE
Fix generation of "schema" section for a "body" parameter to contain correct "type" & "format"

### DIFF
--- a/springfox-swagger2/src/main/java/springfox/documentation/swagger2/mappers/ParameterMapper.java
+++ b/springfox-swagger2/src/main/java/springfox/documentation/swagger2/mappers/ParameterMapper.java
@@ -25,6 +25,7 @@ import io.swagger.models.ModelImpl;
 import io.swagger.models.RefModel;
 import io.swagger.models.parameters.BodyParameter;
 import io.swagger.models.parameters.Parameter;
+import io.swagger.models.properties.Property;
 import org.mapstruct.Mapper;
 import springfox.documentation.schema.ModelRef;
 
@@ -59,8 +60,10 @@ public class ParameterMapper {
       return baseModel;
     }
     if (isBaseType(modelRef.getType())) {
+      Property property = Properties.property(modelRef.getType());
       ModelImpl baseModel = new ModelImpl();
-      baseModel.setType(modelRef.getType());
+      baseModel.setType(property.getType());
+      baseModel.setFormat(property.getFormat());
       return baseModel;
     }
     return new RefModel(modelRef.getType());

--- a/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-feature-demonstration-service-codeGen.json
+++ b/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-feature-demonstration-service-codeGen.json
@@ -205,7 +205,8 @@
                         "description": "input",
                         "required": false,
                         "schema": {
-                            "type": "double"
+                            "type": "number",
+                            "format": "double"
                         }
                     }
                 ],

--- a/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-feature-demonstration-service.json
+++ b/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-feature-demonstration-service.json
@@ -205,7 +205,8 @@
                         "description": "input",
                         "required": false,
                         "schema": {
-                            "type": "double"
+                            "type": "number",
+                            "format": "double"
                         }
                     }
                 ],


### PR DESCRIPTION
I ran into a problem where the Swagger2 JSON document generated from a SpringBoot application with the following API method:

```java
  @RequestMapping(...)
  @ResponseStatus(...)
  public void setThreshold(..., @RequestBody int threshold) { ... }
```

would include the following for the `@RequestBody` parameter

```json
{
  "in": "body",
  "name": "threshold",
  "description": "threshold",
  "required": true,
  "schema": {
    "type": "int"
  }
}
```

This JSON has `"int"` for the `"type"` property, when it should be `"integer"`, with `"format": "int32"`.

This pull request updates `ParameterMapper` to ensure that it uses `io.swagger.models.properties.Property` for the `"schema"` `"type"` and `"format"` information, similar to what is done for collections and maps in that class. 