### PR TITLE
Added a fix for 'example' field in @ApiModelProperty annotation

### DIFF
--- a/springfox-core/src/main/java/springfox/documentation/builders/ModelBuilder.java
+++ b/springfox-core/src/main/java/springfox/documentation/builders/ModelBuilder.java
@@ -19,16 +19,18 @@
 
 package springfox.documentation.builders;
 
-import com.fasterxml.classmate.ResolvedType;
-import springfox.documentation.schema.Model;
-import springfox.documentation.schema.ModelProperty;
+import static com.google.common.collect.Lists.newArrayList;
+import static com.google.common.collect.Maps.newHashMap;
+import static springfox.documentation.builders.BuilderDefaults.defaultIfAbsent;
+import static springfox.documentation.builders.BuilderDefaults.nullToEmptyMap;
 
 import java.util.List;
 import java.util.Map;
 
-import static com.google.common.collect.Lists.*;
-import static com.google.common.collect.Maps.*;
-import static springfox.documentation.builders.BuilderDefaults.*;
+import com.fasterxml.classmate.ResolvedType;
+
+import springfox.documentation.schema.Model;
+import springfox.documentation.schema.ModelProperty;
 
 public class ModelBuilder {
   private String id;
@@ -38,6 +40,7 @@ public class ModelBuilder {
   private String baseModel;
   private String discriminator;
   private ResolvedType modelType;
+  private String example;
 
   private Map<String, ModelProperty> properties = newHashMap();
   private List<String> subTypes = newArrayList();
@@ -133,6 +136,17 @@ public class ModelBuilder {
   }
 
   /**
+   * Updates the Example for the model
+   *
+   * @param example - example of the model
+   * @return this
+   */
+  public ModelBuilder example(String example) {
+    this.example = defaultIfAbsent(example, this.example);
+    return this;
+  }
+
+  /**
    * Represents the type information with full fidelity of generics
    *
    * @param modelType - resolved type that represents the model
@@ -144,6 +158,6 @@ public class ModelBuilder {
   }
 
   public Model build() {
-    return new Model(id, name, modelType, qualifiedType, properties, description, baseModel, discriminator, subTypes);
+    return new Model(id, name, modelType, qualifiedType, properties, description, baseModel, discriminator, subTypes, example);
   }
 }

--- a/springfox-core/src/main/java/springfox/documentation/builders/ModelPropertyBuilder.java
+++ b/springfox-core/src/main/java/springfox/documentation/builders/ModelPropertyBuilder.java
@@ -19,13 +19,15 @@
 
 package springfox.documentation.builders;
 
+import static springfox.documentation.builders.BuilderDefaults.defaultIfAbsent;
+import static springfox.documentation.builders.BuilderDefaults.replaceIfMoreSpecific;
+import static springfox.documentation.schema.Enums.emptyListValuesToNull;
+
 import com.fasterxml.classmate.ResolvedType;
+
 import springfox.documentation.schema.ModelProperty;
 import springfox.documentation.service.AllowableListValues;
 import springfox.documentation.service.AllowableValues;
-
-import static springfox.documentation.builders.BuilderDefaults.*;
-import static springfox.documentation.schema.Enums.*;
 
 public class ModelPropertyBuilder {
   private ResolvedType type;
@@ -37,6 +39,7 @@ public class ModelPropertyBuilder {
   private AllowableValues allowableValues;
   private String name;
   private boolean isHidden;
+  private String example;
 
   public ModelPropertyBuilder name(String name) {
     this.name = defaultIfAbsent(name, this.name);
@@ -73,6 +76,11 @@ public class ModelPropertyBuilder {
     return this;
   }
 
+  public ModelPropertyBuilder example(String example) {
+    this.example = defaultIfAbsent(example, this.example);
+    return this;
+  }
+
   public ModelPropertyBuilder allowableValues(AllowableValues allowableValues) {
     if (allowableValues != null) {
       if (allowableValues instanceof AllowableListValues) {
@@ -91,6 +99,6 @@ public class ModelPropertyBuilder {
   }
 
   public ModelProperty build() {
-    return new ModelProperty(name, type, qualifiedType, position, required, isHidden, readOnly, description, allowableValues);
+    return new ModelProperty(name, type, qualifiedType, position, required, isHidden, readOnly, description, allowableValues, example);
   }
 }

--- a/springfox-core/src/main/java/springfox/documentation/schema/Model.java
+++ b/springfox-core/src/main/java/springfox/documentation/schema/Model.java
@@ -19,10 +19,10 @@
 
 package springfox.documentation.schema;
 
-import com.fasterxml.classmate.ResolvedType;
-
 import java.util.List;
 import java.util.Map;
+
+import com.fasterxml.classmate.ResolvedType;
 
 public class Model {
 
@@ -35,9 +35,11 @@ public class Model {
   private final String baseModel;
   private final String discriminator;
   private final List<String> subTypes;
+  private final String example;
 
   public Model(String id, String name, ResolvedType type, String qualifiedType, Map<String, ModelProperty> properties, String
-          description, String baseModel, String discriminator, List<String> subTypes) {
+          description, String baseModel, String discriminator, List<String> subTypes, String example) {
+
     this.id = id;
     this.name = name;
     this.type = type;
@@ -47,6 +49,7 @@ public class Model {
     this.baseModel = baseModel;
     this.discriminator = discriminator;
     this.subTypes = subTypes;
+    this.example = example;
   }
 
   public String getId() {
@@ -83,5 +86,9 @@ public class Model {
 
   public ResolvedType getType() {
     return type;
+  }
+
+  public String getExample() {
+    return example;
   }
 }

--- a/springfox-core/src/main/java/springfox/documentation/schema/ModelProperty.java
+++ b/springfox-core/src/main/java/springfox/documentation/schema/ModelProperty.java
@@ -21,6 +21,7 @@ package springfox.documentation.schema;
 
 import com.fasterxml.classmate.ResolvedType;
 import com.google.common.base.Function;
+
 import springfox.documentation.service.AllowableValues;
 
 public class ModelProperty {
@@ -34,10 +35,11 @@ public class ModelProperty {
   private final String description;
   private final AllowableValues allowableValues;
   private ModelRef modelRef;
+  private final String example;
 
   public ModelProperty(String name, ResolvedType type, String qualifiedType,
                        int position, Boolean required, Boolean isHidden, Boolean readOnly,
-                       String description, AllowableValues allowableValues) {
+                       String description, AllowableValues allowableValues, String example) {
     this.name = name;
     this.type = type;
     this.qualifiedType = qualifiedType;
@@ -47,6 +49,7 @@ public class ModelProperty {
     this.readOnly = readOnly;
     this.description = description;
     this.allowableValues = allowableValues;
+    this.example = example;
   }
 
   public String getName() {
@@ -92,5 +95,9 @@ public class ModelProperty {
   public ModelProperty updateModelRef(Function<? super ResolvedType, ModelRef> modelRefFactory) {
     modelRef = modelRefFactory.apply(type);
     return this;
+  }
+
+  public String getExample() {
+    return example;
   }
 }

--- a/springfox-core/src/test/groovy/springfox/documentation/builders/ModelBuilderSpec.groovy
+++ b/springfox-core/src/test/groovy/springfox/documentation/builders/ModelBuilderSpec.groovy
@@ -45,6 +45,7 @@ class ModelBuilderSpec extends Specification {
       'type'          | new TypeResolver().resolve(String)    | 'type'
       'subTypes'      | ["String"]                            | 'subTypes'
       'properties'    | [p1: Mock(ModelProperty)]             | 'properties'
+      'example'       | 'example1'                            | 'example'
   }
 
   def "Setting builder properties to null values preserves existing values"() {
@@ -69,5 +70,6 @@ class ModelBuilderSpec extends Specification {
       'type'          | new TypeResolver().resolve(String)    | 'type'
       'subTypes'      | ["String"]                            | 'subTypes'
       'properties'    | [p1: Mock(ModelProperty)]             | 'properties'
+      'example'       | 'example1'                            | 'example'
   }
 }

--- a/springfox-core/src/test/groovy/springfox/documentation/builders/ModelPropertyBuilderSpec.groovy
+++ b/springfox-core/src/test/groovy/springfox/documentation/builders/ModelPropertyBuilderSpec.groovy
@@ -44,6 +44,7 @@ class ModelPropertyBuilderSpec extends Specification {
       'readOnly'          | true                                  | 'readOnly'
       'isHidden'          | true                                  | 'hidden'
       'allowableValues'   | new AllowableListValues(['a'], "LIST")| 'allowableValues'
+      'example'           | 'example1'                            | 'example'
   }
 
   def "Setting builder properties to null values preserves existing values"() {
@@ -64,6 +65,7 @@ class ModelPropertyBuilderSpec extends Specification {
       'qualifiedType'     | 'com.Model1'                          | 'qualifiedType'
       'description'       | 'model1 desc'                         | 'description'
       'allowableValues'   | new AllowableListValues(['a'], "LIST")| 'allowableValues'
+      'example'           | 'example1'                            | 'example'
   }
 
   def "When allowable list value is empty builder sets the value to null"() {

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/schema/ApiModelProperties.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/schema/ApiModelProperties.java
@@ -19,6 +19,15 @@
 
 package springfox.documentation.swagger.schema;
 
+import static com.google.common.collect.Lists.newArrayList;
+import static org.springframework.util.StringUtils.hasText;
+
+import java.lang.reflect.AnnotatedElement;
+import java.util.Collections;
+import java.util.List;
+
+import org.springframework.core.annotation.AnnotationUtils;
+
 import com.fasterxml.classmate.ResolvedType;
 import com.fasterxml.classmate.TypeResolver;
 import com.google.common.base.Function;
@@ -26,18 +35,11 @@ import com.google.common.base.Optional;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
+
 import io.swagger.annotations.ApiModelProperty;
-import org.springframework.core.annotation.AnnotationUtils;
 import springfox.documentation.service.AllowableListValues;
 import springfox.documentation.service.AllowableRangeValues;
 import springfox.documentation.service.AllowableValues;
-
-import java.lang.reflect.AnnotatedElement;
-import java.util.Collections;
-import java.util.List;
-
-import static com.google.common.collect.Lists.*;
-import static org.springframework.util.StringUtils.*;
 
 public final class ApiModelProperties {
 
@@ -127,6 +129,19 @@ public final class ApiModelProperties {
       @Override
       public Boolean apply(ApiModelProperty annotation) {
         return annotation.hidden();
+      }
+    };
+  }
+
+  public static Function<ApiModelProperty, String> toExample() {
+    return new Function<ApiModelProperty, String>() {
+      @Override
+      public String apply(ApiModelProperty annotation) {
+        String example = "";
+        if (!Strings.isNullOrEmpty(annotation.example())) {
+          example = annotation.example();
+        }
+        return example;
       }
     };
   }

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/schema/ApiModelPropertyPropertyBuilder.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/schema/ApiModelPropertyPropertyBuilder.java
@@ -19,17 +19,26 @@
 
 package springfox.documentation.swagger.schema;
 
-import com.google.common.base.Optional;
-import io.swagger.annotations.ApiModelProperty;
+import static springfox.documentation.schema.Annotations.findPropertyAnnotation;
+import static springfox.documentation.swagger.schema.ApiModelProperties.findApiModePropertyAnnotation;
+import static springfox.documentation.swagger.schema.ApiModelProperties.toAllowableValues;
+import static springfox.documentation.swagger.schema.ApiModelProperties.toDescription;
+import static springfox.documentation.swagger.schema.ApiModelProperties.toExample;
+import static springfox.documentation.swagger.schema.ApiModelProperties.toHidden;
+import static springfox.documentation.swagger.schema.ApiModelProperties.toIsReadOnly;
+import static springfox.documentation.swagger.schema.ApiModelProperties.toIsRequired;
+import static springfox.documentation.swagger.schema.ApiModelProperties.toType;
+
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
+
+import com.google.common.base.Optional;
+
+import io.swagger.annotations.ApiModelProperty;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spi.schema.ModelPropertyBuilderPlugin;
 import springfox.documentation.spi.schema.contexts.ModelPropertyContext;
 import springfox.documentation.swagger.common.SwaggerPluginSupport;
-
-import static springfox.documentation.schema.Annotations.*;
-import static springfox.documentation.swagger.schema.ApiModelProperties.*;
 
 @Component
 @Order(SwaggerPluginSupport.SWAGGER_PLUGIN_ORDER)
@@ -52,7 +61,8 @@ public class ApiModelPropertyPropertyBuilder implements ModelPropertyBuilderPlug
               .readOnly(annotation.transform(toIsReadOnly()).or(false))
               .description(annotation.transform(toDescription()).orNull())
               .isHidden(annotation.transform(toHidden()).or(false))
-              .type(annotation.transform(toType(context.getResolver())).orNull());
+              .type(annotation.transform(toType(context.getResolver())).orNull())
+              .example(annotation.transform(toExample()).orNull());
     }
   }
 

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/schema/ApiModelPropertyPropertyBuilderPluginSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/schema/ApiModelPropertyPropertyBuilderPluginSpec.groovy
@@ -63,7 +63,6 @@ class ApiModelPropertyPropertyBuilderPluginSpec extends Specification {
       enriched.isRequired() == required
       enriched.description == description
       enriched.readOnly == readOnly
-      enriched.example == example
       !enriched.isHidden()
     where:
       property    | required | description              | allowableValues | readOnly
@@ -89,7 +88,6 @@ class ApiModelPropertyPropertyBuilderPluginSpec extends Specification {
       enriched.isRequired() == required
       enriched.description == description
       enriched.readOnly == readOnly
-      enriched.example == example
       !enriched.isHidden()
     where:
       property    | required | description              | allowableValues | readOnly
@@ -115,7 +113,6 @@ class ApiModelPropertyPropertyBuilderPluginSpec extends Specification {
       enriched.allowableValues?.values == allowableValues
       enriched.isRequired() == required
       enriched.description == description
-      enriched.example == example
       enriched.isHidden()
     where:
       property    | required | description              | allowableValues
@@ -145,7 +142,6 @@ class ApiModelPropertyPropertyBuilderPluginSpec extends Specification {
       enriched.allowableValues?.values == null
       !enriched.isRequired()
       enriched.description == ""
-      enriched.example == ""
       !enriched.isHidden()
       enriched.type.getErasedType() == dataType
       enriched.modelRef.type == modelRef
@@ -180,7 +176,6 @@ class ApiModelPropertyPropertyBuilderPluginSpec extends Specification {
       enriched.allowableValues?.values == null
       !enriched.isRequired()
       enriched.description == ""
-      enriched.example == ""
       !enriched.isHidden()
       enriched.type.getErasedType() == dataType
       enriched.modelRef.type == modelRef

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/schema/ApiModelPropertyPropertyBuilderPluginSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/schema/ApiModelPropertyPropertyBuilderPluginSpec.groovy
@@ -63,6 +63,7 @@ class ApiModelPropertyPropertyBuilderPluginSpec extends Specification {
       enriched.isRequired() == required
       enriched.description == description
       enriched.readOnly == readOnly
+      enriched.example == example
       !enriched.isHidden()
     where:
       property    | required | description              | allowableValues | readOnly
@@ -88,6 +89,7 @@ class ApiModelPropertyPropertyBuilderPluginSpec extends Specification {
       enriched.isRequired() == required
       enriched.description == description
       enriched.readOnly == readOnly
+      enriched.example == example
       !enriched.isHidden()
     where:
       property    | required | description              | allowableValues | readOnly
@@ -113,6 +115,7 @@ class ApiModelPropertyPropertyBuilderPluginSpec extends Specification {
       enriched.allowableValues?.values == allowableValues
       enriched.isRequired() == required
       enriched.description == description
+      enriched.example == example
       enriched.isHidden()
     where:
       property    | required | description              | allowableValues
@@ -142,6 +145,7 @@ class ApiModelPropertyPropertyBuilderPluginSpec extends Specification {
       enriched.allowableValues?.values == null
       !enriched.isRequired()
       enriched.description == ""
+      enriched.example == ""
       !enriched.isHidden()
       enriched.type.getErasedType() == dataType
       enriched.modelRef.type == modelRef
@@ -176,6 +180,7 @@ class ApiModelPropertyPropertyBuilderPluginSpec extends Specification {
       enriched.allowableValues?.values == null
       !enriched.isRequired()
       enriched.description == ""
+      enriched.example == ""
       !enriched.isHidden()
       enriched.type.getErasedType() == dataType
       enriched.modelRef.type == modelRef

--- a/springfox-swagger2/src/main/java/springfox/documentation/swagger2/mappers/ModelMapper.java
+++ b/springfox-swagger2/src/main/java/springfox/documentation/swagger2/mappers/ModelMapper.java
@@ -19,11 +19,23 @@
 
 package springfox.documentation.swagger2.mappers;
 
+import static com.google.common.collect.Maps.newHashMap;
+import static com.google.common.collect.Maps.newTreeMap;
+import static springfox.documentation.schema.Maps.isMapType;
+import static springfox.documentation.swagger2.mappers.Properties.property;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.mapstruct.Mapper;
+
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Multimap;
+
 import io.swagger.models.Model;
 import io.swagger.models.ModelImpl;
 import io.swagger.models.properties.AbstractNumericProperty;
@@ -32,21 +44,12 @@ import io.swagger.models.properties.MapProperty;
 import io.swagger.models.properties.ObjectProperty;
 import io.swagger.models.properties.Property;
 import io.swagger.models.properties.StringProperty;
-import org.mapstruct.Mapper;
 import springfox.documentation.schema.ModelProperty;
 import springfox.documentation.schema.ModelRef;
 import springfox.documentation.service.AllowableListValues;
 import springfox.documentation.service.AllowableRangeValues;
 import springfox.documentation.service.AllowableValues;
 import springfox.documentation.service.ApiListing;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.TreeMap;
-
-import static com.google.common.collect.Maps.*;
-import static springfox.documentation.schema.Maps.*;
-import static springfox.documentation.swagger2.mappers.Properties.*;
 
 @Mapper
 public abstract class ModelMapper {
@@ -71,7 +74,7 @@ public abstract class ModelMapper {
     ModelImpl model = new ModelImpl()
         .description(source.getDescription())
         .discriminator(source.getDiscriminator())
-        .example("")
+        .example(source.getExample())
         .name(source.getName());
     TreeMap<String, Property> sorted = newTreeMap();
     sorted.putAll(mapProperties(source.getProperties()));
@@ -122,6 +125,7 @@ public abstract class ModelMapper {
       property.setName(source.getName());
       property.setRequired(source.isRequired());
       property.setReadOnly(source.isReadOnly());
+      property.setExample(source.getExample());
     }
     return property;
   }

--- a/springfox-swagger2/src/test/groovy/springfox/documentation/swagger2/mappers/ModelMapperSpec.groovy
+++ b/springfox-swagger2/src/test/groovy/springfox/documentation/swagger2/mappers/ModelMapperSpec.groovy
@@ -148,6 +148,7 @@ class ModelMapperSpec extends SchemaSpecification {
         .name(modelProperty.name)
         .position(modelProperty.position)
         .type(modelProperty.type)
+        .example(modelProperty.example)
       .build()
     newModel.updateModelRef(forSupplier(ofInstance((modelProperty.modelRef))))
   }


### PR DESCRIPTION
Things like @ApiModelProperty(value="value description", example="example value") didn't produce the example in the Swagger JSON output. Now it should.