### PR TITLE
Skip events from child application context, fixes #1207

### DIFF
--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/plugins/DocumentationPluginsBootstrapper.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/plugins/DocumentationPluginsBootstrapper.java
@@ -80,6 +80,13 @@ public class DocumentationPluginsBootstrapper implements ApplicationListener<Con
 
   @Override
   public void onApplicationEvent(ContextRefreshedEvent contextRefreshedEvent) {
+
+    // run the bootstrapper only if the event is from the root context
+    if(contextRefreshedEvent.getApplicationContext().getParent() != null) {
+      log.info("contextRefreshedEvent {} not from root application context. So skipping this event.", contextRefreshedEvent);
+      return;
+    }
+
     if (initialized.compareAndSet(false, true)) {
       log.info("Context refreshed");
       List<DocumentationPlugin> plugins = pluginOrdering()

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/plugins/DocumentationPluginsBootstrapperSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/plugins/DocumentationPluginsBootstrapperSpec.groovy
@@ -94,4 +94,18 @@ class DocumentationPluginsBootstrapperSpec extends Specification {
     then:
       1 * plugin.configure(_)
   }
+
+  def "bootstrapper only if the event is from the root context"() {
+    given: "ContextRefreshedEvent from a non-root application context."
+    ApplicationContext appCtx = Mock(ApplicationContext)
+    appCtx.getParent() >> Mock(ApplicationContext)
+    ContextRefreshedEvent rootAppCtxEvent = new ContextRefreshedEvent(appCtx)
+    pluginManager.documentationPlugins() >>  []
+
+    when:
+    bootstrapper.onApplicationEvent(rootAppCtxEvent)
+
+    then:
+    bootstrapper.initialized.get() == false
+  }
 }


### PR DESCRIPTION
This PR fixes #1207. The bootstrapper runs only if the event received is from the root application context. More details on why this is required is explained in https://github.com/springfox/springfox/issues/1207#issuecomment-197921417
