### PR TITLE
adds basePath from x-forwarded-prefix for reverse proxy scenarios

### DIFF
--- a/springfox-swagger2/src/main/java/springfox/documentation/swagger2/web/Swagger2Controller.java
+++ b/springfox-swagger2/src/main/java/springfox/documentation/swagger2/web/Swagger2Controller.java
@@ -20,6 +20,7 @@
 package springfox.documentation.swagger2.web;
 
 import com.google.common.base.Optional;
+import com.google.common.base.Strings;
 import io.swagger.models.Swagger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -80,16 +81,17 @@ public class Swagger2Controller {
     }
     Swagger swagger = mapper.mapDocumentation(documentation);
     if (isNullOrEmpty(swagger.getHost())) {
-      swagger.host(hostName(servletRequest));
+      final UriComponents uriComponents = componentsFrom(servletRequest);
+      swagger.basePath(Strings.isNullOrEmpty(uriComponents.getPath()) ? "/" : uriComponents.getPath());
+      swagger.host(hostName(uriComponents));
     }
     return new ResponseEntity<Json>(jsonSerializer.toJson(swagger), HttpStatus.OK);
   }
 
-  private String hostName(HttpServletRequest servletRequest) {
+  private String hostName(UriComponents uriComponents) {
     if ("DEFAULT".equals(hostNameOverride)) {
-      UriComponents uri = componentsFrom(servletRequest);
-      String host = uri.getHost();
-      int port = uri.getPort();
+      String host = uriComponents.getHost();
+      int port = uriComponents.getPort();
       if (port > -1) {
         return String.format("%s:%d", host, port);
       }

--- a/springfox-swagger2/src/test/groovy/springfox/documentation/swagger2/web/Swagger2ControllerSpec.groovy
+++ b/springfox-swagger2/src/test/groovy/springfox/documentation/swagger2/web/Swagger2ControllerSpec.groovy
@@ -7,6 +7,8 @@ import org.springframework.http.MediaType
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.MvcResult
+import org.springframework.test.web.servlet.ResultActions
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 import org.springframework.web.servlet.View
 import spock.lang.Shared
 import spock.lang.Unroll
@@ -23,10 +25,10 @@ import springfox.documentation.spring.web.scanners.ApiListingScanner
 import springfox.documentation.swagger2.configuration.Swagger2JacksonModule
 import springfox.documentation.swagger2.mappers.MapperSupport
 
-import static com.google.common.collect.Maps.*
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*
-import static org.springframework.test.web.servlet.setup.MockMvcBuilders.*
+import static com.google.common.collect.Maps.newHashMap
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup
 
 @Mixin([JsonSupport, ApiListingSupport, AuthSupport])
 class Swagger2ControllerSpec extends DocumentationContextSpec implements MapperSupport {
@@ -80,6 +82,28 @@ class Swagger2ControllerSpec extends DocumentationContextSpec implements MapperS
       "/v2/api-docs"               | 200
       "/v2/api-docs?group=default" | 200
       "/v2/api-docs?group=unknown" | 404
+  }
+
+  @Unroll("x-forwarded-prefix: #prefix")
+  def "should respect proxy headers ('X-Forwarded-*') when setting host, port and basePath"() {
+    given:
+      ApiDocumentationScanner swaggerApiResourceListing =
+          new ApiDocumentationScanner(listingReferenceScanner, listingScanner)
+      controller.documentationCache.addDocumentation(swaggerApiResourceListing.scan(context()))
+    when:
+      ResultActions result = mockMvc
+          .perform(get("/v2/api-docs")
+          .header("x-forwarded-host", "myhost:6060")
+          .header("x-forwarded-prefix", prefix))
+
+    then:
+      result.andExpect(MockMvcResultMatchers.jsonPath("basePath").value(expectedPath))
+
+    where:
+      prefix        | expectedPath
+      "/fooservice" | "/fooservice"
+      "/"           | "/"
+      ""            | "/"
   }
 
   def "Should omit port number if it is -1"() {


### PR DESCRIPTION
Hi, 

this is my suggested solution for the [issue 1210](https://github.com/springfox/springfox/issues/1210). 

It fixes generated URLs in the swagger-ui when called from behind a reverse proxy (Netflix Zuul).

Hope for addition...
mat
