### PR TITLE
Updated the Docket XML Configuration Documentation

### DIFF
--- a/asciidoc/current-documentation.adoc
+++ b/asciidoc/current-documentation.adoc
@@ -122,6 +122,9 @@ This config class must then be defined in your xml application context.
 <!-- Required so springfox can access spring's RequestMappingHandlerMapping  -->
 <mvc:annotation-driven/>
 
+<!-- Required to enable Spring post processing on @Configuration classes. -->
+<context:annotation-config/>
+
 <bean class="com.yourapp.configuration.MySwaggerConfig"/>
 ```
 


### PR DESCRIPTION
The sample Springfox configuration class uses the `@Configuration` annotation. This requires the xml configuration to have an extra element so that Spring can carry out post processing on the configuration class for Springfox. According to the [Spring documentation](http://docs.spring.io/autorepo/docs/spring/current/javadoc-api/org/springframework/context/annotation/Configuration.html): 

> In the example above, <context:annotation-config/> is required in order to enable ConfigurationClassPostProcessor and other annotation-related post processors that facilitate handling `@Configuration` classes.