### PR TITLE
Only encode the API key when passed in URL query

### DIFF
--- a/springfox-swagger-ui/src/web/js/springfox.js
+++ b/springfox-swagger-ui/src/web/js/springfox.js
@@ -49,7 +49,7 @@ $(function() {
     initializeBaseUrl();
 
     function addApiKeyAuthorization() {
-      var key = encodeURIComponent($('#input_apiKey')[0].value);
+      var key = window.apiKeyVehicle == 'query ? encodeURIComponent($('#input_apiKey')[0].value) : $('#input_apiKey')[0].value;
       if (key && key.trim() != "") {
         var apiKeyAuth = new SwaggerClient.ApiKeyAuthorization(window.apiKeyName, key, window.apiKeyVehicle);
         window.swaggerUi.api.clientAuthorizations.add(window.apiKeyName, apiKeyAuth);

--- a/springfox-swagger-ui/src/web/js/springfox.js
+++ b/springfox-swagger-ui/src/web/js/springfox.js
@@ -49,7 +49,7 @@ $(function() {
     initializeBaseUrl();
 
     function addApiKeyAuthorization() {
-      var key = window.apiKeyVehicle == 'query ? encodeURIComponent($('#input_apiKey')[0].value) : $('#input_apiKey')[0].value;
+      var key = (window.apiKeyVehicle == 'query') ? encodeURIComponent($('#input_apiKey')[0].value) : $('#input_apiKey')[0].value;
       if (key && key.trim() != "") {
         var apiKeyAuth = new SwaggerClient.ApiKeyAuthorization(window.apiKeyName, key, window.apiKeyVehicle);
         window.swaggerUi.api.clientAuthorizations.add(window.apiKeyName, apiKeyAuth);


### PR DESCRIPTION


I am current passing tokens through the header. Everything is working using the current app but when trying it on Swagger UI, I noticed that the tokens changed.