### PR TITLE
Add Polymorphism Support

### DIFF
--- a/springfox-core/src/main/java/springfox/documentation/builders/ModelBuilder.java
+++ b/springfox-core/src/main/java/springfox/documentation/builders/ModelBuilder.java
@@ -39,6 +39,7 @@ public class ModelBuilder {
   private String discriminator;
   private ResolvedType modelType;
   private String example;
+  private Model parent;
 
   private Map<String, ModelProperty> properties = newHashMap();
   private List<String> subTypes = newArrayList();
@@ -155,8 +156,19 @@ public class ModelBuilder {
     return this;
   }
 
+  /**
+   * Represents the parent type information with full fidelity of generics
+   *
+   * @param parent - resolved type that represents the parent model
+   * @return this
+   */
+  public ModelBuilder parent(Model parent) {
+    this.parent = defaultIfAbsent(parent, this.parent);
+    return this;
+  }
+
   public Model build() {
     return new Model(id, name, modelType, qualifiedType, properties, description, baseModel, discriminator, subTypes,
-        example);
+        example, parent);
   }
 }

--- a/springfox-core/src/main/java/springfox/documentation/schema/Model.java
+++ b/springfox-core/src/main/java/springfox/documentation/schema/Model.java
@@ -36,6 +36,7 @@ public class Model {
   private final String discriminator;
   private final List<String> subTypes;
   private final String example;
+  private final Model parent;
 
   public Model(
       String id,
@@ -47,7 +48,8 @@ public class Model {
       String baseModel,
       String discriminator,
       List<String> subTypes,
-      String example) {
+      String example,
+      Model parent) {
 
     this.id = id;
     this.name = name;
@@ -59,6 +61,7 @@ public class Model {
     this.discriminator = discriminator;
     this.subTypes = subTypes;
     this.example = example;
+    this.parent = parent;
   }
 
   public String getId() {
@@ -99,5 +102,9 @@ public class Model {
 
   public String getExample() {
     return example;
+  }
+
+  public Model getParent() {
+    return parent;
   }
 }

--- a/springfox-core/src/test/groovy/springfox/documentation/builders/ModelBuilderSpec.groovy
+++ b/springfox-core/src/test/groovy/springfox/documentation/builders/ModelBuilderSpec.groovy
@@ -21,6 +21,7 @@ package springfox.documentation.builders
 
 import com.fasterxml.classmate.TypeResolver
 import spock.lang.Specification
+import springfox.documentation.schema.Model
 import springfox.documentation.schema.ModelProperty
 
 class ModelBuilderSpec extends Specification {
@@ -46,6 +47,7 @@ class ModelBuilderSpec extends Specification {
       'subTypes'      | ["String"]                            | 'subTypes'
       'properties'    | [p1: Mock(ModelProperty)]             | 'properties'
       'example'       | 'example1'                            | 'example'
+      'parent'        | Mock(Model)                           | 'parent'
   }
 
   def "Setting builder properties to null values preserves existing values"() {
@@ -71,5 +73,6 @@ class ModelBuilderSpec extends Specification {
       'subTypes'      | ["String"]                            | 'subTypes'
       'properties'    | [p1: Mock(ModelProperty)]             | 'properties'
       'example'       | 'example1'                            | 'example'
+      'parent'        | Mock(Model)                           | 'parent'
   }
 }

--- a/springfox-schema/src/test/groovy/springfox/documentation/schema/mixins/TypesForTestingSupport.groovy
+++ b/springfox-schema/src/test/groovy/springfox/documentation/schema/mixins/TypesForTestingSupport.groovy
@@ -200,4 +200,12 @@ class TypesForTestingSupport {
   def ResolvedType typeForTestingPropertyPositions() {
     resolver.resolve(TypeForTestingPropertyPositions)
   }
+
+  def ResolvedType typeForInheritedComplexType() {
+    resolver.resolve(InheritedComplexType)
+  }
+
+  def ResolvedType typeForComplexType() {
+    resolver.resolve(ComplexType)
+  }
 }

--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/scanners/ApiModelReader.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/scanners/ApiModelReader.java
@@ -113,6 +113,7 @@ public class ApiModelReader  {
                 .baseModel(targetModelValue.getBaseModel())
                 .discriminator(targetModelValue.getDiscriminator())
                 .subTypes(targetModelValue.getSubTypes())
+                .parent(targetModelValue.getParent())
                 .build();
 
         target.put(sourceModelKey, mergedModel);

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/schema/ApiModelBuilder.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/schema/ApiModelBuilder.java
@@ -20,11 +20,16 @@
 package springfox.documentation.swagger.schema;
 
 import com.fasterxml.classmate.TypeResolver;
+import com.google.common.base.Optional;
 import io.swagger.annotations.ApiModel;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import springfox.documentation.schema.Model;
+import springfox.documentation.schema.ModelProvider;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spi.schema.ModelBuilderPlugin;
 import springfox.documentation.spi.schema.contexts.ModelContext;
@@ -36,10 +41,13 @@ import static springfox.documentation.swagger.common.SwaggerPluginSupport.*;
 @Order(SwaggerPluginSupport.SWAGGER_PLUGIN_ORDER)
 public class ApiModelBuilder implements ModelBuilderPlugin {
   private final TypeResolver typeResolver;
+  private final ModelProvider modelProvider;
 
   @Autowired
-  public ApiModelBuilder(TypeResolver typeResolver) {
+  public ApiModelBuilder(TypeResolver typeResolver,
+                         @Qualifier("cachedModels") ModelProvider modelProvider) {
     this.typeResolver = typeResolver;
+    this.modelProvider = modelProvider;
   }
 
 
@@ -48,6 +56,19 @@ public class ApiModelBuilder implements ModelBuilderPlugin {
     ApiModel annotation = AnnotationUtils.findAnnotation(forClass(context), ApiModel.class);
     if (annotation != null) {
       context.getBuilder().description(annotation.description());
+      if(StringUtils.hasText(annotation.discriminator())){
+        context.getBuilder().discriminator(annotation.discriminator());
+      }
+
+      // default parent is Void
+      if (!annotation.parent().isAssignableFrom(Void.class)) {
+        Optional<Model> parentModel = modelProvider.modelFor(ModelContext.fromParent(context, this.typeResolver.resolve(annotation.parent())));
+
+        // parent model exist because @ApiModel not required on model
+        // if(parentModel.isPresent()) {
+          context.getBuilder().parent(parentModel.get());
+        // }
+      }
     }
   }
 

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/mixins/SwaggerPluginsSupport.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/mixins/SwaggerPluginsSupport.groovy
@@ -21,6 +21,8 @@ package springfox.documentation.swagger.mixins
 
 import com.fasterxml.classmate.TypeResolver
 import org.springframework.plugin.core.PluginRegistry
+import springfox.documentation.schema.mixins.ModelProviderSupport
+import springfox.documentation.schema.mixins.SchemaPluginsSupport
 import springfox.documentation.schema.plugins.SchemaPluginsManager
 import springfox.documentation.spi.DocumentationType
 import springfox.documentation.spi.schema.ModelBuilderPlugin
@@ -42,13 +44,14 @@ import static com.google.common.collect.Lists.*
 import static org.springframework.plugin.core.OrderAwarePluginRegistry.*
 
 @SuppressWarnings("GrMethodMayBeStatic")
+@Mixin([ModelProviderSupport, SchemaPluginsSupport])
 class SwaggerPluginsSupport {
   SchemaPluginsManager swaggerSchemaPlugins() {
     PluginRegistry<ModelPropertyBuilderPlugin, DocumentationType> propRegistry =
         create(newArrayList(new ApiModelPropertyPropertyBuilder()))
 
     PluginRegistry<ModelBuilderPlugin, DocumentationType> modelRegistry =
-        create(newArrayList(new ApiModelBuilder(new TypeResolver())))
+        create(newArrayList(new ApiModelBuilder(new TypeResolver(), defaultModelProvider())))
 
     new SchemaPluginsManager(propRegistry, modelRegistry)
   }

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/schema/ApiModelBuilderSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/schema/ApiModelBuilderSpec.groovy
@@ -3,19 +3,18 @@ package springfox.documentation.swagger.schema
 import com.fasterxml.classmate.TypeResolver
 import io.swagger.annotations.ApiModel
 import spock.lang.Shared
-import spock.lang.Specification
 import springfox.documentation.schema.DefaultGenericTypeNamingStrategy
-import springfox.documentation.spi.DocumentationType
+import springfox.documentation.schema.SchemaSpecification
 import springfox.documentation.spi.schema.AlternateTypeProvider
 import springfox.documentation.spi.schema.contexts.ModelContext
 
-class ApiModelBuilderSpec extends Specification {
+class ApiModelBuilderSpec extends SchemaSpecification {
   @Shared def resolver = new TypeResolver()
 
   def "Api model builder parses ApiModel annotation as expected" () {
     given:
-      ApiModelBuilder sut = new ApiModelBuilder(resolver)
-      ModelContext context = ModelContext.inputParam(type, DocumentationType.SWAGGER_12,
+      ApiModelBuilder sut = new ApiModelBuilder(resolver, modelProvider)
+      ModelContext context = ModelContext.inputParam(type, documentationType,
           new AlternateTypeProvider([]), new DefaultGenericTypeNamingStrategy())
     when:
       sut.apply(context)
@@ -31,5 +30,64 @@ class ApiModelBuilderSpec extends Specification {
   @ApiModel(description = "description")
   class AnnotatedTest {
 
+  }
+
+  def "Api model builder parses ApiModel annotation discriminator as expected" () {
+    given:
+      ApiModelBuilder sut = new ApiModelBuilder(resolver, modelProvider)
+      ModelContext context = ModelContext.inputParam(type, documentationType,
+          new AlternateTypeProvider([]), new DefaultGenericTypeNamingStrategy())
+    when:
+      sut.apply(context)
+    then:
+      context.builder.build().discriminator == expected
+    where:
+      type                | expected
+      String              | null
+      DiscriminatorTest   | "discriminator"
+
+  }
+
+  @ApiModel(discriminator = "discriminator")
+  class DiscriminatorTest {
+
+  }
+
+  def "Api model builder parses ApiModel annotation parent as expected" () {
+    given:
+      ApiModelBuilder sut = new ApiModelBuilder(resolver, modelProvider)
+      ModelContext context = ModelContext.inputParam(type, documentationType,
+          new AlternateTypeProvider([]), new DefaultGenericTypeNamingStrategy())
+    when:
+      sut.apply(context)
+    and:
+      def enriched = context.builder.build()
+    then:
+      enriched.parent.name == expected
+    where:
+      type                | expected
+      ParentTest          | "DiscriminatorTest"
+
+  }
+
+  @ApiModel(parent = DiscriminatorTest.class)
+  class ParentTest {
+
+  }
+
+  def "Api model builder parses ApiModel annotation without parent" () {
+    given:
+      ApiModelBuilder sut = new ApiModelBuilder(resolver, modelProvider)
+      ModelContext context = ModelContext.inputParam(type, documentationType,
+        new AlternateTypeProvider([]), new DefaultGenericTypeNamingStrategy())
+    when:
+      sut.apply(context)
+    and:
+      def enriched = context.builder.build()
+    then:
+      enriched.parent == expected
+    where:
+      type                | expected
+      AnnotatedTest       | null
   }
 }

--- a/springfox-swagger2/src/test/groovy/springfox/documentation/swagger2/mappers/ModelMapperSpec.groovy
+++ b/springfox-swagger2/src/test/groovy/springfox/documentation/swagger2/mappers/ModelMapperSpec.groovy
@@ -1,5 +1,6 @@
 package springfox.documentation.swagger2.mappers
 
+import io.swagger.models.ComposedModel
 import io.swagger.models.properties.AbstractNumericProperty
 import io.swagger.models.properties.ObjectProperty
 import io.swagger.models.properties.RefProperty
@@ -295,7 +296,53 @@ class ModelMapperSpec extends SchemaSpecification {
         '',
         '',
         null,
-        '')
+        '',
+        null)
+    model
+  }
+
+  def "Inherited complex type are supported"() {
+    given:
+      Model model = createInheritedModel()
+    when:
+      def mapped = Mappers.getMapper(ModelMapper).mapModels([test: model])
+    then:
+      mapped != null
+     !((ComposedModel)mapped['test']).interfaces.empty
+     "#/definitions/ComplexType".equals(((ComposedModel)mapped['test']).interfaces.get(0).$ref)
+     !((ComposedModel)mapped['test']).child.properties.empty
+     ['inheritedProperty'] == ((ComposedModel)mapped['test']).child.properties.keySet().toList()
+    }
+
+  Model createInheritedModel() {
+
+    def modelParentType = typeForComplexType()
+    def modelParent = new Model(
+            'ComplexType',
+            'ComplexType',
+            modelParentType,
+            simpleQualifiedTypeName(modelParentType),
+            ['inheritedProperty' : createModelPropertyWithPosition('name', 0)],
+            '',
+            '',
+            'name',
+            null,
+            '',
+            null)
+
+    def modelType = typeForInheritedComplexType()
+    def model = new Model(
+            'InheritedComplexType',
+            'InheritedComplexType',
+            modelType,
+            simpleQualifiedTypeName(modelType),
+            ['inheritedProperty' : createModelPropertyWithPosition('inheritedProperty', 0)],
+            '',
+            '',
+            '',
+            null,
+            '',
+            modelParent)
     model
   }
 


### PR DESCRIPTION
I've added "Polymorphism support" (discriminator on parent, and allOf on child(s)) with springfox

```
{
  "definitions": {
    "Pet": {
      "type": "object",
      "discriminator": "petType",
      "properties": {
        "name": {
          "type": "string"
        },
        "petType": {
          "type": "string"
        }/
      },
      "required": [
        "name",
        "petType"
      ]
    },
    "Cat": {
      "description": "A representation of a cat",
      "allOf": [
        {
          "$ref": "#/definitions/Pet"
        },
        {
          "type": "object",
          "properties": {
            "huntingSkill": {
              "type": "string",
              "description": "The measured skill for hunting",
              "default": "lazy",
              "enum": [
                "clueless",
                "lazy",
                "adventurous",
                "aggressive"
              ]
            }
          },
          "required": [
            "huntingSkill"
          ]
        }
      ]
    },
    "Dog": {
      "description": "A representation of a dog",
      "allOf": [
        {
          "$ref": "#/definitions/Pet"
        },
        {
          "type": "object",
          "properties": {
            "packSize": {
              "type": "integer",
              "format": "int32",
              "description": "the size of the pack the dog is from",
              "default": 0,
              "minimum": 0
            }
          },
          "required": [
            "packSize"
          ]
        }
      ]
    }
  }
}
```

On java models : 
Parent -> @ApiModel(discriminator="id")
Child -> @ApiModel(parent = Parent.class)

see https://github.com/Fyro-Ing/springfox/commit/43923f583dc85e009f11f623655624a903042abb