### PR TITLE
Proper handling of @ResponseStatus with default reason().

### DIFF
--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/operation/ResponseMessagesReader.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/operation/ResponseMessagesReader.java
@@ -127,6 +127,9 @@ public class ResponseMessagesReader implements OperationBuilderPlugin {
     String reasonPhrase = HttpStatus.OK.getReasonPhrase();
     if (responseStatus.isPresent()) {
       reasonPhrase = responseStatus.get().reason();
+      if (reasonPhrase.isEmpty()) {
+        reasonPhrase = responseStatus.get().value().getReasonPhrase();
+      }
     }
     return reasonPhrase;
   }

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/operation/DefaultResponseMessageReaderSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/operation/DefaultResponseMessageReaderSpec.groovy
@@ -134,4 +134,19 @@ class DefaultResponseMessageReaderSpec extends DocumentationContextSpec {
       responseMessage.getResponseModel().type == 'BusinessModel'
       responseMessage.getMessage() == "Accepted request"
   }
+
+  def "Methods with return type containing ResponseStatus annotation and empty reason message"() {
+    given:
+      OperationContext operationContext = new OperationContext(new OperationBuilder(new CachingOperationNameGenerator()),
+              RequestMethod.GET, dummyHandlerMethod('methodWithResponseStatusAnnotationAndEmptyReason'), 0,
+              requestMappingInfo('/somePath'), context(), "")
+    when:
+      sut.apply(operationContext)
+      def operation = operationContext.operationBuilder().build()
+      def responseMessages = operation.responseMessages
+    then:
+      ResponseMessage responseMessage = responseMessages.find { it.code == 204 }
+      responseMessage.getCode() == HttpStatus.NO_CONTENT.value()
+      responseMessage.getMessage() == HttpStatus.NO_CONTENT.reasonPhrase
+  }
 }

--- a/springfox-spring-web/src/test/java/springfox/documentation/spring/web/dummy/DummyClass.java
+++ b/springfox-spring-web/src/test/java/springfox/documentation/spring/web/dummy/DummyClass.java
@@ -277,6 +277,11 @@ public class DummyClass {
   }
 
   @ResponseBody
+  @ResponseStatus(value = HttpStatus.NO_CONTENT)
+  public void methodWithResponseStatusAnnotationAndEmptyReason() {
+  }
+
+  @ResponseBody
   public DummyModels.AnnotatedBusinessModel methodWithModelPropertyAnnotations() {
     return null;
   }


### PR DESCRIPTION
- Javadoc for @ResponseStatus.reason() says that if no value is given, the
  default message from HttpStatus will be used.