### PR TITLE
Suggested fix for "Adding Models using ApiImplicitParam #468".  Allow…

### DIFF
--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/operation/OperationImplicitParameterReader.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/operation/OperationImplicitParameterReader.java
@@ -80,7 +80,7 @@ public class OperationImplicitParameterReader implements OperationBuilderPlugin 
 
   static ModelRef maybeGetModelRef(ApiImplicitParam param) {
     String baseType = param.dataType();
-    if (!isBaseType(param.dataType())) {
+    if (baseType.equals("")) {
       LOGGER.warn("Coercing to be of type string. This may not even be a scalar type in actuality");
       baseType = "string";
     }

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/operation/OperationImplicitParameterReader.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/operation/OperationImplicitParameterReader.java
@@ -80,7 +80,7 @@ public class OperationImplicitParameterReader implements OperationBuilderPlugin 
 
   static ModelRef maybeGetModelRef(ApiImplicitParam param) {
     String baseType = param.dataType();
-    if (baseType.equals("")) {
+    if ("".equals(baseType)) {
       LOGGER.warn("Coercing to be of type string. This may not even be a scalar type in actuality");
       baseType = "string";
     }


### PR DESCRIPTION
This PR suggests a fix for "Adding Models using ApiImplicitParam #468".  It allows class names to be used in addition to basic types within the ApiImplicitParam annotation.

There are no unit tests currently.  I scratched this out as a suggestion/design review.

I have tested it on my local machine and have observed swagger-ui now correctly presenting the model suggested by the annotation when a class name is given.  So, the code has passed a basic "smoke test".

If this approach looks sensible then I'll happily add unit tests and resubmit the pull request.