### PR TITLE
Fix Nullpointer exception when spring framework failed to get paramter name

### DIFF
--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/parameter/ParameterNameReader.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/parameter/ParameterNameReader.java
@@ -53,10 +53,10 @@ public class ParameterNameReader implements ParameterBuilderPlugin {
   @Override
   public void apply(ParameterContext context) {
     MethodParameter methodParameter = context.methodParameter();
-    String discoveredName
-        = parameterNameDiscover.getParameterNames(methodParameter.getMethod())[methodParameter.getParameterIndex()];
     String name = findParameterNameFromAnnotations(methodParameter);
     if (isNullOrEmpty(name)) {
+      String[] discoveredNames = parameterNameDiscover.getParameterNames(methodParameter.getMethod());
+      String discoveredName = (discoveredNames == null) ? null : discoveredNames[methodParameter.getParameterIndex()];
       name = isNullOrEmpty(discoveredName)
                        ? format("param%s", methodParameter.getParameterIndex())
                        : discoveredName;


### PR DESCRIPTION
When using JAVA8 without enable -parameters in javac, spring will failed to obtain the parameter name . see [http://stackoverflow.com/questions/21455403/how-to-get-method-parameter-names-in-java-8-using-reflection]

 It causes springfox throw nullpointerexception.

This fix allow springfox using @ApiParam by default and prevent the nullpointerexception when Spring failed to obtain parameter name.