### PR TITLE
Complex type support by @ModelAttribute

### DIFF
--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/parameter/ModelAttributeParameterExpander.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/parameter/ModelAttributeParameterExpander.java
@@ -221,7 +221,7 @@ public class ModelAttributeParameterExpander {
     ResolvedType alternativeType = alternateTypeProvider.alternateFor(resolvedType);
     Class<?> erasedType = alternativeType.getErasedType();
     if (type != erasedType) {
-      LOG.debug("Found alternative type [{}] for field: [{}-{}]", erasedType, field);
+      LOG.debug("Found alternative type [{}] for field: [{}-{}]", erasedType, field, type);
     }
     return erasedType;
   }

--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/parameter/ModelAttributeParameterExpander.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/parameter/ModelAttributeParameterExpander.java
@@ -188,9 +188,11 @@ public class ModelAttributeParameterExpander {
   }
 
   private String nestedParentName(String parentName, Field field) {
-	String name = field.getName();
-	if (isCollection(field.getType())) name += "[#ind]";
-	
+    String name = field.getName();
+    if (isCollection(field.getType())) {
+        name += "[#ind]";
+    }
+    
     if (isNullOrEmpty(parentName)) {
       return name;
     }
@@ -203,18 +205,18 @@ public class ModelAttributeParameterExpander {
     
     if (isContainerType(resolvedType)) {
         try {
-    	    if (type.isArray()) {
-    	        resolvedType = resolver.arrayType(type.getComponentType());
-    	    } else {
-    	        ParameterizedType parameterizedType = (ParameterizedType) field.getGenericType();
-    	        Optional<Type> itemClazz = FluentIterable.from(newArrayList(parameterizedType.getActualTypeArguments())).first();
-    	          if (itemClazz.isPresent()) {
-    	        	  resolvedType = resolver.resolve(type, itemClazz.get());
-    	          }
-    	        }
-    	      } catch (Exception e) {
-    	    	  LOG.warn(String.format("Failed to get generic type of field (%s)", field.getName()), e);
-    	      }
+            if (type.isArray()) {
+                resolvedType = resolver.arrayType(type.getComponentType());
+            } else {
+                ParameterizedType parameterizedType = (ParameterizedType) field.getGenericType();
+                Optional<Type> itemClazz = FluentIterable.from(newArrayList(parameterizedType.getActualTypeArguments())).first();
+                  if (itemClazz.isPresent()) {
+                      resolvedType = resolver.resolve(type, itemClazz.get());
+                  }
+                }
+              } catch (Exception e) {
+                  LOG.warn(String.format("Failed to get generic type of field (%s)", field.getName()), e);
+              }
         resolvedType = collectionElementType(resolvedType);
     }
     

--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/parameter/ModelAttributeParameterExpander.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/parameter/ModelAttributeParameterExpander.java
@@ -190,7 +190,7 @@ public class ModelAttributeParameterExpander {
   private String nestedParentName(String parentName, Field field) {
     String name = field.getName();
     if (isCollection(field.getType())) {
-        name += "[#ind]";
+        name += "[0]";
     }
     
     if (isNullOrEmpty(parentName)) {
@@ -209,7 +209,7 @@ public class ModelAttributeParameterExpander {
                 resolvedType = resolver.arrayType(type.getComponentType());
             } else {
                 ParameterizedType parameterizedType = (ParameterizedType) field.getGenericType();
-                Optional<Type> itemClazz = FluentIterable.from(newArrayList(parameterizedType.getActualTypeArguments())).first();
+                Optional<Type> itemClazz = from(newArrayList(parameterizedType.getActualTypeArguments())).first();
                   if (itemClazz.isPresent()) {
                       resolvedType = resolver.resolve(type, itemClazz.get());
                   }

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/parameter/ModelAttributeParameterExpanderSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/parameter/ModelAttributeParameterExpanderSpec.groovy
@@ -73,21 +73,21 @@ class ModelAttributeParameterExpanderSpec extends DocumentationContextSpec {
   }
   
   def "should expand complex types"() {
-      when:
-        sut.expand("", ModelAttributeComplexTypeExample, parameters, context());
-      then:
-        parameters.size() == 11
-        parameters.find { it.name == 'stringProp' }
-        parameters.find { it.name == 'intProp' }
-        parameters.find { it.name == 'listProp' }
-        parameters.find { it.name == 'arrayProp' }
-        parameters.find { it.name == 'complexProp.name' }
-        parameters.find { it.name == 'fancyPets[#ind].categories[#ind].name' }
-        parameters.find { it.name == 'fancyPets[#ind].id' }
-        parameters.find { it.name == 'fancyPets[#ind].name' }
-        parameters.find { it.name == 'fancyPets[#ind].age' }
-        parameters.find { it.name == 'categories[#ind].name' }
-        parameters.find { it.name == 'modelAttributeProperty' } 
+    when:
+      sut.expand("", ModelAttributeComplexTypeExample, parameters, context());
+    then:
+      parameters.size() == 11
+      parameters.find { it.name == 'stringProp' }
+      parameters.find { it.name == 'intProp' }
+      parameters.find { it.name == 'listProp' }
+      parameters.find { it.name == 'arrayProp' }
+      parameters.find { it.name == 'complexProp.name' }
+      parameters.find { it.name == 'fancyPets[#ind].categories[#ind].name' }
+      parameters.find { it.name == 'fancyPets[#ind].id' }
+      parameters.find { it.name == 'fancyPets[#ind].name' }
+      parameters.find { it.name == 'fancyPets[#ind].age' }
+      parameters.find { it.name == 'categories[#ind].name' }
+      parameters.find { it.name == 'modelAttributeProperty' } 
   }
 
   def "should expand parameters when parent name is not empty"() {

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/parameter/ModelAttributeParameterExpanderSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/parameter/ModelAttributeParameterExpanderSpec.groovy
@@ -83,11 +83,11 @@ class ModelAttributeParameterExpanderSpec extends DocumentationContextSpec {
       parameters.find { it.name == 'listProp' }
       parameters.find { it.name == 'arrayProp' }
       parameters.find { it.name == 'complexProp.name' }
-      parameters.find { it.name == 'fancyPets[#ind].categories[#ind].name' }
-      parameters.find { it.name == 'fancyPets[#ind].id' }
-      parameters.find { it.name == 'fancyPets[#ind].name' }
-      parameters.find { it.name == 'fancyPets[#ind].age' }
-      parameters.find { it.name == 'categories[#ind].name' }
+      parameters.find { it.name == 'fancyPets[0].categories[0].name' }
+      parameters.find { it.name == 'fancyPets[0].id' }
+      parameters.find { it.name == 'fancyPets[0].name' }
+      parameters.find { it.name == 'fancyPets[0].age' }
+      parameters.find { it.name == 'categories[0].name' }
       parameters.find { it.name == 'modelAttributeProperty' } 
   }
 

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/parameter/ModelAttributeParameterExpanderSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/parameter/ModelAttributeParameterExpanderSpec.groovy
@@ -73,21 +73,21 @@ class ModelAttributeParameterExpanderSpec extends DocumentationContextSpec {
   }
   
   def "should expand complex types"() {
-	  when:
-		sut.expand("", ModelAttributeComplexTypeExample, parameters, context());
-	  then:
-		parameters.size() == 11
-		parameters.find { it.name == 'stringProp' }
-		parameters.find { it.name == 'intProp' }
-		parameters.find { it.name == 'listProp' }
-		parameters.find { it.name == 'arrayProp' }
-		parameters.find { it.name == 'complexProp.name' }
-		parameters.find { it.name == 'fancyPets[#ind].categories[#ind].name' }
-		parameters.find { it.name == 'fancyPets[#ind].id' }
-		parameters.find { it.name == 'fancyPets[#ind].name' }
-		parameters.find { it.name == 'fancyPets[#ind].age' }
-		parameters.find { it.name == 'categories[#ind].name' }
-		parameters.find { it.name == 'modelAttributeProperty' }	
+      when:
+        sut.expand("", ModelAttributeComplexTypeExample, parameters, context());
+      then:
+        parameters.size() == 11
+        parameters.find { it.name == 'stringProp' }
+        parameters.find { it.name == 'intProp' }
+        parameters.find { it.name == 'listProp' }
+        parameters.find { it.name == 'arrayProp' }
+        parameters.find { it.name == 'complexProp.name' }
+        parameters.find { it.name == 'fancyPets[#ind].categories[#ind].name' }
+        parameters.find { it.name == 'fancyPets[#ind].id' }
+        parameters.find { it.name == 'fancyPets[#ind].name' }
+        parameters.find { it.name == 'fancyPets[#ind].age' }
+        parameters.find { it.name == 'categories[#ind].name' }
+        parameters.find { it.name == 'modelAttributeProperty' } 
   }
 
   def "should expand parameters when parent name is not empty"() {

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/parameter/ModelAttributeParameterExpanderSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/parameter/ModelAttributeParameterExpanderSpec.groovy
@@ -23,6 +23,7 @@ import com.fasterxml.classmate.TypeResolver
 import org.joda.time.LocalDateTime
 import springfox.documentation.service.Parameter
 import springfox.documentation.spring.web.dummy.models.ModelAttributeExample
+import springfox.documentation.spring.web.dummy.models.ModelAttributeComplexTypeExample
 import springfox.documentation.spring.web.mixins.ServicePluginsSupport
 import springfox.documentation.spring.web.dummy.models.Example
 import springfox.documentation.spring.web.plugins.DocumentationContextSpec

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/parameter/ModelAttributeParameterExpanderSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/parameter/ModelAttributeParameterExpanderSpec.groovy
@@ -71,6 +71,24 @@ class ModelAttributeParameterExpanderSpec extends DocumentationContextSpec {
       parameters.find { it.name == 'arrayProp' }
       parameters.find { it.name == 'complexProp.name' }
   }
+  
+  def "should expand complex types"() {
+	  when:
+		sut.expand("", ModelAttributeComplexTypeExample, parameters, context());
+	  then:
+		parameters.size() == 11
+		parameters.find { it.name == 'stringProp' }
+		parameters.find { it.name == 'intProp' }
+		parameters.find { it.name == 'listProp' }
+		parameters.find { it.name == 'arrayProp' }
+		parameters.find { it.name == 'complexProp.name' }
+		parameters.find { it.name == 'fancyPets[#ind].categories[#ind].name' }
+		parameters.find { it.name == 'fancyPets[#ind].id' }
+		parameters.find { it.name == 'fancyPets[#ind].name' }
+		parameters.find { it.name == 'fancyPets[#ind].age' }
+		parameters.find { it.name == 'categories[#ind].name' }
+		parameters.find { it.name == 'modelAttributeProperty' }	
+  }
 
   def "should expand parameters when parent name is not empty"() {
     when:

--- a/springfox-spring-web/src/test/java/springfox/documentation/spring/web/dummy/models/ModelAttributeComplexTypeExample.java
+++ b/springfox-spring-web/src/test/java/springfox/documentation/spring/web/dummy/models/ModelAttributeComplexTypeExample.java
@@ -1,0 +1,37 @@
+package springfox.documentation.spring.web.dummy.models;
+
+import java.util.List;
+
+public class ModelAttributeComplexTypeExample extends ModelAttributeExample {
+	
+	private List<FancyPet> fancyPets;
+	
+	private Category[] categories;
+	
+	private String[] modelAttributeProperty;
+
+	public List<FancyPet> getFancyPets() {
+		return fancyPets;
+	}
+
+	public void setFancyPets(List<FancyPet> fancyPets) {
+		this.fancyPets = fancyPets;
+	}
+
+	public Category[] getCategories() {
+		return categories;
+	}
+
+	public void setCategories(Category[] categories) {
+		this.categories = categories;
+	}
+
+	public String[] getModelAttributeProperty() {
+		return modelAttributeProperty;
+	}
+
+	public void setModelAttributeProperty(String[] modelAttributeProperty) {
+		this.modelAttributeProperty = modelAttributeProperty;
+	}
+
+}

--- a/springfox-spring-web/src/test/java/springfox/documentation/spring/web/dummy/models/ModelAttributeComplexTypeExample.java
+++ b/springfox-spring-web/src/test/java/springfox/documentation/spring/web/dummy/models/ModelAttributeComplexTypeExample.java
@@ -3,35 +3,35 @@ package springfox.documentation.spring.web.dummy.models;
 import java.util.List;
 
 public class ModelAttributeComplexTypeExample extends ModelAttributeExample {
-	
-	private List<FancyPet> fancyPets;
-	
-	private Category[] categories;
-	
-	private String[] modelAttributeProperty;
+    
+    private List<FancyPet> fancyPets;
+    
+    private Category[] categories;
+    
+    private String[] modelAttributeProperty;
 
-	public List<FancyPet> getFancyPets() {
-		return fancyPets;
-	}
+    public List<FancyPet> getFancyPets() {
+        return fancyPets;
+    }
 
-	public void setFancyPets(List<FancyPet> fancyPets) {
-		this.fancyPets = fancyPets;
-	}
+    public void setFancyPets(List<FancyPet> fancyPets) {
+        this.fancyPets = fancyPets;
+    }
 
-	public Category[] getCategories() {
-		return categories;
-	}
+    public Category[] getCategories() {
+        return categories;
+    }
 
-	public void setCategories(Category[] categories) {
-		this.categories = categories;
-	}
+    public void setCategories(Category[] categories) {
+        this.categories = categories;
+    }
 
-	public String[] getModelAttributeProperty() {
-		return modelAttributeProperty;
-	}
+    public String[] getModelAttributeProperty() {
+        return modelAttributeProperty;
+    }
 
-	public void setModelAttributeProperty(String[] modelAttributeProperty) {
-		this.modelAttributeProperty = modelAttributeProperty;
-	}
+    public void setModelAttributeProperty(String[] modelAttributeProperty) {
+        this.modelAttributeProperty = modelAttributeProperty;
+    }
 
 }

--- a/springfox-spring-web/src/test/java/springfox/documentation/spring/web/dummy/models/ModelAttributeComplexTypeExample.java
+++ b/springfox-spring-web/src/test/java/springfox/documentation/spring/web/dummy/models/ModelAttributeComplexTypeExample.java
@@ -1,3 +1,22 @@
+/*
+ *
+ *  Copyright 2015 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+ 
 package springfox.documentation.spring.web.dummy.models;
 
 import java.util.List;


### PR DESCRIPTION
This code adds functionality to unwrap complex parameters, that were annotated with @ModelAttribute annotation.

Example:
```java
Parameter List<MyObject> myObject;
```
Where:

```java
MyObject {
    String a;
    Integer b;
    List<MyObject2> myObject2;
}

MyObject2 {
    Long c;
}
```
Will be unwrapped to:
```
myObject[#ind].a

myObject[#ind].b

myObject[#ind].myObject2[#ind].c
```