### PR TITLE
Fixing java.sql.Date to be a date in swagger instead of date-time

### DIFF
--- a/springfox-schema/src/main/java/springfox/documentation/schema/Types.java
+++ b/springfox-schema/src/main/java/springfox/documentation/schema/Types.java
@@ -62,7 +62,7 @@ public class Types {
       .put(Character.TYPE, "string")
 
       .put(Date.class, "date-time")
-      .put(java.sql.Date.class, "date-time")
+      .put(java.sql.Date.class, "date")
       .put(String.class, "string")
       .put(Object.class, "object")
       .put(Long.class, "long")

--- a/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-bugs-service.json
+++ b/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-bugs-service.json
@@ -49,7 +49,7 @@
             "description": "OK",
             "schema": {
               "type": "string",
-              "format": "date-time"
+              "format": "date"
             }
           }
         }


### PR DESCRIPTION
The original fix in e99f059182ee5ff57b72a670f0761cb3e12b0e68 for #1162 broke the swagger type so that it reported as date-time instead of date.
The unit test from the original fix has been modified to test for date instead of date-time

