### PR TITLE
Fix for broken contributing link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For more information on this project visit the [Springfox Website] (http://sprin
 ### Useful links
 - [Reference Documentation](http://springfox.io)
 - [Examples repository](https://github.com/springfox/springfox-demos)
-- [Contributing](https://github.com/springfox/springfox/wiki/Contribution-guidelines)
+- [Contribution Guidelines](https://github.com/springfox/springfox/wiki/Contribution-guidelines)
 - [Core contributors](http://springfox.github.io/springfox/contributors.html)
 - [Development and contribution guidelines](https://github.com/martypitt/swagger-springmvc/wiki/Development)
 - [Change log](docs/CHANGELOG.md)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For more information on this project visit the [Springfox Website] (http://sprin
 ### Useful links
 - [Reference Documentation](http://springfox.io)
 - [Examples repository](https://github.com/springfox/springfox-demos)
-- [Contributing](CONTRIBUTING.md)
+- [Contributing](https://github.com/springfox/springfox/wiki/Contribution-guidelines)
 - [Core contributors](http://springfox.github.io/springfox/contributors.html)
 - [Development and contribution guidelines](https://github.com/martypitt/swagger-springmvc/wiki/Development)
 - [Change log](docs/CHANGELOG.md)


### PR DESCRIPTION
Replaces broken link in README.md with link to contribution guidelines
Fix for issue #1281 
