### PR TITLE
upgrade to swagger-ui 2.2.0

### DIFF
--- a/springfox-swagger-ui/build.gradle
+++ b/springfox-swagger-ui/build.gradle
@@ -26,7 +26,7 @@ plugins {
 }
 
 ext {
-  swaggerUiVersion = '2.1.4'
+  swaggerUiVersion = '2.2.0'
   swaggerUiDist = "build/libs/swagger-ui-dist.zip"
   swaggerUiExplodedDir = "swagger-ui-${swaggerUiVersion}/dist/"
   downloadUrl = "https://github.com/swagger-api/swagger-ui/archive/v${swaggerUiVersion}.zip"


### PR DESCRIPTION
Title says it all. Updated `swaggerUiVersion` in `springfox-swagger-ui/build.gradle` from 2.1.4 to 2.2.0, [the latest swagger-ui release](https://github.com/swagger-api/swagger-ui/tree/v2.2.0).
