### PR TITLE
java.sql.Date should become a "date" in JSON Schema output, according to docs

### DIFF
--- a/springfox-schema/src/main/java/springfox/documentation/schema/Types.java
+++ b/springfox-schema/src/main/java/springfox/documentation/schema/Types.java
@@ -62,7 +62,7 @@ public class Types {
       .put(Character.TYPE, "string")
 
       .put(Date.class, "date-time")
-      .put(java.sql.Date.class, "date-time")
+      .put(java.sql.Date.class, "date")
       .put(String.class, "string")
       .put(Object.class, "object")
       .put(Long.class, "long")

--- a/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-bugs-service.json
+++ b/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-bugs-service.json
@@ -45,7 +45,7 @@
             "description": "OK",
             "schema": {
               "type": "string",
-              "format": "date-time"
+              "format": "date"
             }
           }
         }


### PR DESCRIPTION
Fixes issue #1337.