### PR TITLE
Added support for documenting headers in @RequestMapping

### DIFF
--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/operation/AbstractOperationParameterRequestConditionReader.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/operation/AbstractOperationParameterRequestConditionReader.java
@@ -1,0 +1,88 @@
+/*
+ *
+ *  Copyright 2016 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+
+package springfox.documentation.spring.web.readers.operation;
+
+import com.fasterxml.classmate.TypeResolver;
+import org.springframework.web.servlet.mvc.condition.NameValueExpression;
+import springfox.documentation.builders.ParameterBuilder;
+import springfox.documentation.schema.ModelRef;
+import springfox.documentation.service.AllowableListValues;
+import springfox.documentation.service.Parameter;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.service.OperationBuilderPlugin;
+
+import java.util.List;
+import java.util.Set;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.collect.Iterables.any;
+import static com.google.common.collect.Lists.newArrayList;
+import static springfox.documentation.builders.Parameters.withName;
+
+public abstract class AbstractOperationParameterRequestConditionReader implements OperationBuilderPlugin {
+
+  private final TypeResolver resolver;
+
+  public AbstractOperationParameterRequestConditionReader(TypeResolver resolver) {
+    this.resolver = resolver;
+  }
+
+  public List<Parameter> getParameters(Set<NameValueExpression<String>> expressions, String parameterType) {
+    List<Parameter> parameters = newArrayList();
+    for (NameValueExpression<String> expression : expressions) {
+      if (skipParameter(parameters, expression)) {
+        continue;
+      }
+
+      String paramValue = expression.getValue();
+      AllowableListValues allowableValues = null;
+      if (!isNullOrEmpty(paramValue)) {
+        allowableValues = new AllowableListValues(newArrayList(paramValue), "string");
+      }
+      Parameter parameter = new ParameterBuilder()
+              .name(expression.getName())
+              .description(null)
+              .defaultValue(paramValue)
+              .required(true)
+              .allowMultiple(false)
+              .type(resolver.resolve(String.class))
+              .modelRef(new ModelRef("string"))
+              .allowableValues(allowableValues)
+              .parameterType(parameterType)
+              .build();
+      parameters.add(parameter);
+    }
+
+    return parameters;
+  }
+
+  private boolean skipParameter(List<Parameter> parameters, NameValueExpression<String> expression) {
+    return expression.isNegated() || parameterHandled(parameters, expression);
+  }
+
+  private boolean parameterHandled(List<Parameter> parameters, NameValueExpression<String> expression) {
+    return any(parameters, withName(expression.getName()));
+  }
+
+  @Override
+  public boolean supports(DocumentationType delimiter) {
+    return true;
+  }
+}

--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/operation/OperationParameterHeadersConditionReader.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/operation/OperationParameterHeadersConditionReader.java
@@ -1,0 +1,48 @@
+/*
+ *
+ *  Copyright 2016 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+
+package springfox.documentation.spring.web.readers.operation;
+
+import com.fasterxml.classmate.TypeResolver;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.condition.HeadersRequestCondition;
+import springfox.documentation.service.Parameter;
+import springfox.documentation.spi.service.contexts.OperationContext;
+
+import java.util.List;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE + 10)
+public class OperationParameterHeadersConditionReader extends AbstractOperationParameterRequestConditionReader {
+
+  @Autowired
+  public OperationParameterHeadersConditionReader(TypeResolver resolver) {
+    super(resolver);
+  }
+
+  @Override
+  public void apply(OperationContext context) {
+    HeadersRequestCondition headersCondition = context.getRequestMappingInfo().getHeadersCondition();
+    List<Parameter> parameters = getParameters(headersCondition.getExpressions(), "header");
+    context.operationBuilder().parameters(parameters);
+  }
+}

--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/operation/OperationParameterRequestConditionReader.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/operation/OperationParameterRequestConditionReader.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2015 the original author or authors.
+ *  Copyright 2016 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -24,74 +24,25 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
-import org.springframework.web.servlet.mvc.condition.NameValueExpression;
 import org.springframework.web.servlet.mvc.condition.ParamsRequestCondition;
-import springfox.documentation.builders.ParameterBuilder;
-import springfox.documentation.schema.ModelRef;
-import springfox.documentation.service.AllowableListValues;
 import springfox.documentation.service.Parameter;
-import springfox.documentation.spi.DocumentationType;
-import springfox.documentation.spi.service.OperationBuilderPlugin;
 import springfox.documentation.spi.service.contexts.OperationContext;
 
 import java.util.List;
 
-import static com.google.common.base.Strings.isNullOrEmpty;
-import static com.google.common.collect.Iterables.*;
-import static com.google.common.collect.Lists.*;
-import static springfox.documentation.builders.Parameters.*;
-
 @Component
 @Order(Ordered.HIGHEST_PRECEDENCE + 10)
-public class OperationParameterRequestConditionReader implements OperationBuilderPlugin {
-
-  private final TypeResolver resolver;
+public class OperationParameterRequestConditionReader extends AbstractOperationParameterRequestConditionReader {
 
   @Autowired
   public OperationParameterRequestConditionReader(TypeResolver resolver) {
-    this.resolver = resolver;
+    super(resolver);
   }
 
   @Override
   public void apply(OperationContext context) {
     ParamsRequestCondition paramsCondition = context.getRequestMappingInfo().getParamsCondition();
-    List<Parameter> parameters = newArrayList();
-    for (NameValueExpression<String> expression : paramsCondition.getExpressions()) {
-      if (skipParameter(parameters, expression)) {
-        continue;
-      }
-
-      String paramValue = expression.getValue();
-      AllowableListValues allowableValues = null;
-      if (!isNullOrEmpty(paramValue)) {
-        allowableValues = new AllowableListValues(newArrayList(paramValue), "string");
-      }
-      Parameter parameter = new ParameterBuilder()
-              .name(expression.getName())
-              .description(null)
-              .defaultValue(paramValue)
-              .required(true)
-              .allowMultiple(false)
-              .type(resolver.resolve(String.class))
-              .modelRef(new ModelRef("string"))
-              .allowableValues(allowableValues)
-              .parameterType("query")
-              .build();
-      parameters.add(parameter);
-    }
+    List<Parameter> parameters = getParameters(paramsCondition.getExpressions(), "query");
     context.operationBuilder().parameters(parameters);
-  }
-
-  private boolean skipParameter(List<Parameter> parameters, NameValueExpression<String> expression) {
-    return expression.isNegated() || parameterHandled(parameters, expression);
-  }
-
-  private boolean parameterHandled(List<Parameter> parameters, NameValueExpression<String> expression) {
-    return any(parameters, withName(expression.getName()));
-  }
-
-  @Override
-  public boolean supports(DocumentationType delimiter) {
-    return true;
   }
 }

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/mixins/RequestMappingSupport.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/mixins/RequestMappingSupport.groovy
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2015 the original author or authors.
+ *  Copyright 2016 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ package springfox.documentation.spring.web.mixins
 import org.springframework.web.bind.annotation.RequestMethod
 import org.springframework.web.method.HandlerMethod
 import org.springframework.web.servlet.mvc.condition.ConsumesRequestCondition
+import org.springframework.web.servlet.mvc.condition.HeadersRequestCondition
 import org.springframework.web.servlet.mvc.condition.ParamsRequestCondition
 import org.springframework.web.servlet.mvc.condition.PatternsRequestCondition
 import org.springframework.web.servlet.mvc.condition.ProducesRequestCondition
@@ -46,10 +47,11 @@ class RequestMappingSupport {
     ProducesRequestCondition producesRequestCondition = overrides['producesRequestCondition'] ?: producesRequestCondition()
     PatternsRequestCondition patternsRequestCondition = overrides['patternsRequestCondition'] ?: singlePatternRequestCondition
     ParamsRequestCondition paramsRequestCondition = overrides["paramsCondition"] ?: paramsRequestCondition()
+    HeadersRequestCondition headersRequestCondition = overrides["headersCondition"] ?: headersRequestCondition()
     RequestMethodsRequestCondition requestMethodsRequestCondition =
             overrides['requestMethodsRequestCondition'] ?: requestMethodsRequestCondition(RequestMethod.values())
 
-    new RequestMappingInfo(patternsRequestCondition, requestMethodsRequestCondition, paramsRequestCondition, null, consumesRequestCondition, producesRequestCondition, null)
+    new RequestMappingInfo(patternsRequestCondition, requestMethodsRequestCondition, paramsRequestCondition, headersRequestCondition, consumesRequestCondition, producesRequestCondition, null)
   }
 
   HandlerMethod dummyHandlerMethod(String methodName = "dummyMethod", Class<?>... parameterTypes = null) {
@@ -122,6 +124,10 @@ class RequestMappingSupport {
 
   ParamsRequestCondition paramsRequestCondition(String... params) {
     new ParamsRequestCondition(params)
+  }
+
+  HeadersRequestCondition headersRequestCondition(String... params) {
+    new HeadersRequestCondition(params)
   }
 
   ConsumesRequestCondition consumesRequestCondition(String... conditions) {

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/operation/OperationParameterHeadersConditionReaderSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/operation/OperationParameterHeadersConditionReaderSpec.groovy
@@ -1,0 +1,106 @@
+/*
+ *
+ *  Copyright 2016 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+
+package springfox.documentation.spring.web.readers.operation
+
+import com.fasterxml.classmate.TypeResolver
+import org.springframework.web.bind.annotation.RequestMethod
+import org.springframework.web.method.HandlerMethod
+import org.springframework.web.servlet.mvc.condition.HeadersRequestCondition
+import org.springframework.web.servlet.mvc.condition.ParamsRequestCondition
+import org.springframework.web.servlet.mvc.method.RequestMappingInfo
+import springfox.documentation.builders.OperationBuilder
+import springfox.documentation.service.Parameter
+import springfox.documentation.spi.DocumentationType
+import springfox.documentation.spi.service.contexts.OperationContext
+import springfox.documentation.spring.web.mixins.RequestMappingSupport
+import springfox.documentation.spring.web.plugins.DocumentationContextSpec
+
+@Mixin([RequestMappingSupport])
+class OperationParameterHeadersConditionReaderSpec extends DocumentationContextSpec {
+
+  OperationParameterHeadersConditionReader sut = new OperationParameterHeadersConditionReader(new TypeResolver())
+  def "Should read a parameter given a parameter request condition"() {
+    given:
+      HandlerMethod handlerMethod = dummyHandlerMethod('methodWithParameterRequestCondition')
+      HeadersRequestCondition headersCondition = new HeadersRequestCondition("test=testValue")
+      RequestMappingInfo requestMappingInfo = requestMappingInfo('/parameter-conditions',
+              ["headersCondition": headersCondition])
+      OperationContext operationContext = new OperationContext(new OperationBuilder(new CachingOperationNameGenerator()),
+              RequestMethod.GET, handlerMethod, 0, requestMappingInfo,
+              context(), "")
+    when:
+      sut.apply(operationContext)
+      def operation = operationContext.operationBuilder().build()
+
+    then:
+      sut.supports(DocumentationType.SPRING_WEB)
+      sut.supports(DocumentationType.SWAGGER_12)
+      sut.supports(DocumentationType.SWAGGER_2)
+    and:
+      Parameter parameter = operation.parameters[0]
+      assert parameter."$property" == expectedValue
+
+    where:
+      property        | expectedValue
+      'name'          | 'test'
+      'defaultValue'  | 'testValue'
+      'description'   | null
+      'required'      | true
+      'allowMultiple' | false
+      'paramType'     | "header"
+
+  }
+
+  def "Should ignore a negated parameter in a parameter request condition"() {
+    given:
+      HandlerMethod handlerMethod = dummyHandlerMethod('methodWithParameterRequestCondition')
+      HeadersRequestCondition headersCondition = new HeadersRequestCondition("!test")
+      RequestMappingInfo requestMappingInfo = requestMappingInfo('/parameter-conditions',
+              ["headersCondition": headersCondition])
+      OperationContext operationContext = new OperationContext(new OperationBuilder(new CachingOperationNameGenerator()),
+              RequestMethod.GET, handlerMethod, 0, requestMappingInfo,
+              context(), "")
+
+    when:
+      sut.apply(operationContext)
+      def operation = operationContext.operationBuilder().build()
+
+    then:
+      0 == operation.parameters.size()
+
+  }
+
+  def "Should ignore a parameter request condition expression that is already present in the parameters"() {
+    given:
+      HandlerMethod handlerMethod = dummyHandlerMethod('methodWithParameterRequestCondition')
+      HeadersRequestCondition paramCondition = new HeadersRequestCondition("test=testValue", "test=3")
+      OperationContext operationContext = new OperationContext(new OperationBuilder(new CachingOperationNameGenerator()),
+              RequestMethod.GET, handlerMethod, 0,  requestMappingInfo('/parameter-conditions',
+                      ["headersCondition": paramCondition]),
+              context(), "/anyPath")
+
+    when:
+      sut.apply(operationContext)
+
+    then:
+      1 == operationContext.operationBuilder().build().parameters.size()
+
+  }
+}

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/operation/OperationParameterRequestConditionReaderSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/operation/OperationParameterRequestConditionReaderSpec.groovy
@@ -89,16 +89,14 @@ class OperationParameterRequestConditionReaderSpec extends DocumentationContextS
   def "Should ignore a parameter request condition expression that is already present in the parameters"() {
     given:
       HandlerMethod handlerMethod = dummyHandlerMethod('methodWithParameterRequestCondition')
-      ParamsRequestCondition paramCondition = new ParamsRequestCondition("test=3")
+      ParamsRequestCondition paramCondition = new ParamsRequestCondition("test=testValue", "test=3")
       OperationContext operationContext = new OperationContext(new OperationBuilder(new CachingOperationNameGenerator()),
               RequestMethod.GET, handlerMethod, 0,  requestMappingInfo('/parameter-conditions',
                       ["paramsCondition": paramCondition]),
               context(), "/anyPath")
 
     when:
-      OperationParameterRequestConditionReader operationParameterReader = 
-              new OperationParameterRequestConditionReader(new TypeResolver())
-      operationParameterReader.apply(operationContext)
+      sut.apply(operationContext)
 
     then:
       1 == operationContext.operationBuilder().build().parameters.size()

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/operation/OperationParameterRequestConditionReaderSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/operation/OperationParameterRequestConditionReaderSpec.groovy
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2015 the original author or authors.
+ *  Copyright 2016 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/operation/OperationParameterRequestConditionReaderSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/operation/OperationParameterRequestConditionReaderSpec.groovy
@@ -59,6 +59,7 @@ class OperationParameterRequestConditionReaderSpec extends DocumentationContextS
     where:
       property        | expectedValue
       'name'          | 'test'
+      'defaultValue'  | 'testValue'
       'description'   | null
       'required'      | true
       'allowMultiple' | false

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/operation/OperationParameterRequestConditionReaderSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/operation/OperationParameterRequestConditionReaderSpec.groovy
@@ -17,7 +17,7 @@
  *
  */
 
-package springfox.documentation.spring.web.readers
+package springfox.documentation.spring.web.readers.operation
 
 import com.fasterxml.classmate.TypeResolver
 import org.springframework.web.bind.annotation.RequestMethod
@@ -30,8 +30,6 @@ import springfox.documentation.spi.DocumentationType
 import springfox.documentation.spi.service.contexts.OperationContext
 import springfox.documentation.spring.web.mixins.RequestMappingSupport
 import springfox.documentation.spring.web.plugins.DocumentationContextSpec
-import springfox.documentation.spring.web.readers.operation.CachingOperationNameGenerator
-import springfox.documentation.spring.web.readers.operation.OperationParameterRequestConditionReader
 
 @Mixin([RequestMappingSupport])
 class OperationParameterRequestConditionReaderSpec extends DocumentationContextSpec {


### PR DESCRIPTION
Added documentation of headers from the `headers` attribute of `@RequestMapping` annotations
Fix for issue #1287 