### PR TITLE
Added bean validation support for @DecimalMin/@DecimalMax and made the min/max values explicit

### DIFF
--- a/springfox-bean-validators/src/main/java/springfox/bean/validators/configuration/BeanValidatorPluginsConfiguration.java
+++ b/springfox-bean-validators/src/main/java/springfox/bean/validators/configuration/BeanValidatorPluginsConfiguration.java
@@ -20,16 +20,18 @@ package springfox.bean.validators.configuration;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import springfox.bean.validators.plugins.MinMaxAnnotationPlugin;
-import springfox.bean.validators.plugins.NotNullAnnotationPlugin;
-import springfox.bean.validators.plugins.PatternAnnotationPlugin;
-import springfox.bean.validators.plugins.SizeAnnotationPlugin;
+import springfox.bean.validators.plugins.*;
 
 @Configuration
 public class BeanValidatorPluginsConfiguration {
   @Bean
   public MinMaxAnnotationPlugin minMaxPlugin() {
     return new MinMaxAnnotationPlugin();
+  }
+
+  @Bean
+  public DecimalMinMaxAnnotationPlugin decimalMinMaxPlugin() {
+    return new DecimalMinMaxAnnotationPlugin();
   }
 
   @Bean

--- a/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/DecimalMinMaxAnnotationPlugin.java
+++ b/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/DecimalMinMaxAnnotationPlugin.java
@@ -83,14 +83,12 @@ public class DecimalMinMaxAnnotationPlugin implements ModelPropertyBuilderPlugin
     } else if (decimalMin.isPresent()) {
       LOG.debug("@DecimalMin detected: adding AllowableRangeValues to field ");
       DecimalMin min = decimalMin.get();
-      // use Max value until "infinity" works
-      myvalues = new AllowableRangeValues(min.value(), !min.inclusive(), Double.toString(Double.MAX_VALUE), false);
+      myvalues = new AllowableRangeValues(min.value(), !min.inclusive(), null, null);
 
     } else if (decimalMax.isPresent()) {
-      // use Min value until "infinity" works
       LOG.debug("@DecimalMax detected: adding AllowableRangeValues to field ");
       DecimalMax max = decimalMax.get();
-      myvalues = new AllowableRangeValues(Double.toString(-Double.MAX_VALUE), false, max.value(), !max.inclusive());
+      myvalues = new AllowableRangeValues(null, null, max.value(), !max.inclusive());
 
     }
     return myvalues;

--- a/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/DecimalMinMaxAnnotationPlugin.java
+++ b/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/DecimalMinMaxAnnotationPlugin.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2015 the original author or authors.
+ *  Copyright 2016 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/DecimalMinMaxAnnotationPlugin.java
+++ b/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/DecimalMinMaxAnnotationPlugin.java
@@ -71,26 +71,29 @@ public class DecimalMinMaxAnnotationPlugin implements ModelPropertyBuilderPlugin
   }
 
 
