### PR TITLE
Fix 2 minor typos in the documentation

### DIFF
--- a/asciidoc/getting_started.adoc
+++ b/asciidoc/getting_started.adoc
@@ -99,7 +99,7 @@ include::../springfox-spring-config/src/main/java/springfox/springconfig/Swagger
 ===== Configuration explained
 <1> Enables Springfox swagger 2
 <2> Instructs spring where to scan for API controllers
-<3> `Docket`, Sringfox's, primary api configuration mechanism is initialized for swagger specification 2.0
+<3> `Docket`, Springfox's, primary api configuration mechanism is initialized for swagger specification 2.0
 <4> `select()` returns an instance of `ApiSelectorBuilder` to give fine grained control over the endpoints exposed
 via swagger.
 <5> `apis()` allows selection of `RequestHandler`'s using a predicate. The example here uses an `any` predicate

--- a/asciidoc/introduction.adoc
+++ b/asciidoc/introduction.adoc
@@ -116,5 +116,5 @@ Please see the https://github.com/springfox/springfox/wiki[wiki] for some guidel
 
 === Support
 
-If you find issues or bugs please use the github issue https://github.com/springfox/springfox/issues[springfox project]
+If you find issues or bugs please submit them via the https://github.com/springfox/springfox/issues[Springfox Github project]
 


### PR DESCRIPTION
Fixes a misspelling of _Springfox_ and rewords an awkward sentence.