### PR TITLE
#1373 - Modified how to set jsonEditor parameter

### DIFF
--- a/springfox-swagger-ui/src/web/js/springfox.js
+++ b/springfox-swagger-ui/src/web/js/springfox.js
@@ -40,7 +40,7 @@ $(function() {
         log("Unable to Load SwaggerUI");
       },
       docExpansion: data.docExpansion || 'none',
-      jsonEditor: data.jsonEditor || false,
+      jsonEditor: JSON.parse(data.jsonEditor) || false,
       apisSorter: data.apisSorter || 'alpha',
       defaultModelRendering: data.defaultModelRendering || 'schema',
       showRequestHeaders: data.showRequestHeaders || true


### PR DESCRIPTION
#### What's this PR do/fix?
This PR modifies how to set jsonEditor parameter to solve problem related on #1373 task
#### Are there unit tests? If not how should this be manually tested?
No there aren't. To test it you should configure  `UiConfiguration` with `enableJsonEditor` parameter to `false`. In swagger page, the button `Try it!` shouldn't be accesible.
#### Any background context you want to provide?
No
#### What are the relevant issues?
#1373 