-  private AllowableValues createAllowableValuesFromDecimalMinMaxForNumbers(Optional<DecimalMin> min, Optional<DecimalMax> max) {
+  private AllowableValues createAllowableValuesFromDecimalMinMaxForNumbers(Optional<DecimalMin> decimalMin, Optional<DecimalMax> decimalMax) {
     AllowableRangeValues myvalues = null;
 
-    if (min.isPresent() && max.isPresent()) {
+    if (decimalMin.isPresent() && decimalMax.isPresent()) {
       LOG.debug("@DecimalMin+@DecimalMax detected: adding AllowableRangeValues to field ");
-      myvalues = new AllowableRangeValues(min.get().value(), max.get().value());
+      DecimalMin min = decimalMin.get();
+      DecimalMax max = decimalMax.get();
+      myvalues = new AllowableRangeValues(min.value(), !min.inclusive(), max.value(), !max.inclusive());
 
-    } else if (min.isPresent()) {
+    } else if (decimalMin.isPresent()) {
       LOG.debug("@DecimalMin detected: adding AllowableRangeValues to field ");
+      DecimalMin min = decimalMin.get();
       // use Max value until "infinity" works
-      myvalues = new AllowableRangeValues(min.get().value(), Double.toString(Double.MAX_VALUE));
+      myvalues = new AllowableRangeValues(min.value(), !min.inclusive(), Double.toString(Double.MAX_VALUE), false);
 
-    } else if (max.isPresent()) {
+    } else if (decimalMax.isPresent()) {
       // use Min value until "infinity" works
       LOG.debug("@DecimalMax detected: adding AllowableRangeValues to field ");
-      myvalues = new AllowableRangeValues(Double.toString(-Double.MAX_VALUE), max.get().value());
+      DecimalMax max = decimalMax.get();
+      myvalues = new AllowableRangeValues(Double.toString(-Double.MAX_VALUE), false, max.value(), !max.inclusive());
 
     }
     return myvalues;
   }
-
 
 }

--- a/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/DecimalMinMaxAnnotationPlugin.java
+++ b/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/DecimalMinMaxAnnotationPlugin.java
@@ -1,0 +1,96 @@
+/*
+ *
+ *  Copyright 2015 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package springfox.bean.validators.plugins;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import springfox.documentation.service.AllowableRangeValues;
+import springfox.documentation.service.AllowableValues;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.schema.ModelPropertyBuilderPlugin;
+import springfox.documentation.spi.schema.contexts.ModelPropertyContext;
+
+import javax.validation.constraints.DecimalMax;
+import javax.validation.constraints.DecimalMin;
+
+import static springfox.bean.validators.plugins.BeanValidators.validatorFromBean;
+import static springfox.bean.validators.plugins.BeanValidators.validatorFromField;
+
+@Component
+@Order(BeanValidators.BEAN_VALIDATOR_PLUGIN_ORDER)
+public class DecimalMinMaxAnnotationPlugin implements ModelPropertyBuilderPlugin {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DecimalMinMaxAnnotationPlugin.class);
+
+  @Override
+  public boolean supports(DocumentationType delimiter) {
+    // we simply support all documentationTypes!
+    return true;
+  }
+
+  @Override
+  public void apply(ModelPropertyContext context) {
+    Optional<DecimalMin> min = extractMin(context);
+    Optional<DecimalMax> max = extractMax(context);
+
+    // add support for @DecimalMin/@DecimalMax
+    context.getBuilder().allowableValues(createAllowableValuesFromDecimalMinMaxForNumbers(min, max));
+
+  }
+
+  @VisibleForTesting
+  Optional<DecimalMin> extractMin(ModelPropertyContext context) {
+    return validatorFromBean(context, DecimalMin.class)
+        .or(validatorFromField(context, DecimalMin.class));
+  }
+
+  @VisibleForTesting
+  Optional<DecimalMax> extractMax(ModelPropertyContext context) {
+    return validatorFromBean(context, DecimalMax.class)
+        .or(validatorFromField(context, DecimalMax.class));
+  }
+
+
+  private AllowableValues createAllowableValuesFromDecimalMinMaxForNumbers(Optional<DecimalMin> min, Optional<DecimalMax> max) {
+    AllowableRangeValues myvalues = null;
+
+    if (min.isPresent() && max.isPresent()) {
+      LOG.debug("@DecimalMin+@DecimalMax detected: adding AllowableRangeValues to field ");
+      myvalues = new AllowableRangeValues(min.get().value(), max.get().value());
+
+    } else if (min.isPresent()) {
+      LOG.debug("@DecimalMin detected: adding AllowableRangeValues to field ");
+      // use Max value until "infinity" works
+      myvalues = new AllowableRangeValues(min.get().value(), Double.toString(Double.MAX_VALUE));
+
+    } else if (max.isPresent()) {
+      // use Min value until "infinity" works
+      LOG.debug("@DecimalMax detected: adding AllowableRangeValues to field ");
+      myvalues = new AllowableRangeValues(Double.toString(-Double.MAX_VALUE), max.get().value());
+
+    }
+    return myvalues;
+  }
+
+
+}

--- a/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/MinMaxAnnotationPlugin.java
+++ b/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/MinMaxAnnotationPlugin.java
@@ -75,17 +75,17 @@ public class MinMaxAnnotationPlugin implements ModelPropertyBuilderPlugin {
 
     if (min.isPresent() && max.isPresent()) {
       LOG.debug("@Min+@Max detected: adding AllowableRangeValues to field ");
-      myvalues = new AllowableRangeValues(Double.toString(min.get().value()), Double.toString(max.get().value()));
+      myvalues = new AllowableRangeValues(Double.toString(min.get().value()), false, Double.toString(max.get().value()), false);
 
     } else if (min.isPresent()) {
       LOG.debug("@Min detected: adding AllowableRangeValues to field ");
       // use Max value until "infinity" works
-      myvalues = new AllowableRangeValues(Double.toString(min.get().value()), Double.toString(Double.MAX_VALUE));
+      myvalues = new AllowableRangeValues(Double.toString(min.get().value()), false, Double.toString(Double.MAX_VALUE), false);
 
     } else if (max.isPresent()) {
       // use Min value until "infinity" works
       LOG.debug("@Max detected: adding AllowableRangeValues to field ");
-      myvalues = new AllowableRangeValues(Double.toString(-Double.MAX_VALUE), Double.toString(max.get().value()));
+      myvalues = new AllowableRangeValues(Double.toString(-Double.MAX_VALUE), false, Double.toString(max.get().value()), false);
 
     }
     return myvalues;

--- a/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/MinMaxAnnotationPlugin.java
+++ b/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/MinMaxAnnotationPlugin.java
@@ -79,13 +79,11 @@ public class MinMaxAnnotationPlugin implements ModelPropertyBuilderPlugin {
 
     } else if (min.isPresent()) {
       LOG.debug("@Min detected: adding AllowableRangeValues to field ");
-      // use Max value until "infinity" works
-      myvalues = new AllowableRangeValues(Double.toString(min.get().value()), false, Double.toString(Double.MAX_VALUE), false);
+      myvalues = new AllowableRangeValues(Double.toString(min.get().value()), false, null, null);
 
     } else if (max.isPresent()) {
-      // use Min value until "infinity" works
       LOG.debug("@Max detected: adding AllowableRangeValues to field ");
-      myvalues = new AllowableRangeValues(Double.toString(-Double.MAX_VALUE), false, Double.toString(max.get().value()), false);
+      myvalues = new AllowableRangeValues(null, null, Double.toString(max.get().value()), false);
 
     }
     return myvalues;

--- a/springfox-bean-validators/src/test/groovy/springfox/bean/validators/plugins/DecimalMinMaxAnnotationPluginSpec.groovy
+++ b/springfox-bean-validators/src/test/groovy/springfox/bean/validators/plugins/DecimalMinMaxAnnotationPluginSpec.groovy
@@ -51,12 +51,17 @@ class DecimalMinMaxAnnotationPluginSpec extends Specification {
     then:
       def range = property.allowableValues as AllowableRangeValues
       range?.max == expectedMax
+      range?.exclusiveMax == exclusiveMax
       range?.min == expectedMin
+      range?.exclusiveMin == exclusiveMin
     where:
-      propertyName      | expectedMin                   | expectedMax
-      "noAnnotation"    | null                          | null
-      "onlyMin"         | "10.5"                        | Double.MAX_VALUE.toString()
-      "onlyMax"         | (-Double.MAX_VALUE).toString()| "20.5"
-      "both"            | "10.5"                        | "20.5"
+      propertyName      | expectedMin                   | exclusiveMin | expectedMax                 | exclusiveMax
+      "noAnnotation"    | null                          | null         | null                        | null
+      "onlyMin"         | "10.5"                        | false        | Double.MAX_VALUE.toString() | false
+      "onlyMax"         | (-Double.MAX_VALUE).toString()| false        | "20.5"                      | false
+      "both"            | "10.5"                        | false        | "20.5"                      | false
+      "minExclusive"    | "10.5"                        | true         | Double.MAX_VALUE.toString() | false
+      "maxExclusive"    | (-Double.MAX_VALUE).toString()| false        | "20.5"                      | true
+      "bothExclusive"   | "10.5"                        | true         | "20.5"                      | true
   }
 }

--- a/springfox-bean-validators/src/test/groovy/springfox/bean/validators/plugins/DecimalMinMaxAnnotationPluginSpec.groovy
+++ b/springfox-bean-validators/src/test/groovy/springfox/bean/validators/plugins/DecimalMinMaxAnnotationPluginSpec.groovy
@@ -55,13 +55,13 @@ class DecimalMinMaxAnnotationPluginSpec extends Specification {
       range?.min == expectedMin
       range?.exclusiveMin == exclusiveMin
     where:
-      propertyName      | expectedMin                   | exclusiveMin | expectedMax                 | exclusiveMax
-      "noAnnotation"    | null                          | null         | null                        | null
-      "onlyMin"         | "10.5"                        | false        | Double.MAX_VALUE.toString() | false
-      "onlyMax"         | (-Double.MAX_VALUE).toString()| false        | "20.5"                      | false
-      "both"            | "10.5"                        | false        | "20.5"                      | false
-      "minExclusive"    | "10.5"                        | true         | Double.MAX_VALUE.toString() | false
-      "maxExclusive"    | (-Double.MAX_VALUE).toString()| false        | "20.5"                      | true
-      "bothExclusive"   | "10.5"                        | true         | "20.5"                      | true
+      propertyName      | expectedMin | exclusiveMin | expectedMax                 | exclusiveMax
+      "noAnnotation"    | null        | null         | null                        | null
+      "onlyMin"         | "10.5"      | false        | null                        | null
+      "onlyMax"         | null        | null         | "20.5"                      | false
+      "both"            | "10.5"      | false        | "20.5"                      | false
+      "minExclusive"    | "10.5"      | true         | null                        | null
+      "maxExclusive"    | null        | null         | "20.5"                      | true
+      "bothExclusive"   | "10.5"      | true         | "20.5"                      | true
   }
 }

--- a/springfox-bean-validators/src/test/groovy/springfox/bean/validators/plugins/DecimalMinMaxAnnotationPluginSpec.groovy
+++ b/springfox-bean-validators/src/test/groovy/springfox/bean/validators/plugins/DecimalMinMaxAnnotationPluginSpec.groovy
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2015 the original author or authors.
+ *  Copyright 2016 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/springfox-bean-validators/src/test/groovy/springfox/bean/validators/plugins/DecimalMinMaxAnnotationPluginSpec.groovy
+++ b/springfox-bean-validators/src/test/groovy/springfox/bean/validators/plugins/DecimalMinMaxAnnotationPluginSpec.groovy
@@ -1,0 +1,62 @@
+/*
+ *
+ *  Copyright 2015 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package springfox.bean.validators.plugins
+
+import com.fasterxml.classmate.TypeResolver
+import spock.lang.Specification
+import spock.lang.Unroll
+import springfox.bean.validators.plugins.models.DecimalMinMaxTestModel
+import springfox.documentation.builders.ModelPropertyBuilder
+import springfox.documentation.service.AllowableRangeValues
+import springfox.documentation.spi.DocumentationType
+import springfox.documentation.spi.schema.contexts.ModelPropertyContext
+
+class DecimalMinMaxAnnotationPluginSpec extends Specification {
+  def "Always supported" () {
+    expect:
+      new DecimalMinMaxAnnotationPlugin().supports(types)
+    where:
+      types << [DocumentationType.SPRING_WEB, DocumentationType.SWAGGER_2, DocumentationType.SWAGGER_12]
+  }
+
+  @Unroll
+  def "@DecimalMin/@DecimalMax annotations are reflected in the model #propertyName that are AnnotatedElements"()  {
+    given:
+      def sut = new DecimalMinMaxAnnotationPlugin()
+      def element = DecimalMinMaxTestModel.getDeclaredField(propertyName)
+      def context = new ModelPropertyContext(
+          new ModelPropertyBuilder(),
+          element,
+          new TypeResolver(),
+          DocumentationType.SWAGGER_12)
+    when:
+      sut.apply(context)
+      def property = context.builder.build()
+    then:
+      def range = property.allowableValues as AllowableRangeValues
+      range?.max == expectedMax
+      range?.min == expectedMin
+    where:
+      propertyName      | expectedMin                   | expectedMax
+      "noAnnotation"    | null                          | null
+      "onlyMin"         | "10.5"                        | Double.MAX_VALUE.toString()
+      "onlyMax"         | (-Double.MAX_VALUE).toString()| "20.5"
+      "both"            | "10.5"                        | "20.5"
+  }
+}

--- a/springfox-bean-validators/src/test/groovy/springfox/bean/validators/plugins/MinMaxAnnotationPluginSpec.groovy
+++ b/springfox-bean-validators/src/test/groovy/springfox/bean/validators/plugins/MinMaxAnnotationPluginSpec.groovy
@@ -55,10 +55,10 @@ class MinMaxAnnotationPluginSpec extends Specification {
       range?.min == expectedMin
       range?.exclusiveMin == exclusiveMin
     where:
-      propertyName      | expectedMin                   | exclusiveMin | expectedMax                 | exclusiveMax
-      "noAnnotation"    | null                          | null         | null                        | null
-      "onlyMin"         | "10.0"                        | false        | Double.MAX_VALUE.toString() | false
-      "onlyMax"         | (-Double.MAX_VALUE).toString()| false        | "20.0"                      | false
-      "both"            | "10.0"                        | false        | "20.0"                      | false
+      propertyName      | expectedMin | exclusiveMin | expectedMax                 | exclusiveMax
+      "noAnnotation"    | null        | null         | null                        | null
+      "onlyMin"         | "10.0"      | false        | null                        | null
+      "onlyMax"         | null        | null         | "20.0"                      | false
+      "both"            | "10.0"      | false        | "20.0"                      | false
   }
 }

--- a/springfox-bean-validators/src/test/groovy/springfox/bean/validators/plugins/MinMaxAnnotationPluginSpec.groovy
+++ b/springfox-bean-validators/src/test/groovy/springfox/bean/validators/plugins/MinMaxAnnotationPluginSpec.groovy
@@ -51,12 +51,14 @@ class MinMaxAnnotationPluginSpec extends Specification {
     then:
       def range = property.allowableValues as AllowableRangeValues
       range?.max == expectedMax
+      range?.exclusiveMax == exclusiveMax
       range?.min == expectedMin
+      range?.exclusiveMin == exclusiveMin
     where:
-      propertyName      | expectedMin                   | expectedMax
-      "noAnnotation"    | null                          | null
-      "onlyMin"         | "10.0"                        | Double.MAX_VALUE.toString()
-      "onlyMax"         | (-Double.MAX_VALUE).toString()| "20.0"
-      "both"            | "10.0"                        | "20.0"
+      propertyName      | expectedMin                   | exclusiveMin | expectedMax                 | exclusiveMax
+      "noAnnotation"    | null                          | null         | null                        | null
+      "onlyMin"         | "10.0"                        | false        | Double.MAX_VALUE.toString() | false
+      "onlyMax"         | (-Double.MAX_VALUE).toString()| false        | "20.0"                      | false
+      "both"            | "10.0"                        | false        | "20.0"                      | false
   }
 }

--- a/springfox-bean-validators/src/test/java/springfox/bean/validators/plugins/models/DecimalMinMaxTestModel.java
+++ b/springfox-bean-validators/src/test/java/springfox/bean/validators/plugins/models/DecimalMinMaxTestModel.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2015 the original author or authors.
+ *  Copyright 2016 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/springfox-bean-validators/src/test/java/springfox/bean/validators/plugins/models/DecimalMinMaxTestModel.java
+++ b/springfox-bean-validators/src/test/java/springfox/bean/validators/plugins/models/DecimalMinMaxTestModel.java
@@ -30,4 +30,11 @@ public class DecimalMinMaxTestModel {
   @DecimalMin("10.5")
   @DecimalMax("20.5")
   private int both;
+  @DecimalMin(value = "10.5", inclusive = false)
+  private int minExclusive;
+  @DecimalMax(value = "20.5", inclusive = false)
+  private int maxExclusive;
+  @DecimalMin(value = "10.5", inclusive = false)
+  @DecimalMax(value = "20.5", inclusive = false)
+  private int bothExclusive;
 }

--- a/springfox-bean-validators/src/test/java/springfox/bean/validators/plugins/models/DecimalMinMaxTestModel.java
+++ b/springfox-bean-validators/src/test/java/springfox/bean/validators/plugins/models/DecimalMinMaxTestModel.java
@@ -1,0 +1,33 @@
+/*
+ *
+ *  Copyright 2015 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package springfox.bean.validators.plugins.models;
+
+import javax.validation.constraints.DecimalMax;
+import javax.validation.constraints.DecimalMin;
+
+public class DecimalMinMaxTestModel {
+  private int noAnnotation;
+  @DecimalMin("10.5")
+  private int onlyMin;
+  @DecimalMax("20.5")
+  private int onlyMax;
+  @DecimalMin("10.5")
+  @DecimalMax("20.5")
+  private int both;
+}

--- a/springfox-core/src/main/java/springfox/documentation/service/AllowableRangeValues.java
+++ b/springfox-core/src/main/java/springfox/documentation/service/AllowableRangeValues.java
@@ -22,10 +22,18 @@ package springfox.documentation.service;
 public class AllowableRangeValues implements AllowableValues {
   private final String min;
   private final String max;
+  private final Boolean exclusiveMin;
+  private final Boolean exclusiveMax;
 
   public AllowableRangeValues(String min, String max) {
+    this(min, null, max, null);
+  }
+
+  public AllowableRangeValues(String min, Boolean exclusiveMin, String max, Boolean exclusiveMax) {
     this.min = min;
     this.max = max;
+    this.exclusiveMin = exclusiveMin;
+    this.exclusiveMax = exclusiveMax;
   }
 
   public String getMin() {
@@ -34,5 +42,13 @@ public class AllowableRangeValues implements AllowableValues {
 
   public String getMax() {
     return max;
+  }
+
+  public Boolean getExclusiveMin() {
+    return exclusiveMin;
+  }
+
+  public Boolean getExclusiveMax() {
+    return exclusiveMax;
   }
 }

--- a/springfox-swagger2/src/main/java/springfox/documentation/swagger2/mappers/EnumMapper.java
+++ b/springfox-swagger2/src/main/java/springfox/documentation/swagger2/mappers/EnumMapper.java
@@ -55,13 +55,17 @@ public class EnumMapper {
       toReturn.setEnum(((AllowableListValues) allowableValues).getValues());
     }
     if (allowableValues instanceof AllowableRangeValues) {
-      toReturn.setMinimum(safeDouble(((AllowableRangeValues) allowableValues).getMin()));
-      toReturn.setMaximum(safeDouble(((AllowableRangeValues) allowableValues).getMax()));
+      AllowableRangeValues range = (AllowableRangeValues) allowableValues;
+      toReturn.setMinimum(safeDouble(range.getMin()));
+      toReturn.setMaximum(safeDouble(range.getMax()));
     }
     return toReturn;
   }
 
   static Double safeDouble(String doubleString) {
+    if (doubleString == null){
+      return null;
+    }
     try {
       return Double.valueOf(doubleString);
     } catch (NumberFormatException e) {

--- a/springfox-swagger2/src/main/java/springfox/documentation/swagger2/mappers/ModelMapper.java
+++ b/springfox-swagger2/src/main/java/springfox/documentation/swagger2/mappers/ModelMapper.java
@@ -150,7 +150,9 @@ public abstract class ModelMapper {
       if (allowableValues instanceof AllowableRangeValues) {
         AllowableRangeValues range = (AllowableRangeValues) allowableValues;
         ((AbstractNumericProperty) property).maximum(safeDouble(range.getMax()));
+        ((AbstractNumericProperty) property).exclusiveMaximum(range.getExclusiveMax());
         ((AbstractNumericProperty) property).minimum(safeDouble(range.getMin()));
+        ((AbstractNumericProperty) property).exclusiveMinimum(range.getExclusiveMin());
       }
     }
 

--- a/springfox-swagger2/src/main/java/springfox/documentation/swagger2/mappers/ModelMapper.java
+++ b/springfox-swagger2/src/main/java/springfox/documentation/swagger2/mappers/ModelMapper.java
@@ -146,25 +146,27 @@ public abstract class ModelMapper {
     }
 
     if (property instanceof AbstractNumericProperty) {
+      AbstractNumericProperty numericProperty = (AbstractNumericProperty) property;
       AllowableValues allowableValues = source.getAllowableValues();
       if (allowableValues instanceof AllowableRangeValues) {
         AllowableRangeValues range = (AllowableRangeValues) allowableValues;
-        ((AbstractNumericProperty) property).maximum(safeDouble(range.getMax()));
-        ((AbstractNumericProperty) property).exclusiveMaximum(range.getExclusiveMax());
-        ((AbstractNumericProperty) property).minimum(safeDouble(range.getMin()));
-        ((AbstractNumericProperty) property).exclusiveMinimum(range.getExclusiveMin());
+        numericProperty.maximum(safeDouble(range.getMax()));
+        numericProperty.exclusiveMaximum(range.getExclusiveMax());
+        numericProperty.minimum(safeDouble(range.getMin()));
+        numericProperty.exclusiveMinimum(range.getExclusiveMin());
       }
     }
 
     if (property instanceof StringProperty) {
+      StringProperty stringProperty = (StringProperty) property;
       AllowableValues allowableValues = source.getAllowableValues();
       if (allowableValues instanceof AllowableRangeValues) {
         AllowableRangeValues range = (AllowableRangeValues) allowableValues;
-        ((StringProperty) property).maxLength(safeInteger(range.getMax()));
-        ((StringProperty) property).minLength(safeInteger(range.getMin()));
+        stringProperty.maxLength(safeInteger(range.getMax()));
+        stringProperty.minLength(safeInteger(range.getMin()));
       }
       if(source.getPattern() != null) {
-        ((StringProperty) property).setPattern(source.getPattern());
+        stringProperty.setPattern(source.getPattern());
       }
     }
 


### PR DESCRIPTION
Added bean validation support for @DecimalMin/@DecimalMax. Code is heavily based on existing `MinMaxAnnotationPlugin`.

I was tempted to change the default min/max values from `Double.MAX_VALUE` to reflect the actual property type (e.g. an Integer should use `Integer.MAX_VALUE` for example), but that is probably a separate issue.

