### PR TITLE
#1296: Adding Pattern annotation support

### DIFF
--- a/springfox-bean-validators/src/main/java/springfox/bean/validators/configuration/BeanValidatorPluginsConfiguration.java
+++ b/springfox-bean-validators/src/main/java/springfox/bean/validators/configuration/BeanValidatorPluginsConfiguration.java
@@ -22,6 +22,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import springfox.bean.validators.plugins.MinMaxAnnotationPlugin;
 import springfox.bean.validators.plugins.NotNullAnnotationPlugin;
+import springfox.bean.validators.plugins.PatternAnnotationPlugin;
 import springfox.bean.validators.plugins.SizeAnnotationPlugin;
 
 @Configuration
@@ -39,5 +40,10 @@ public class BeanValidatorPluginsConfiguration {
   @Bean
   public NotNullAnnotationPlugin notNullPlugin() {
     return new NotNullAnnotationPlugin();
+  }
+
+  @Bean
+  public PatternAnnotationPlugin patternPlugin() {
+    return new PatternAnnotationPlugin();
   }
 }

--- a/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/PatternAnnotationPlugin.java
+++ b/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/PatternAnnotationPlugin.java
@@ -1,0 +1,63 @@
+/*
+ *
+ *  Copyright 2015 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package springfox.bean.validators.plugins;
+
+import com.google.common.base.Optional;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.schema.ModelPropertyBuilderPlugin;
+import springfox.documentation.spi.schema.contexts.ModelPropertyContext;
+
+import javax.validation.constraints.Pattern;
+
+import static springfox.bean.validators.plugins.BeanValidators.validatorFromBean;
+import static springfox.bean.validators.plugins.BeanValidators.validatorFromField;
+
+/**
+ * @author : ashutosh
+ *         28/04/2016
+ */
+@Component
+@Order(BeanValidators.BEAN_VALIDATOR_PLUGIN_ORDER)
+public class PatternAnnotationPlugin implements ModelPropertyBuilderPlugin {
+  @Override
+  public void apply(ModelPropertyContext context) {
+    Optional<Pattern> pattern = extractPattern(context);
+    context.getBuilder().pattern(createPatternValueFromAnnotation(pattern));
+  }
+
+  Optional<Pattern> extractPattern(ModelPropertyContext context) {
+    return validatorFromBean(context, Pattern.class)
+        .or(validatorFromField(context, Pattern.class));
+  }
+
+  private String createPatternValueFromAnnotation(Optional<Pattern> pattern) {
+    String patternValue = null;
+    if(pattern.isPresent()){
+      patternValue = pattern.get().regexp();
+    }
+    return patternValue;
+  }
+
+  @Override
+  public boolean supports(DocumentationType delimiter) {
+    return true;
+  }
+}

--- a/springfox-bean-validators/src/test/groovy/springfox/bean/validators/plugins/PatternAndSizePluginSpec.groovy
+++ b/springfox-bean-validators/src/test/groovy/springfox/bean/validators/plugins/PatternAndSizePluginSpec.groovy
@@ -1,3 +1,21 @@
+/*
+ *
+ *  Copyright 2015 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
 package springfox.bean.validators.plugins
 
 import com.fasterxml.classmate.TypeResolver

--- a/springfox-bean-validators/src/test/groovy/springfox/bean/validators/plugins/PatternAndSizePluginSpec.groovy
+++ b/springfox-bean-validators/src/test/groovy/springfox/bean/validators/plugins/PatternAndSizePluginSpec.groovy
@@ -1,0 +1,78 @@
+package springfox.bean.validators.plugins
+
+import com.fasterxml.classmate.TypeResolver
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.type.TypeFactory
+import spock.lang.Specification
+import spock.lang.Unroll
+import springfox.bean.validators.plugins.models.PatternAndSizeTestModel
+import springfox.documentation.builders.ModelPropertyBuilder
+import springfox.documentation.service.AllowableRangeValues
+import springfox.documentation.spi.DocumentationType
+import springfox.documentation.spi.schema.contexts.ModelPropertyContext
+
+/**
+ * @author : ashutosh 
+ * 18/05/2016
+ */
+class PatternAndSizePluginSpec extends Specification{
+
+  @Unroll
+  def "@Pattern annotations are reflected in the model properties that are AnnotatedElements"()  {
+    given:
+    def pat = new PatternAnnotationPlugin()
+    def sat = new SizeAnnotationPlugin()
+    def element = PatternAndSizeTestModel.getDeclaredField(propertyName)
+    def context = new ModelPropertyContext(
+        new ModelPropertyBuilder(),
+        element,
+        new TypeResolver(),
+        DocumentationType.SWAGGER_12)
+    when:
+    sat.apply(context)
+    pat.apply(context)
+    def property = context.builder.build()
+    then:
+    def range = property.allowableValues as AllowableRangeValues
+    range?.max == expectedMax
+    range?.min == expectedMin
+    property.getPattern() == pattern
+    where:
+    propertyName                   | pattern        | expectedMin   | expectedMax
+    "propertyString"               | "[a-zA-Z0-9_]" | "3"           | "5"
+    "getterString"                 | null           | null          | null
+  }
+
+  @Unroll
+  def "@Pattern annotations are reflected in the model properties that are BeanPropertyDefinitions"()  {
+    given:
+    def pat = new PatternAnnotationPlugin()
+    def sat = new SizeAnnotationPlugin()
+    def beanProperty = beanProperty(propertyName)
+    def context = new ModelPropertyContext(
+        new ModelPropertyBuilder(),
+        beanProperty,
+        new TypeResolver(),
+        DocumentationType.SWAGGER_12)
+    when:
+    sat.apply(context)
+    pat.apply(context)
+    def property = context.builder.build()
+    then:
+    property.getPattern() == pattern
+    where:
+    propertyName                   | pattern        | expectedMin   | expectedMax
+    "propertyString"               | "[a-zA-Z0-9_]" | "3"           | "5"
+    "getterString"                 | "[A-Z]"        | "1"           | "4"
+
+  }
+
+  def beanProperty(property) {
+    def mapper = new ObjectMapper()
+    mapper
+        .serializationConfig
+        .introspect(TypeFactory.defaultInstance().constructType(PatternAndSizeTestModel))
+        .findProperties()
+        .find { p -> property.equals(p.name) };
+  }
+}

