### PR TITLE
Fixing logging error

### DIFF
--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/plugins/DocumentationPluginsBootstrapper.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/plugins/DocumentationPluginsBootstrapper.java
@@ -80,7 +80,7 @@ public class DocumentationPluginsBootstrapper implements ApplicationListener<Con
       log.info("Context refreshed");
       List<DocumentationPlugin> plugins = pluginOrdering()
           .sortedCopy(documentationPluginsManager.documentationPlugins());
-      log.info("Found {0} custom documentation plugin(s)", plugins.size());
+      log.info("Found {} custom documentation plugin(s)", plugins.size());
       for (DocumentationPlugin each : plugins) {
         DocumentationType documentationType = each.getDocumentationType();
         if (each.isEnabled()) {


### PR DESCRIPTION
log.info("{0}", "hi") -> "{0}"
log.info("{}", "hi" -> "hi"
I believe the second form is preferred in this case.