### PR TITLE
Add minLength and maxLength support from StringProperty

### DIFF
--- a/springfox-swagger2/src/main/java/springfox/documentation/swagger2/mappers/ModelMapper.java
+++ b/springfox-swagger2/src/main/java/springfox/documentation/swagger2/mappers/ModelMapper.java
@@ -117,6 +117,16 @@ public abstract class ModelMapper {
         ((AbstractNumericProperty) property).minimum(Double.valueOf(range.getMin()));
       }
     }
+
+    if (property instanceof StringProperty) {
+      AllowableValues allowableValues = source.getAllowableValues();
+      if (allowableValues instanceof AllowableRangeValues) {
+        AllowableRangeValues range = (AllowableRangeValues) allowableValues;
+        ((StringProperty) property).maxLength(Integer.valueOf(range.getMax()));
+        ((StringProperty) property).minLength(Integer.valueOf(range.getMin()));
+      }
+    }
+
     if (property != null) {
       property.setDescription(source.getDescription());
       property.setName(source.getName());

--- a/springfox-swagger2/src/test/groovy/springfox/documentation/swagger2/mappers/ModelMapperSpec.groovy
+++ b/springfox-swagger2/src/test/groovy/springfox/documentation/swagger2/mappers/ModelMapperSpec.groovy
@@ -152,4 +152,44 @@ class ModelMapperSpec extends SchemaSpecification {
     newModel.updateModelRef(forSupplier(ofInstance((modelProperty.modelRef))))
   }
 
+
+  def "models with allowable ranges are serialized correctly for string property" (){
+    given:
+      Model model = modelProvider.modelFor(inputParam(simpleType(),
+          DocumentationType.SWAGGER_2, alternateTypeProvider(), namingStrategy)).get()
+      def modelMap = newHashMap()
+    and:
+      modelMap.put("test", model)
+    and: "we add a fake allowable range"
+      def stringObject = model.properties.get("aString")
+      model.properties.put("aString", updatedStringObject(stringObject))
+    when:
+      def mapped = Mappers.getMapper(ModelMapper).mapModels(modelMap)
+    then:
+      mapped.containsKey("test")
+    and: "Required values contains the modified property"
+      def mappedModel = mapped.get("test")
+      mappedModel.properties.size() == model.properties.size()
+      mappedModel.getRequired().size() == 1
+      mappedModel.getRequired().contains("aString")
+    and: "Range expectations are mapped correctly"
+      def mappedStringObject = mappedModel.properties.get("aString")
+      ((StringProperty)mappedStringObject).minLength == 1
+      ((StringProperty)mappedStringObject).maxLength == 255
+  }
+
+  ModelProperty updatedStringObject(ModelProperty modelProperty) {
+    ModelPropertyBuilder builder = new ModelPropertyBuilder()
+    def newModel = builder
+        .allowableValues(new AllowableRangeValues("1", "255"))
+        .description(modelProperty.description)
+        .isHidden(modelProperty.hidden)
+        .required(true)
+        .name(modelProperty.name)
+        .position(modelProperty.position)
+        .type(modelProperty.type)
+      .build()
+    newModel.updateModelRef(forSupplier(ofInstance((modelProperty.modelRef))))
+  }
+
 }


### PR DESCRIPTION
Add support of minLength and maxLength to  StringProperty. Needed if a ModelPropertyBuilderPlugin is created to support \@Min, \@Max and \@Size annotations.

Thanks 