### PR TITLE
Support for JSR-303: @Pattern annotation #1296

### DIFF
--- a/springfox-bean-validators/src/main/java/springfox/bean/validators/configuration/BeanValidatorPluginsConfiguration.java
+++ b/springfox-bean-validators/src/main/java/springfox/bean/validators/configuration/BeanValidatorPluginsConfiguration.java
@@ -22,6 +22,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import springfox.bean.validators.plugins.MinMaxAnnotationPlugin;
 import springfox.bean.validators.plugins.NotNullAnnotationPlugin;
+import springfox.bean.validators.plugins.PatternAnnotationPlugin;
 import springfox.bean.validators.plugins.SizeAnnotationPlugin;
 
 @Configuration
@@ -39,5 +40,10 @@ public class BeanValidatorPluginsConfiguration {
   @Bean
   public NotNullAnnotationPlugin notNullPlugin() {
     return new NotNullAnnotationPlugin();
+  }
+
+  @Bean
+  public PatternAnnotationPlugin patternPlugin() {
+    return new PatternAnnotationPlugin();
   }
 }

--- a/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/PatternAnnotationPlugin.java
+++ b/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/PatternAnnotationPlugin.java
@@ -1,0 +1,71 @@
+/*
+ *
+ *  Copyright 2015 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package springfox.bean.validators.plugins;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import springfox.documentation.service.AllowablePatternValues;
+import springfox.documentation.service.AllowableValues;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.schema.ModelPropertyBuilderPlugin;
+import springfox.documentation.spi.schema.contexts.ModelPropertyContext;
+
+import javax.validation.constraints.Pattern;
+
+import static springfox.bean.validators.plugins.BeanValidators.*;
+
+/**
+ * Created by Igor Sokolov on 5/15/16.
+ */
+@Component
+@Order(BeanValidators.BEAN_VALIDATOR_PLUGIN_ORDER)
+public class PatternAnnotationPlugin implements ModelPropertyBuilderPlugin {
+    private static final Logger LOG = LoggerFactory.getLogger(PatternAnnotationPlugin.class);
+
+    @Override
+    public boolean supports(DocumentationType delimiter) {
+        // we simply support all documentationTypes!
+        return true;
+    }
+
+    @Override
+    public void apply(ModelPropertyContext context) {
+        Optional<Pattern> pattern = extractAnnotation(context);
+
+        if (pattern.isPresent()) {
+            context.getBuilder().allowableValues(createAllowableValuesFromPattern(pattern.get()));
+        }
+    }
+
+    private AllowableValues createAllowableValuesFromPattern(Pattern pattern) {
+        LOG.debug("@Size detected: adding MinLength/MaxLength to field");
+        return new AllowablePatternValues(pattern.regexp());
+    }
+
+
+    @VisibleForTesting
+    private Optional<Pattern> extractAnnotation(ModelPropertyContext context) {
+        return validatorFromBean(context, Pattern.class)
+                .or(validatorFromField(context, Pattern.class));
+    }
+}

--- a/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/PatternAnnotationPlugin.java
+++ b/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/PatternAnnotationPlugin.java
@@ -24,6 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
+import springfox.bean.validators.configuration.BeanValidatorPluginsConfiguration;
 import springfox.documentation.service.AllowablePatternValues;
 import springfox.documentation.service.AllowableValues;
 import springfox.documentation.spi.DocumentationType;
@@ -35,10 +36,18 @@ import javax.validation.constraints.Pattern;
 import static springfox.bean.validators.plugins.BeanValidators.*;
 
 /**
- * Created by Igor Sokolov on 5/15/16.
+ * Plugin to handle {@link Pattern} annotation.
+ * <p>
+ * If there are both annotations {@link Pattern} and {@link Pattern} assigned to one field or
+ * getter/setter then the current handler will <b>always</b>
+ * the result of {@link springfox.bean.validators.plugins.SizeAnnotationPlugin}.
+ * This is implemented through order annotation. It has +1 priority than all other plugins defined in
+ * {@link BeanValidatorPluginsConfiguration}. The behavior above can be examined in groovy unit test
+ * {@link springfox.bean.validators.plugins.PatternAnnotationPluginSpec}
+ *
  */
 @Component
