### PR TITLE
Merge method-level and class-level @ApiResponses annotations.

### DIFF
--- a/springfox-spring-web/src/test/java/springfox/documentation/spring/web/dummy/DummyClass.java
+++ b/springfox-spring-web/src/test/java/springfox/documentation/spring/web/dummy/DummyClass.java
@@ -55,6 +55,9 @@ import java.util.List;
 import java.util.Map;
 
 @RequestMapping(produces = {"application/json"}, consumes = {"application/json", "application/xml"})
+@ApiResponses({
+  @ApiResponse(code = 404, response = RestError.class, message = "Not Found")
+})
 public class DummyClass {
 
 

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/annotations/Annotations.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/annotations/Annotations.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Set;
 
 import static com.google.common.base.Optional.*;
+import static com.google.common.collect.Lists.*;
 import static org.springframework.core.annotation.AnnotationUtils.*;
 
 public class Annotations {
@@ -52,8 +53,16 @@ public class Annotations {
     return fromNullable(findAnnotation(annotated, ApiOperation.class));
   }
 
-  public static Optional<ApiResponses> findApiResponsesAnnotations(Method annotated) {
-    return fromNullable(findAnnotation(annotated, ApiResponses.class));
+  public static List<Optional<ApiResponses>> findApiResponsesAnnotations(AnnotatedElement annotated) {
+    return newArrayList(
+            fromNullable(getAnnotation(annotated, ApiResponses.class)),
+            fromNullable(annotated instanceof Method
+                    ?
+                    findAnnotation(((Method) annotated).getDeclaringClass(), ApiResponses.class)
+                    :
+                    (ApiResponses) null
+            )
+    );
   }
 
   public static Optional<ResponseHeader> findResponseHeader(Method annotated) {

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/annotations/Annotations.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/annotations/Annotations.java
@@ -53,16 +53,19 @@ public class Annotations {
     return fromNullable(findAnnotation(annotated, ApiOperation.class));
   }
 
-  public static List<Optional<ApiResponses>> findApiResponsesAnnotations(AnnotatedElement annotated) {
-    return newArrayList(
-            fromNullable(getAnnotation(annotated, ApiResponses.class)),
-            fromNullable(annotated instanceof Method
-                    ?
-                    findAnnotation(((Method) annotated).getDeclaringClass(), ApiResponses.class)
-                    :
-                    (ApiResponses) null
-            )
-    );
+  public static List<ApiResponses> findApiResponsesAnnotations(AnnotatedElement annotated) {
+    List<ApiResponses> results = newArrayList();
+    ApiResponses currentLevel = getAnnotation(annotated, ApiResponses.class);
+    if (currentLevel != null) {
+      results.add(currentLevel);
+    }
+    if (annotated instanceof Method) {
+      ApiResponses parentLevel = findAnnotation(((Method)annotated).getDeclaringClass(), ApiResponses.class);
+      if (parentLevel != null) {
+        results.add(parentLevel);
+      }
+    }
+    return results;
   }
 
   public static Optional<ResponseHeader> findResponseHeader(Method annotated) {

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/operation/SwaggerOperationModelsProvider.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/operation/SwaggerOperationModelsProvider.java
@@ -37,7 +37,6 @@ import springfox.documentation.spi.service.contexts.RequestMappingContext;
 import springfox.documentation.spring.web.readers.operation.HandlerMethodResolver;
 import springfox.documentation.swagger.common.SwaggerPluginSupport;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -85,13 +84,12 @@ public class SwaggerOperationModelsProvider implements OperationModelsProviderPl
   private void collectApiResponses(RequestMappingContext context) {
 
     HandlerMethod handlerMethod = context.getHandlerMethod();
-    List<Optional<ApiResponses>> allApiResponses = findApiResponsesAnnotations(handlerMethod.getMethod());
+    List<ApiResponses> allApiResponses = findApiResponsesAnnotations(handlerMethod.getMethod());
 
     LOG.debug("Reading parameters models for handlerMethod |{}|", handlerMethod.getMethod().getName());
     Set<ResolvedType> seenTypes = newHashSet();
-    for (Optional<ApiResponses> apiResponses : allApiResponses) {
-      List<ResolvedType> modelTypes = apiResponses.transform(toResolvedTypes(context))
-              .or(new ArrayList<ResolvedType>());
+    for (ApiResponses apiResponses : allApiResponses) {
+      List<ResolvedType> modelTypes = toResolvedTypes(context).apply(apiResponses);
       for (ResolvedType modelType : modelTypes) {
         if (!seenTypes.contains(modelType)) {
           seenTypes.add(modelType);

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/annotations/AnnotationsSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/annotations/AnnotationsSpec.groovy
@@ -40,7 +40,7 @@ class AnnotationsSpec extends Specification {
     given:
       AnnotatedElement annotatedElement = ConcreteController.getMethod("get", Object)
     expect:
-      findApiResponsesAnnotations(annotatedElement)[0].isPresent()
+      findApiResponsesAnnotations(annotatedElement).size() == 1
   }
 
   def "ApiParam annotations should be looked up through the entire inheritance hierarchy"() {
@@ -55,11 +55,10 @@ class AnnotationsSpec extends Specification {
       AnnotatedElement classLevel = DummyClass.class
       AnnotatedElement methodLevel = DummyClass.getMethod("methodAnnotatedWithApiResponse")
     expect:
-      findApiResponsesAnnotations(classLevel)[0].isPresent()
-      findApiResponsesAnnotations(classLevel)[1].absent()
-      findApiResponsesAnnotations(methodLevel)[0].isPresent()
-      findApiResponsesAnnotations(methodLevel)[1].isPresent()
-      findApiResponsesAnnotations(methodLevel).findAll{it.isPresent()}.collect{it.get()}.containsAll([classLevel.getAnnotation(ApiResponses), methodLevel.getAnnotation(ApiResponses)])
+      findApiResponsesAnnotations(classLevel).size() == 1
+      findApiResponsesAnnotations(methodLevel).size() == 2
+      findApiResponsesAnnotations(methodLevel)[0]== methodLevel.getAnnotation(ApiResponses)
+      findApiResponsesAnnotations(methodLevel)[1] == classLevel.getAnnotation(ApiResponses)
   }
 
   def "Cannot instantiate the annotations helper"() {

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/annotations/AnnotationsSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/annotations/AnnotationsSpec.groovy
@@ -21,6 +21,7 @@ package springfox.documentation.swagger.annotations
 import com.fasterxml.classmate.TypeResolver
 import io.swagger.annotations.ApiOperation
 import io.swagger.annotations.ApiResponse
+import io.swagger.annotations.ApiResponses
 import spock.lang.Shared
 import spock.lang.Specification
 import springfox.documentation.spring.web.dummy.DummyClass
@@ -39,7 +40,7 @@ class AnnotationsSpec extends Specification {
     given:
       AnnotatedElement annotatedElement = ConcreteController.getMethod("get", Object)
     expect:
-      findApiResponsesAnnotations(annotatedElement).isPresent()
+      findApiResponsesAnnotations(annotatedElement)[0].isPresent()
   }
 
   def "ApiParam annotations should be looked up through the entire inheritance hierarchy"() {
@@ -47,6 +48,18 @@ class AnnotationsSpec extends Specification {
       AnnotatedElement annotatedElement = DummyClass.getMethod("annotatedWithApiParam")
     expect:
       findApiParamAnnotation(annotatedElement).isPresent()
+  }
+
+  def "ApiResponses annotations should be looked up when annotated at class level"() {
+    given:
+      AnnotatedElement classLevel = DummyClass.class
+      AnnotatedElement methodLevel = DummyClass.getMethod("methodAnnotatedWithApiResponse")
+    expect:
+      findApiResponsesAnnotations(classLevel)[0].isPresent()
+      findApiResponsesAnnotations(classLevel)[1].absent()
+      findApiResponsesAnnotations(methodLevel)[0].isPresent()
+      findApiResponsesAnnotations(methodLevel)[1].isPresent()
+      findApiResponsesAnnotations(methodLevel).findAll{it.isPresent()}.collect{it.get()}.containsAll([classLevel.getAnnotation(ApiResponses), methodLevel.getAnnotation(ApiResponses)])
   }
 
   def "Cannot instantiate the annotations helper"() {

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/operation/SwaggerOperationModelsProviderSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/operation/SwaggerOperationModelsProviderSpec.groovy
@@ -28,9 +28,9 @@ class SwaggerOperationModelsProviderSpec extends DocumentationContextSpec {
       sut.supports(DocumentationType.SWAGGER_2)
     where:
       operationName                         | modelCount
-      'dummyMethod'                         | 0
-      'methodWithPosition'                  | 0
-      'methodApiResponseClass'              | 1
+      'dummyMethod'                         | 1
+      'methodWithPosition'                  | 1
+      'methodApiResponseClass'              | 2
       'methodAnnotatedWithApiResponse'      | 2
   }
 

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/operation/SwaggerResponseMessageReaderSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/operation/SwaggerResponseMessageReaderSpec.groovy
@@ -67,10 +67,13 @@ class SwaggerResponseMessageReaderSpec extends DocumentationContextSpec {
       def responseMessages = operation.responseMessages
 
     then:
-      responseMessages.size() == 1
+      responseMessages.size() == 2
       def annotatedResponse = responseMessages.find { it.code == 413 }
       annotatedResponse != null
       annotatedResponse.message == "a message"
+      def classLevelResponse = responseMessages.find { it.code == 404 }
+      classLevelResponse != null
+      classLevelResponse.message == "Not Found"
   }
 
   def "ApiOperation annotation should provide response"() {
@@ -98,10 +101,13 @@ class SwaggerResponseMessageReaderSpec extends DocumentationContextSpec {
       def responseMessages = operation.responseMessages
 
     then:
-      responseMessages.size() == 1
+      responseMessages.size() == 2
       def annotatedResponse = responseMessages.find { it.code == 200 }
       annotatedResponse != null
       annotatedResponse.message == "OK"
+      def classLevelResponse = responseMessages.find { it.code == 404 }
+      classLevelResponse != null
+      classLevelResponse.message == "Not Found"
   }
 
   @Unroll

--- a/springfox-swagger1/src/test/groovy/springfox/documentation/spring/web/scanners/SwaggerApiModelReaderSpec.groovy
+++ b/springfox-swagger1/src/test/groovy/springfox/documentation/spring/web/scanners/SwaggerApiModelReaderSpec.groovy
@@ -112,8 +112,9 @@ class SwaggerApiModelReaderSpec extends DocumentationContextSpec {
       def models = sut.read(context)
 
     then:
-      models.size() == 1 // instead of 3
+      models.size() == 2 // instead of 3
       models.containsKey("BusinessModel")
+      models.containsKey("RestError") // from class-level annotation.
 
   }
 
@@ -149,7 +150,8 @@ class SwaggerApiModelReaderSpec extends DocumentationContextSpec {
       def models = sut.read(context)
 
     then:
-      models.size() == 1
+      models.size() == 2
+      models.containsKey('RestError') // from class-level annotation.
 
       String modelName = DummyModels.AnnotatedBusinessModel.class.simpleName
       models.containsKey(modelName)


### PR DESCRIPTION
#### What's this PR do/fix?
Merges `@ApiResponses` annotations from method-level and type-level (at least, when annotated in the same class). Method-level annotations take priority over type-level annotations.
#### Are there unit tests? If not how should this be manually tested?
I have updated `AnnotationsSpec` to verify the behavior when the annotations are defined in the same class. I have not tested subclassing behavior. I have also manually tested against the example project I created for #1465 (https://github.com/sworisbreathing/springfox-issues)
#### Any background context you want to provide?
See #1465.
#### What are the relevant issues?
#1465