### PR TITLE
ParameterDefaultReader in swagger does not honor other annotations usage of DefaultValue

### DIFF
--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/parameter/ParameterDefaultReader.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/parameter/ParameterDefaultReader.java
@@ -43,7 +43,7 @@ public class ParameterDefaultReader implements ParameterBuilderPlugin {
     String defaultValue = findAnnotatedDefaultValue(methodParameter);
     boolean isSkip = ValueConstants.DEFAULT_NONE.equals(defaultValue);
     if (!isSkip) {
-      context.parameterBuilder().defaultValue(nullToEmpty(defaultValue));
+      context.parameterBuilder().defaultValue(defaultValue);
     }
   }
 


### PR DESCRIPTION
When annotations other then ApiParam are used, the defaultValue set by them is not honored. 
If an annotation such as Springs @RequestParam is used with a defaultValue set and @APIParam is not used, the current implementation will override the defaultValue of the parameterBuilder to  empty string. 

Note: springfox.documentation.spring.web.readers.parameter.ParameterDefaultReader correctly evaluates the defaultValue of RequestParam and correctly assigns the defaultValue (not overriding previous values set if the annotation doesn't exist).