--- a/springfox-bean-validators/src/test/groovy/springfox/bean/validators/plugins/PatternAnnotationPluginSpec.groovy
+++ b/springfox-bean-validators/src/test/groovy/springfox/bean/validators/plugins/PatternAnnotationPluginSpec.groovy
@@ -1,0 +1,98 @@
+/*
+ *
+ *  Copyright 2015 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package springfox.bean.validators.plugins
+
+import com.fasterxml.classmate.TypeResolver
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.type.TypeFactory
+import spock.lang.Specification
+import spock.lang.Unroll
+import springfox.bean.validators.plugins.models.PatternTestModel
+import springfox.documentation.builders.ModelPropertyBuilder
+import springfox.documentation.spi.DocumentationType
+import springfox.documentation.spi.schema.contexts.ModelPropertyContext
+
+/**
+ * @author : ashutosh 
+ * 29/04/2016
+ */
+class PatternAnnotationPluginSpec extends Specification{
+
+  def "Always supported" () {
+    expect:
+    new PatternAnnotationPlugin().supports(types)
+    where:
+    types << [DocumentationType.SPRING_WEB, DocumentationType.SWAGGER_2, DocumentationType.SWAGGER_12]
+  }
+
+  @Unroll
+  def "@Pattern annotations are reflected in the model properties that are AnnotatedElements"()  {
+    given:
+    def sut = new PatternAnnotationPlugin()
+    def element = PatternTestModel.getDeclaredField(propertyName)
+    def context = new ModelPropertyContext(
+        new ModelPropertyBuilder(),
+        element,
+        new TypeResolver(),
+        DocumentationType.SWAGGER_12)
+    when:
+    sut.apply(context)
+    def property = context.builder.build()
+    then:
+    property.getPattern() == pattern
+    where:
+    propertyName                  | pattern
+    "patternString"               | "[a-zA-Z0-9_]"
+    "getterPatternString"         | null
+    "noPatternString"             | null
+
+  }
+
+  @Unroll
+  def "@Pattern annotations are reflected in the model properties that are BeanPropertyDefinitions"()  {
+    given:
+    def sut = new PatternAnnotationPlugin()
+    def beanProperty = beanProperty(propertyName)
+    def context = new ModelPropertyContext(
+        new ModelPropertyBuilder(),
+        beanProperty,
+        new TypeResolver(),
+        DocumentationType.SWAGGER_12)
+    when:
+    sut.apply(context)
+    def property = context.builder.build()
+    then:
+    property.getPattern() == pattern
+    where:
+    propertyName                  | pattern
+    "patternString"               | "[a-zA-Z0-9_]"
+    "getterPatternString"         | "[A-Z]"
+    "noPatternString"             | null
+
+  }
+
+  def beanProperty(property) {
+    def mapper = new ObjectMapper()
+    mapper
+        .serializationConfig
+        .introspect(TypeFactory.defaultInstance().constructType(PatternTestModel))
+        .findProperties()
+        .find { p -> property.equals(p.name) };
+  }
+}

--- a/springfox-bean-validators/src/test/java/springfox/bean/validators/plugins/models/PatternAndSizeTestModel.java
+++ b/springfox-bean-validators/src/test/java/springfox/bean/validators/plugins/models/PatternAndSizeTestModel.java
@@ -1,0 +1,27 @@
+package springfox.bean.validators.plugins.models;
+
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+
+/**
+ * @author : ashutosh
+ *         18/05/2016
+ */
+public class PatternAndSizeTestModel {
+
+  @Size(min = 3, max = 5)
+  @Pattern(regexp = "[a-zA-Z0-9_]")
+  private String propertyString;
+
+  private String getterString;
+
+  public String getPropertyString() {
+    return propertyString;
+  }
+
+  @Size(min = 1, max = 4)
+  @Pattern(regexp = "[A-Z]")
+  public String getGetterString() {
+    return getterString;
+  }
+}

