### PR TITLE
Allow extension of ApiResourceController by making its methods public

### DIFF
--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/ApiResourceController.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/ApiResourceController.java
@@ -64,21 +64,21 @@ public class ApiResourceController {
 
   @RequestMapping(value = "/configuration/security")
   @ResponseBody
-  ResponseEntity<SecurityConfiguration> securityConfiguration() {
+  public ResponseEntity<SecurityConfiguration> securityConfiguration() {
     return new ResponseEntity<SecurityConfiguration>(
         Optional.fromNullable(securityConfiguration).or(SecurityConfiguration.DEFAULT), HttpStatus.OK);
   }
 
   @RequestMapping(value = "/configuration/ui")
   @ResponseBody
-  ResponseEntity<UiConfiguration> uiConfiguration() {
+  public ResponseEntity<UiConfiguration> uiConfiguration() {
     return new ResponseEntity<UiConfiguration>(
         Optional.fromNullable(uiConfiguration).or(UiConfiguration.DEFAULT), HttpStatus.OK);
   }
 
   @RequestMapping(value = "/swagger-resources")
   @ResponseBody
-  ResponseEntity<List<SwaggerResource>> swaggerResources() {
+  public ResponseEntity<List<SwaggerResource>> swaggerResources() {
 
 
     List<SwaggerResource> resources = new ArrayList<SwaggerResource>();


### PR DESCRIPTION
Hello,

JHipster 3.0 needs to extend ApiResourceController for overriding "/swagger-resources" mapping in order to be able to aggregate APIs of micro services proxified by a Zuul proxy.

For details, please see the end of this discussion in jhipster/generator-jhipster#2990

Thanks,
Gael