### PR TITLE
Update to use swagger2markup version 1.0+

### DIFF
--- a/springfox-staticdocs/build.gradle
+++ b/springfox-staticdocs/build.gradle
@@ -26,7 +26,8 @@ sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
 dependencies {
-  compile "io.github.robwin:swagger2markup:0.9.2"
+  compile "io.github.swagger2markup:swagger2markup:1.0.1"
+  compile "io.github.swagger2markup:swagger2markup-extension-commons:1.0.0"
   provided "org.springframework:spring-test:${spring}"
   provided libs.clientProvided
   provided libs.springProvided

--- a/springfox-staticdocs/src/main/java/springfox/documentation/staticdocs/Swagger2MarkupResultHandler.java
+++ b/springfox-staticdocs/src/main/java/springfox/documentation/staticdocs/Swagger2MarkupResultHandler.java
@@ -19,14 +19,22 @@
 
 package springfox.documentation.staticdocs;
 
-import io.github.robwin.markup.builder.MarkupLanguage;
-import io.github.robwin.swagger2markup.Swagger2MarkupConverter;
+import com.google.common.collect.ImmutableMap;
+import io.github.swagger2markup.Swagger2MarkupConfig;
+import io.github.swagger2markup.builder.Swagger2MarkupConfigBuilder;
+import io.github.swagger2markup.markup.builder.MarkupLanguage;
+import io.github.swagger2markup.Swagger2MarkupConverter;
 import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultHandler;
+
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
 
 
 public class Swagger2MarkupResultHandler implements ResultHandler {
@@ -66,8 +74,15 @@ public class Swagger2MarkupResultHandler implements ResultHandler {
         MockHttpServletResponse response = result.getResponse();
         response.setCharacterEncoding(encoding);
         String swaggerJson = response.getContentAsString();
-        Swagger2MarkupConverter.fromString(swaggerJson).withMarkupLanguage(markupLanguage)
-                .withExamples(examplesFolderPath).build().intoFolder(outputDir);
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put("swagger2markup.markupLanguage", markupLanguage.toString());
+        properties.put("swagger2markup.extensions.springRestDocs.snippetBaseUri", examplesFolderPath);
+        Swagger2MarkupConfig config = new Swagger2MarkupConfigBuilder(properties).build();
+
+        Path outputPath = FileSystems.getDefault().getPath(outputDir);
+        Swagger2MarkupConverter.from(swaggerJson).withConfig(config)
+                .build().toFolder(outputPath);
     }
 
 

--- a/springfox-staticdocs/src/main/java/springfox/documentation/staticdocs/Swagger2MarkupResultHandler.java
+++ b/springfox-staticdocs/src/main/java/springfox/documentation/staticdocs/Swagger2MarkupResultHandler.java
@@ -19,7 +19,6 @@
 
 package springfox.documentation.staticdocs;
 
-import com.google.common.collect.ImmutableMap;
 import io.github.swagger2markup.Swagger2MarkupConfig;
 import io.github.swagger2markup.builder.Swagger2MarkupConfigBuilder;
 import io.github.swagger2markup.markup.builder.MarkupLanguage;

--- a/springfox-staticdocs/src/test/groovy/springfox/documentation/staticdocs/Swagger2MarkupDocumentationTest.groovy
+++ b/springfox-staticdocs/src/test/groovy/springfox/documentation/staticdocs/Swagger2MarkupDocumentationTest.groovy
@@ -20,7 +20,7 @@
 package springfox.documentation.staticdocs
 
 import groovy.io.FileType
-import io.github.robwin.markup.builder.MarkupLanguage
+import io.github.swagger2markup.markup.builder.MarkupLanguage
 import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.mock.web.MockHttpServletResponse
 import org.springframework.test.web.servlet.DefaultMvcResult
@@ -39,7 +39,7 @@ class Swagger2MarkupDocumentationTest extends Specification {
     writer.flush()
   }
 
-  def "should convert swagger json into three asciidoc files"() {
+  def "should convert swagger json into four asciidoc files"() {
     given:
       Swagger2MarkupResultHandler resultHandler = Swagger2MarkupResultHandler.outputDirectory('build/docs/asciidoc')
               .withMarkupLanguage(MarkupLanguage.ASCIIDOC).build()
@@ -51,7 +51,7 @@ class Swagger2MarkupDocumentationTest extends Specification {
       dir.eachFileRecurse(FileType.FILES) { file ->
         list << file.name
       }
-      list.sort() == ['definitions.adoc', 'overview.adoc', 'paths.adoc']
+      list.sort() == ['definitions.adoc', 'overview.adoc', 'paths.adoc', 'security.adoc']
   }
 
 


### PR DESCRIPTION
Swagger2Markup has reached 1.0, with some breaking API changes, and new features, like Confluence Wiki Markup generation. This is a minimal set of changes to use the new version/API.