-@Order(BeanValidators.BEAN_VALIDATOR_PLUGIN_ORDER)
+@Order(BeanValidators.BEAN_VALIDATOR_PLUGIN_ORDER + 1)
 public class PatternAnnotationPlugin implements ModelPropertyBuilderPlugin {
     private static final Logger LOG = LoggerFactory.getLogger(PatternAnnotationPlugin.class);
 

--- a/springfox-bean-validators/src/test/groovy/springfox/bean/validators/plugins/PatternAnnotationPluginSpec.groovy
+++ b/springfox-bean-validators/src/test/groovy/springfox/bean/validators/plugins/PatternAnnotationPluginSpec.groovy
@@ -1,0 +1,65 @@
+/*
+ *
+ *  Copyright 2015 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+
+package springfox.bean.validators.plugins
+
+import com.fasterxml.classmate.TypeResolver
+import spock.lang.Specification
+import spock.lang.Unroll
+import springfox.bean.validators.plugins.models.PatternTestModel
+import springfox.documentation.builders.ModelPropertyBuilder
+import springfox.documentation.service.AllowablePatternValues
+import springfox.documentation.spi.DocumentationType
+import springfox.documentation.spi.schema.contexts.ModelPropertyContext
+
+/**
+ * Created by igorsokolov on 5/15/16.
+ */
+class PatternAnnotationPluginSpec extends Specification {
+    def "Always supported" () {
+        expect:
+        new PatternAnnotationPlugin().supports(types)
+        where:
+        types << [DocumentationType.SPRING_WEB, DocumentationType.SWAGGER_2, DocumentationType.SWAGGER_12]
+    }
+
+    @Unroll
+    def "@Pattern annotations are reflected in the model #propertyName that are AnnotatedElements"()  {
+        given:
+            def sut = new PatternAnnotationPlugin()
+            def element = PatternTestModel.getDeclaredField(propertyName)
+            def context = new ModelPropertyContext(
+                    new ModelPropertyBuilder(),
+                    element,
+                    new TypeResolver(),
+                    DocumentationType.SWAGGER_12)
+        when:
+            sut.apply(context)
+            def property = context.builder.build()
+        then:
+            def range = property.allowableValues as AllowablePatternValues
+            range?.regexp == expectedPattern
+        where:
+            propertyName      | expectedPattern
+            "noAnnotation"    | null
+            "currencyCode"    | "^[A-Z]{3}\$"
+            "countryCode"     | "^[A-Z]{2}\$"
+    }
+
+}

--- a/springfox-bean-validators/src/test/groovy/springfox/bean/validators/plugins/PatternAnnotationPluginSpec.groovy
+++ b/springfox-bean-validators/src/test/groovy/springfox/bean/validators/plugins/PatternAnnotationPluginSpec.groovy
@@ -56,10 +56,11 @@ class PatternAnnotationPluginSpec extends Specification {
             def range = property.allowableValues as AllowablePatternValues
             range?.regexp == expectedPattern
         where:
-            propertyName      | expectedPattern
-            "noAnnotation"    | null
-            "currencyCode"    | "^[A-Z]{3}\$"
-            "countryCode"     | "^[A-Z]{2}\$"
+            propertyName                        | expectedPattern
+            "noAnnotation"                      | null
+            "currencyCode"                      | "^[A-Z]{3}\$"
+            "firstSizeThenPatternAnnotation"    | "^[A-Z]{2}\$"
+            "firstPatternThenSizeAnnotation"    | "^[A-Z]{2}\$"
     }
 
 }

--- a/springfox-bean-validators/src/test/java/springfox/bean/validators/plugins/models/PatternTestModel.java
+++ b/springfox-bean-validators/src/test/java/springfox/bean/validators/plugins/models/PatternTestModel.java
@@ -1,0 +1,37 @@
+/*
+ *
+ *  Copyright 2015 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+
+package springfox.bean.validators.plugins.models;
+
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+
+/**
+ * Created by igorsokolov on 5/15/16.
+ */
+public class PatternTestModel {
+    private String noAnnotation;
+
+    @Pattern(regexp = "^[A-Z]{3}$")
+    private String currencyCode; // three letter iso code
+
+    @Size(min = 1, max = 4)
+    @Pattern(regexp = "^[A-Z]{2}$")
+    private String countryCode; // two letter iso code
+}

--- a/springfox-bean-validators/src/test/java/springfox/bean/validators/plugins/models/PatternTestModel.java
+++ b/springfox-bean-validators/src/test/java/springfox/bean/validators/plugins/models/PatternTestModel.java
@@ -28,10 +28,15 @@ import javax.validation.constraints.Size;
 public class PatternTestModel {
     private String noAnnotation;
 
-    @Pattern(regexp = "^[A-Z]{3}$")
-    private String currencyCode; // three letter iso code
+    @Pattern(regexp = "^[A-Z]{3}$") // three letter iso code
+    private String currencyCode;
 
     @Size(min = 1, max = 4)
-    @Pattern(regexp = "^[A-Z]{2}$")
-    private String countryCode; // two letter iso code
+    @Pattern(regexp = "^[A-Z]{2}$") // two letter iso code
+    private String firstSizeThenPatternAnnotation;
+
+    @Pattern(regexp = "^[A-Z]{2}$") // two letter iso code
+    @Size(min = 2, max = 2)
+    private String firstPatternThenSizeAnnotation;
+
 }

--- a/springfox-core/src/main/java/springfox/documentation/service/AllowablePatternValues.java
+++ b/springfox-core/src/main/java/springfox/documentation/service/AllowablePatternValues.java
@@ -1,0 +1,35 @@
+/*
+ *
+ *  Copyright 2015 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+
+package springfox.documentation.service;
+
+/**
+ * Created by igorsokolov on 5/15/16.
+ */
+public class AllowablePatternValues implements AllowableValues {
+    private final String regexp;
+
+    public AllowablePatternValues(String regexp) {
+        this.regexp = regexp;
+    }
+
+    public String getRegexp() {
+        return regexp;
+    }
+}