--- a/springfox-bean-validators/src/test/java/springfox/bean/validators/plugins/models/PatternAndSizeTestModel.java
+++ b/springfox-bean-validators/src/test/java/springfox/bean/validators/plugins/models/PatternAndSizeTestModel.java
@@ -1,3 +1,21 @@
+/*
+ *
+ *  Copyright 2015 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
 package springfox.bean.validators.plugins.models;
 
 import javax.validation.constraints.Pattern;

--- a/springfox-bean-validators/src/test/java/springfox/bean/validators/plugins/models/PatternTestModel.java
+++ b/springfox-bean-validators/src/test/java/springfox/bean/validators/plugins/models/PatternTestModel.java
@@ -1,0 +1,47 @@
+/*
+ *
+ *  Copyright 2015 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package springfox.bean.validators.plugins.models;
+
+import javax.validation.constraints.Pattern;
+
+/**
+ * @author : ashutosh 
+ * 29/04/2016
+ */
+public class PatternTestModel {
+  @Pattern(regexp = "[a-zA-Z0-9_]")
+  private String patternString;
+
+  private String noPatternString;
+
+  private String getterPatternString;
+
+  public String getPatternString() {
+    return patternString;
+  }
+
+  public String getNoPatternString() {
+    return noPatternString;
+  }
+
+  @Pattern(regexp = "[A-Z]")
+  public String getGetterPatternString() {
+    return getterPatternString;
+  }
+}

--- a/springfox-core/src/main/java/springfox/documentation/builders/ModelPropertyBuilder.java
+++ b/springfox-core/src/main/java/springfox/documentation/builders/ModelPropertyBuilder.java
@@ -36,6 +36,7 @@ public class ModelPropertyBuilder {
   private String name;
   private boolean isHidden;
   private String example;
+  private String pattern;
 
   public ModelPropertyBuilder name(String name) {
     this.name = defaultIfAbsent(name, this.name);
@@ -87,8 +88,13 @@ public class ModelPropertyBuilder {
     return this;
   }
 
+  public ModelPropertyBuilder pattern(String pattern) {
+    this.pattern = defaultIfAbsent(pattern, this.pattern);
+    return this;
+  }
+
   public ModelProperty build() {
     return new ModelProperty(name, type, qualifiedType, position, required, isHidden, readOnly, description,
-        allowableValues, example);
+        allowableValues, example, pattern);
   }
 }

--- a/springfox-core/src/main/java/springfox/documentation/schema/ModelProperty.java
+++ b/springfox-core/src/main/java/springfox/documentation/schema/ModelProperty.java
@@ -35,6 +35,7 @@ public class ModelProperty {
   private final AllowableValues allowableValues;
   private ModelReference modelRef;
   private final String example;
+  private final String pattern;
 
   public ModelProperty(
       String name,
@@ -46,7 +47,8 @@ public class ModelProperty {
       Boolean readOnly,
       String description,
       AllowableValues allowableValues,
-      String example) {
+      String example,
+      String pattern) {
 
     this.name = name;
     this.type = type;
@@ -58,6 +60,7 @@ public class ModelProperty {
     this.description = description;
     this.allowableValues = allowableValues;
     this.example = example;
+    this.pattern = pattern;
   }
 
   public String getName() {
@@ -107,5 +110,9 @@ public class ModelProperty {
 
   public String getExample() {
     return example;
+  }
+
+  public String getPattern() {
+    return pattern;
   }
 }

--- a/springfox-swagger2/src/main/java/springfox/documentation/swagger2/mappers/ModelMapper.java
+++ b/springfox-swagger2/src/main/java/springfox/documentation/swagger2/mappers/ModelMapper.java
@@ -161,6 +161,9 @@ public abstract class ModelMapper {
         ((StringProperty) property).maxLength(Integer.valueOf(range.getMax()));
         ((StringProperty) property).minLength(Integer.valueOf(range.getMin()));
       }
+      if(source.getPattern() != null) {
+        ((StringProperty) property).setPattern(source.getPattern());
+      }
     }
 
     if (property != null) {

--- a/springfox-swagger2/src/test/groovy/springfox/documentation/swagger2/mappers/ModelMapperSpec.groovy
+++ b/springfox-swagger2/src/test/groovy/springfox/documentation/swagger2/mappers/ModelMapperSpec.groovy
@@ -299,6 +299,7 @@ class ModelMapperSpec extends SchemaSpecification {
         false,
         '',
         null,
+        '',
         '').with {
       it.updateModelRef({ rt -> new ModelRef(simpleQualifiedTypeName(stringProperty)) })
       it


### PR DESCRIPTION
#### What's this PR do/fix?
Provide support for @Pattern annotation of JSR-303. #1296
#### Are there unit tests? If not how should this be manually tested?
There are new Unit tests added for Pattern tests, Similar to SizeAnnotation plugin.
#### Any background context you want to provide?
Some changes had to be made in core module. ModelPropertyBuilder, ModelProperty from springfox-core and ModelMapper from springfox-swagger2 and their tests had to be changed.
#### What are the relevant issues?
#1296 and #1314 
