### PR TITLE
remove duplicate enum values

### DIFF
--- a/springfox-core/src/main/java/springfox/documentation/schema/Enums.java
+++ b/springfox-core/src/main/java/springfox/documentation/schema/Enums.java
@@ -27,11 +27,14 @@ import springfox.documentation.service.AllowableListValues;
 import springfox.documentation.service.AllowableValues;
 
 import java.lang.reflect.Method;
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 import static com.google.common.base.Strings.*;
 import static com.google.common.collect.Lists.*;
+import static java.util.Arrays.asList;
 
 public class Enums {
 
@@ -48,7 +51,7 @@ public class Enums {
   }
 
   static List<String> getEnumValues(final Class<?> subject) {
-    return transform(Arrays.asList(subject.getEnumConstants()), new Function<Object, String>() {
+    return transformUnique(subject.getEnumConstants(), new Function<Object, String>() {
       @Override
       public String apply(Object input) {
         Optional<String> jsonValue = findJsonValueAnnotatedMethod(input)
@@ -72,6 +75,12 @@ public class Enums {
         return "";
       }
     };
+  }
+
+  private static <E> List<String> transformUnique(E[] values, Function<E, String> mapper) {
+    List<String> nonUniqueValues = transform(asList(values), mapper);
+    Set<String> uniqueValues = new LinkedHashSet<String>(nonUniqueValues);
+    return new ArrayList<String>(uniqueValues);
   }
 
   private static Optional<Method> findJsonValueAnnotatedMethod(Object enumConstant) {

--- a/springfox-core/src/test/groovy/springfox/documentation/schema/EnumsSpec.groovy
+++ b/springfox-core/src/test/groovy/springfox/documentation/schema/EnumsSpec.groovy
@@ -53,4 +53,12 @@ class EnumsSpec extends Specification {
     then:
       thrown(UnsupportedOperationException)
   }
+
+  def "we shouldn't have duplicate enum representations"() {
+    given:
+    def expected = Arrays.asList("one", "two")
+    expect:
+    expected.equals(Enums.getEnumValues(DuplicateRepresentationEnum))
+  }
+
 }

--- a/springfox-core/src/test/java/springfox/documentation/schema/DuplicateRepresentationEnum.java
+++ b/springfox-core/src/test/java/springfox/documentation/schema/DuplicateRepresentationEnum.java
@@ -1,0 +1,43 @@
+/*
+ *
+ *  Copyright 2016 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package springfox.documentation.schema;
+
+/**
+ *
+ * A real life example of this would be org.springframework.http.HttpStatus
+ *
+ * @author Alexandru-Constantin Bledea
+ * @since Sep 12, 2016
+ */
+public enum DuplicateRepresentationEnum {
+
+  ONE,
+  TWO,
+
+  @Deprecated
+  one,
+  @Deprecated
+  two;
+
+  @Override
+  public String toString() {
+    return name().toLowerCase();
+  }
+
+}


### PR DESCRIPTION
This PR fixes #1485

I added the unit test inside EnumsSpec

I wanted to validate the api-docs generated value in the editor and it kept failing because of non-unique values in enums
```
✖ Swagger Error
Array items are not unique (indexes 16 and 17)
```