--- a/springfox-core/src/test/groovy/springfox/documentation/service/model/AllowablePatternValuesSpec.groovy
+++ b/springfox-core/src/test/groovy/springfox/documentation/service/model/AllowablePatternValuesSpec.groovy
@@ -1,0 +1,35 @@
+/*
+ *
+ *  Copyright 2015 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+
+package springfox.documentation.service.model
+
+import spock.lang.Specification
+import springfox.documentation.service.AllowablePatternValues
+
+/**
+ * Created by igorsokolov on 5/16/16.
+ */
+class AllowablePatternValuesSpec extends Specification {
+    def "Bean properties test" () {
+        given:
+            def sut = new AllowablePatternValues("^[+-]?[0-9]{1,3}(?:,?[0-9]{3})*\\.[0-9]{2}\$")
+        expect:
+            sut.regexp == "^[+-]?[0-9]{1,3}(?:,?[0-9]{3})*\\.[0-9]{2}\$"
+    }
+}

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/plugins/DocketSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/plugins/DocketSpec.groovy
@@ -148,8 +148,8 @@ class DocketSpec extends DocumentationContextSpec {
 
     where:
       method                    | args                               | expectedSize
-      'genericModelSubstitutes' | [ResponseEntity.class, List.class] | 8
-      'directModelSubstitute'   | [LocalDate.class, Date.class]      | 7
+      'genericModelSubstitutes' | [ResponseEntity.class, List.class] | 9
+      'directModelSubstitute'   | [LocalDate.class, Date.class]      | 8
   }
 
 

--- a/springfox-swagger1/src/test/groovy/springfox/documentation/swagger1/integration/DocketSpec.groovy
+++ b/springfox-swagger1/src/test/groovy/springfox/documentation/swagger1/integration/DocketSpec.groovy
@@ -142,8 +142,8 @@ class DocketSpec extends DocumentationContextSpec {
 
     where:
       method                    | args                               | expectedSize
-      'genericModelSubstitutes' | [ResponseEntity.class, List.class] | 10
-      'directModelSubstitute'   | [LocalDate.class, Date.class]      | 9
+      'genericModelSubstitutes' | [ResponseEntity.class, List.class] | 11
+      'directModelSubstitute'   | [LocalDate.class, Date.class]      | 10
   }
 
   def "Basic property checks"() {

--- a/springfox-swagger2/src/main/java/springfox/documentation/swagger2/mappers/ModelMapper.java
+++ b/springfox-swagger2/src/main/java/springfox/documentation/swagger2/mappers/ModelMapper.java
@@ -37,6 +37,7 @@ import io.swagger.models.properties.StringProperty;
 import org.mapstruct.Mapper;
 import springfox.documentation.schema.ModelProperty;
 import springfox.documentation.schema.ModelReference;
+import springfox.documentation.service.AllowablePatternValues;
 import springfox.documentation.service.AllowableRangeValues;
 import springfox.documentation.service.AllowableValues;
 import springfox.documentation.service.ApiListing;
@@ -156,7 +157,10 @@ public abstract class ModelMapper {
 
     if (property instanceof StringProperty) {
       AllowableValues allowableValues = source.getAllowableValues();
-      if (allowableValues instanceof AllowableRangeValues) {
+      if (allowableValues instanceof AllowablePatternValues) {
+        AllowablePatternValues pattern = (AllowablePatternValues) allowableValues;
+        ((StringProperty) property).pattern(pattern.getRegexp());
+      } else if (allowableValues instanceof AllowableRangeValues) {
         AllowableRangeValues range = (AllowableRangeValues) allowableValues;
         ((StringProperty) property).maxLength(Integer.valueOf(range.getMax()));
         ((StringProperty) property).minLength(Integer.valueOf(range.getMin()));


### PR DESCRIPTION
#### What's this PR do/fix?
It introduces a basic support of `@Pattern` annotation. It was discussed in the issue: https://github.com/springfox/springfox/issues/1296
#### Are there unit tests? If not how should this be manually tested?
Yes,  added unit tests similar to already existed for `SizeAnnotationPlugin`. Additionally I tested it locally in project that uses Springfox for document generation. The result YAML file contained  pattern ("pattern":"^[A-Z]{3}$"}). It was also rendered on UI but it was not the perfect, I guess due to overlapping in hint sections, one from first field (double) and the second from message field with pattern restriction. 
#### Any background context you want to provide?
I didn't performed any validation of provided in `@Pattern` annotation value, the value just extracted and transferred to Swagger Model object. Ideally it should be validated and also checked that this is not simple a valid RegExp but valid as well for JavaScript.  
#### What are the relevant issues?
https://github.com/springfox/springfox/issues/1296
