### PR TITLE
Added support for composed bean validation constraints

### DIFF
--- a/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/BeanValidators.java
+++ b/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/BeanValidators.java
@@ -18,16 +18,16 @@
  */
 package springfox.bean.validators.plugins;
 
-import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
 import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
-import com.google.common.collect.FluentIterable;
 import org.springframework.core.Ordered;
+import org.springframework.core.annotation.AnnotationUtils;
 import springfox.documentation.spi.schema.contexts.ModelPropertyContext;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 
 public class BeanValidators {
   public final static int BEAN_VALIDATOR_PLUGIN_ORDER = Ordered.HIGHEST_PRECEDENCE + 500;
@@ -36,44 +36,55 @@ public class BeanValidators {
     throw new UnsupportedOperationException();
   }
 
+  public static <T extends Annotation> Optional<T> extractAnnotation(
+          ModelPropertyContext context,
+          Class<T> annotationType) {
+    return validatorFromBean(context, annotationType)
+            .or(validatorFromField(context, annotationType));
+  }
+
   public static <T extends Annotation> Optional<T> validatorFromBean(
-      ModelPropertyContext context,
-      Class<T> annotationType) {
+          ModelPropertyContext context,
+          Class<T> annotationType) {
 
     Optional<BeanPropertyDefinition> propertyDefinition = context.getBeanPropertyDefinition();
     Optional<T> notNull = Optional.absent();
     if (propertyDefinition.isPresent()) {
-      notNull = annotationFrom(propertyDefinition.get().getGetter(), annotationType)
-                .or(annotationFrom(propertyDefinition.get().getField(), annotationType));
+      Optional<Method> getter = extractGetterFromPropertyDefinition(propertyDefinition.get());
+      Optional<Field> field = extractFieldFromPropertyDefinition(propertyDefinition.get());
+      notNull = findAnnotation(getter, annotationType).or(findAnnotation(field, annotationType));
     }
+
     return notNull;
   }
 
   public static <T extends Annotation> Optional<T> validatorFromField(
-      ModelPropertyContext context,
-      Class<T> annotationType) {
+          ModelPropertyContext context,
+          Class<T> annotationType) {
+    return findAnnotation(context.getAnnotatedElement(), annotationType);
+  }
 
-    Optional<AnnotatedElement> annotatedElement = context.getAnnotatedElement();
-    Optional<T> notNull = Optional.absent();
+  private static Optional<Field> extractFieldFromPropertyDefinition(BeanPropertyDefinition propertyDefinition) {
+    if (propertyDefinition.getField() != null) {
+      return Optional.fromNullable(propertyDefinition.getField().getAnnotated());
+    }
+    return Optional.absent();
+  }
+
+  private static Optional<Method> extractGetterFromPropertyDefinition(BeanPropertyDefinition propertyDefinition) {
+    if (propertyDefinition.getGetter() != null) {
+      return Optional.fromNullable(propertyDefinition.getGetter().getMember());
+    }
+    return Optional.absent();
+  }
+
+  private static <T extends Annotation> Optional<T> findAnnotation(
+          Optional<? extends AnnotatedElement> annotatedElement,
+          Class<T> annotationType) {
     if (annotatedElement.isPresent()) {
-      notNull = Optional.fromNullable(annotatedElement.get().getAnnotation(annotationType));
+      return Optional.fromNullable(AnnotationUtils.findAnnotation(annotatedElement.get(), annotationType));
+    } else {
+      return Optional.absent();
     }
-    return notNull;
   }
-
-  @VisibleForTesting
-  static <T extends Annotation> Optional<T> annotationFrom(
-      AnnotatedMember nullableMember,
-      Class<T> annotationType) {
-
-    Optional<AnnotatedMember> member = Optional.fromNullable(nullableMember);
-    Optional<T> notNull = Optional.absent();
-    if (member.isPresent()) {
-      notNull = FluentIterable.from(member.get().annotations())
-          .filter(annotationType)
-          .first();
-    }
-    return notNull;
-  }
-
 }

--- a/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/DecimalMinMaxAnnotationPlugin.java
+++ b/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/DecimalMinMaxAnnotationPlugin.java
@@ -18,7 +18,6 @@
  */
 package springfox.bean.validators.plugins;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,8 +32,7 @@ import springfox.documentation.spi.schema.contexts.ModelPropertyContext;
 import javax.validation.constraints.DecimalMax;
 import javax.validation.constraints.DecimalMin;
 
-import static springfox.bean.validators.plugins.BeanValidators.validatorFromBean;
-import static springfox.bean.validators.plugins.BeanValidators.validatorFromField;
+import static springfox.bean.validators.plugins.BeanValidators.extractAnnotation;
 
 @Component
 @Order(BeanValidators.BEAN_VALIDATOR_PLUGIN_ORDER)
@@ -50,26 +48,13 @@ public class DecimalMinMaxAnnotationPlugin implements ModelPropertyBuilderPlugin
 
   @Override
   public void apply(ModelPropertyContext context) {
-    Optional<DecimalMin> min = extractMin(context);
-    Optional<DecimalMax> max = extractMax(context);
+    Optional<DecimalMin> min = extractAnnotation(context, DecimalMin.class);
+    Optional<DecimalMax> max = extractAnnotation(context, DecimalMax.class);
 
     // add support for @DecimalMin/@DecimalMax
     context.getBuilder().allowableValues(createAllowableValuesFromDecimalMinMaxForNumbers(min, max));
 
   }
-
-  @VisibleForTesting
-  Optional<DecimalMin> extractMin(ModelPropertyContext context) {
-    return validatorFromBean(context, DecimalMin.class)
-        .or(validatorFromField(context, DecimalMin.class));
-  }
-
-  @VisibleForTesting
-  Optional<DecimalMax> extractMax(ModelPropertyContext context) {
-    return validatorFromBean(context, DecimalMax.class)
-        .or(validatorFromField(context, DecimalMax.class));
-  }
-
 
   private AllowableValues createAllowableValuesFromDecimalMinMaxForNumbers(Optional<DecimalMin> decimalMin, Optional<DecimalMax> decimalMax) {
     AllowableRangeValues myvalues = null;

--- a/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/MinMaxAnnotationPlugin.java
+++ b/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/MinMaxAnnotationPlugin.java
@@ -18,7 +18,6 @@
  */
 package springfox.bean.validators.plugins;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,7 +32,7 @@ import springfox.documentation.spi.schema.contexts.ModelPropertyContext;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 
-import static springfox.bean.validators.plugins.BeanValidators.*;
+import static springfox.bean.validators.plugins.BeanValidators.extractAnnotation;
 
 @Component
 @Order(BeanValidators.BEAN_VALIDATOR_PLUGIN_ORDER)
@@ -49,26 +48,13 @@ public class MinMaxAnnotationPlugin implements ModelPropertyBuilderPlugin {
 
   @Override
   public void apply(ModelPropertyContext context) {
-    Optional<Min> min = extractMin(context);
-    Optional<Max> max = extractMax(context);
+    Optional<Min> min = extractAnnotation(context, Min.class);
+    Optional<Max> max = extractAnnotation(context, Max.class);
 
     // add support for @Min/@Max
     context.getBuilder().allowableValues(createAllowableValuesFromMinMaxForNumbers(min, max));
 
   }
-
-  @VisibleForTesting
-  Optional<Min> extractMin(ModelPropertyContext context) {
-    return validatorFromBean(context, Min.class)
-        .or(validatorFromField(context, Min.class));
-  }
-
-  @VisibleForTesting
-  Optional<Max> extractMax(ModelPropertyContext context) {
-    return validatorFromBean(context, Max.class)
-        .or(validatorFromField(context, Max.class));
-  }
-
 
   private AllowableValues createAllowableValuesFromMinMaxForNumbers(Optional<Min> min, Optional<Max> max) {
     AllowableRangeValues myvalues = null;

--- a/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/NotNullAnnotationPlugin.java
+++ b/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/NotNullAnnotationPlugin.java
@@ -18,7 +18,6 @@
  */
 package springfox.bean.validators.plugins;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
@@ -28,7 +27,7 @@ import springfox.documentation.spi.schema.contexts.ModelPropertyContext;
 
 import javax.validation.constraints.NotNull;
 
-import static springfox.bean.validators.plugins.BeanValidators.*;
+import static springfox.bean.validators.plugins.BeanValidators.extractAnnotation;
 
 @Component
 @Order(BeanValidators.BEAN_VALIDATOR_PLUGIN_ORDER)
@@ -42,14 +41,8 @@ public class NotNullAnnotationPlugin implements ModelPropertyBuilderPlugin {
 
   @Override
   public void apply(ModelPropertyContext context) {
-    Optional<NotNull> notNull = extractAnnotation(context);
+    Optional<NotNull> notNull = extractAnnotation(context, NotNull.class);
     context.getBuilder().required(notNull.isPresent());
-  }
-
-  @VisibleForTesting
-  Optional<NotNull> extractAnnotation(ModelPropertyContext context) {
-    return validatorFromBean(context, NotNull.class)
-        .or(validatorFromField(context, NotNull.class));
   }
 
 }

--- a/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/PatternAnnotationPlugin.java
+++ b/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/PatternAnnotationPlugin.java
@@ -27,8 +27,7 @@ import springfox.documentation.spi.schema.contexts.ModelPropertyContext;
 
 import javax.validation.constraints.Pattern;
 
-import static springfox.bean.validators.plugins.BeanValidators.validatorFromBean;
-import static springfox.bean.validators.plugins.BeanValidators.validatorFromField;
+import static springfox.bean.validators.plugins.BeanValidators.extractAnnotation;
 
 /**
  * @author : ashutosh
@@ -39,13 +38,8 @@ import static springfox.bean.validators.plugins.BeanValidators.validatorFromFiel
 public class PatternAnnotationPlugin implements ModelPropertyBuilderPlugin {
   @Override
   public void apply(ModelPropertyContext context) {
-    Optional<Pattern> pattern = extractPattern(context);
+    Optional<Pattern> pattern = extractAnnotation(context, Pattern.class);
     context.getBuilder().pattern(createPatternValueFromAnnotation(pattern));
-  }
-
-  Optional<Pattern> extractPattern(ModelPropertyContext context) {
-    return validatorFromBean(context, Pattern.class)
-        .or(validatorFromField(context, Pattern.class));
   }
 
   private String createPatternValueFromAnnotation(Optional<Pattern> pattern) {

--- a/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/SizeAnnotationPlugin.java
+++ b/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/SizeAnnotationPlugin.java
@@ -18,7 +18,6 @@
  */
 package springfox.bean.validators.plugins;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,7 +31,7 @@ import springfox.documentation.spi.schema.contexts.ModelPropertyContext;
 
 import javax.validation.constraints.Size;
 
-import static springfox.bean.validators.plugins.BeanValidators.*;
+import static springfox.bean.validators.plugins.BeanValidators.extractAnnotation;
 
 @Component
 @Order(BeanValidators.BEAN_VALIDATOR_PLUGIN_ORDER)
@@ -48,17 +47,11 @@ public class SizeAnnotationPlugin implements ModelPropertyBuilderPlugin {
 
   @Override
   public void apply(ModelPropertyContext context) {
-    Optional<Size> size = extractAnnotation(context);
+    Optional<Size> size = extractAnnotation(context, Size.class);
 
     if (size.isPresent()) {
       context.getBuilder().allowableValues(createAllowableValuesFromSizeForStrings(size.get()));
     }
-  }
-
-  @VisibleForTesting
-  Optional<Size> extractAnnotation(ModelPropertyContext context) {
-    return validatorFromBean(context, Size.class)
-        .or(validatorFromField(context, Size.class));
   }
 
   private AllowableValues createAllowableValuesFromSizeForStrings(Size size) {

--- a/springfox-bean-validators/src/test/groovy/springfox/bean/validators/plugins/BeanValidatorsSpec.groovy
+++ b/springfox-bean-validators/src/test/groovy/springfox/bean/validators/plugins/BeanValidatorsSpec.groovy
@@ -1,8 +1,19 @@
 package springfox.bean.validators.plugins
 
+import com.fasterxml.classmate.TypeResolver
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition
+import com.fasterxml.jackson.databind.type.TypeFactory
 import spock.lang.Specification
+import spock.lang.Unroll
+import springfox.bean.validators.plugins.models.BeanValidatorsTestModel
+import springfox.documentation.builders.ModelPropertyBuilder
+import springfox.documentation.spi.DocumentationType
+import springfox.documentation.spi.schema.contexts.ModelPropertyContext
 
-import javax.validation.constraints.Size
+import javax.validation.constraints.NotNull
+import javax.validation.constraints.Pattern
+import java.lang.reflect.AnnotatedElement
 
 class BeanValidatorsSpec extends Specification {
   def "Cannot instantiate" () {
@@ -12,10 +23,125 @@ class BeanValidatorsSpec extends Specification {
       thrown(UnsupportedOperationException)
   }
 
-  def "When member is null annotation is absent"() {
+  def "When AnnotatedElement is null"() {
     when:
-      def annotation = BeanValidators.annotationFrom(null, Size)
+    def context = new ModelPropertyContext(
+            new ModelPropertyBuilder(),
+            (AnnotatedElement) null,
+            new TypeResolver(),
+            DocumentationType.SWAGGER_12)
+      def annotation = BeanValidators.extractAnnotation(context, NotNull)
     then:
       !annotation.isPresent()
   }
+
+  def "When BeanPropertyDefinition has no field/getter"() {
+    when:
+    def context = new ModelPropertyContext(
+            new ModelPropertyBuilder(),
+            Mock(BeanPropertyDefinition),
+            new TypeResolver(),
+            DocumentationType.SWAGGER_12)
+    def annotation = BeanValidators.extractAnnotation(context, NotNull)
+    then:
+    !annotation.isPresent()
+  }
+
+  @Unroll
+  def "@NotNull annotations are reflected in the model #propertyName that are AnnotatedElements"()  {
+    given:
+    def property = BeanValidatorsTestModel.getDeclaredField(propertyName)
+    def context = new ModelPropertyContext(
+            new ModelPropertyBuilder(),
+            property,
+            new TypeResolver(),
+            DocumentationType.SWAGGER_12)
+    when:
+    def annotation = BeanValidators.extractAnnotation(context, NotNull)
+    then:
+    annotation.isPresent() == present
+    where:
+    propertyName                       | present
+    "noAnnotation"                     | false
+    "annotationOnField"                | true
+    "annotationOnGetter"               | false
+    "compositeAnnotationOnField"       | true
+    "compositeAnnotationOnGetter"      | false
+    "extraCompositeAnnotationOnField"  | true
+    "extraCompositeAnnotationOnGetter" | false
+  }
+
+  @Unroll
+  def "@NotNull annotations are reflected in the model #propertyName that are BeanPropertyDefinitions"()  {
+    given:
+    def property = beanProperty(propertyName)
+    def context = new ModelPropertyContext(
+            new ModelPropertyBuilder(),
+            property,
+            new TypeResolver(),
+            DocumentationType.SWAGGER_12)
+    when:
+    def annotation = BeanValidators.extractAnnotation(context, NotNull)
+    then:
+    annotation.isPresent() == present
+    where:
+    propertyName                       | present
+    "noAnnotation"                     | false
+    "annotationOnField"                | true
+    "annotationOnGetter"               | true
+    "compositeAnnotationOnField"       | true
+    "compositeAnnotationOnGetter"      | true
+    "extraCompositeAnnotationOnField"  | true
+    "extraCompositeAnnotationOnGetter" | true
+  }
+
+  @Unroll
+  def "Constraints can be overridden for #propertyName as an AnnotatedElement"()  {
+    given:
+    def property = BeanValidatorsTestModel.getDeclaredField(propertyName)
+    def context = new ModelPropertyContext(
+            new ModelPropertyBuilder(),
+            property,
+            new TypeResolver(),
+            DocumentationType.SWAGGER_12)
+    when:
+    def annotation = BeanValidators.extractAnnotation(context, Pattern)
+    then:
+      def value = annotation.isPresent() ? annotation.get().regexp() : null
+      value == overriddenValue
+    where:
+    propertyName         | overriddenValue
+    "override"           | "overridden"
+    "overrideOnGetter"   | null
+  }
+
+  @Unroll
+  def "Constraints can be overridden for #propertyName as a BeanPropertyDefinition"()  {
+    given:
+    def property = beanProperty(propertyName)
+    def context = new ModelPropertyContext(
+            new ModelPropertyBuilder(),
+            property,
+            new TypeResolver(),
+            DocumentationType.SWAGGER_12)
+    when:
+    def annotation = BeanValidators.extractAnnotation(context, Pattern)
+    then:
+    def value = annotation.isPresent() ? annotation.get().regexp() : null
+    value == overriddenValue
+    where:
+    propertyName         | overriddenValue
+    "override"           | "overridden"
+    "overrideOnGetter"   | "overriddenOnGetter"
+  }
+
+  def beanProperty(property) {
+    def mapper = new ObjectMapper()
+    mapper
+            .serializationConfig
+            .introspect(TypeFactory.defaultInstance().constructType(BeanValidatorsTestModel))
+            .findProperties()
+            .find { p -> (property == p.name) };
+  }
+
 }

--- a/springfox-bean-validators/src/test/java/springfox/bean/validators/plugins/models/BeanValidatorsTestModel.java
+++ b/springfox-bean-validators/src/test/java/springfox/bean/validators/plugins/models/BeanValidatorsTestModel.java
@@ -1,0 +1,163 @@
+/*
+ *
+ *  Copyright 2016 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package springfox.bean.validators.plugins.models;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import javax.validation.ReportAsSingleViolation;
+import javax.validation.constraints.*;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+public class BeanValidatorsTestModel {
+
+  private String noAnnotation;
+  @NotNull
+  private String annotationOnField;
+  private String annotationOnGetter;
+  @Mandatory
+  private String compositeAnnotationOnField;
+  private String compositeAnnotationOnGetter;
+  @MandatoryInteger
+  private String extraCompositeAnnotationOnField;
+  private String extraCompositeAnnotationOnGetter;
+
+  @Pattern(regexp = "overridden")
+  @MandatoryInteger
+  private String override;
+
+  private String overrideOnGetter;
+
+  public String getNoAnnotation() {
+    return noAnnotation;
+  }
+
+  public void setNoAnnotation(String noAnnotation) {
+    this.noAnnotation = noAnnotation;
+  }
+
+  public String getAnnotationOnField() {
+    return annotationOnField;
+  }
+
+  public void setAnnotationOnField(String annotationOnField) {
+    this.annotationOnField = annotationOnField;
+  }
+
+  @NotNull
+  public String getAnnotationOnGetter() {
+    return annotationOnGetter;
+  }
+
+  public void setAnnotationOnGetter(String annotationOnGetter) {
+    this.annotationOnGetter = annotationOnGetter;
+  }
+
+  public String getCompositeAnnotationOnField() {
+    return compositeAnnotationOnField;
+  }
+
+  public void setCompositeAnnotationOnField(String compositeAnnotationOnField) {
+    this.compositeAnnotationOnField = compositeAnnotationOnField;
+  }
+
+  @Mandatory
+  public String getCompositeAnnotationOnGetter() {
+    return compositeAnnotationOnGetter;
+  }
+
+  public void setCompositeAnnotationOnGetter(String compositeAnnotationOnGetter) {
+    this.compositeAnnotationOnGetter = compositeAnnotationOnGetter;
+  }
+
+  public String getExtraCompositeAnnotationOnField() {
+    return extraCompositeAnnotationOnField;
+  }
+
+  public void setExtraCompositeAnnotationOnField(String extraCompositeAnnotationOnField) {
+    this.extraCompositeAnnotationOnField = extraCompositeAnnotationOnField;
+  }
+
+  @MandatoryInteger
+  public String getExtraCompositeAnnotationOnGetter() {
+    return extraCompositeAnnotationOnGetter;
+  }
+
+  public void setExtraCompositeAnnotationOnGetter(String extraCompositeAnnotationOnGetter) {
+    this.extraCompositeAnnotationOnGetter = extraCompositeAnnotationOnGetter;
+  }
+
+  public String getOverride() {
+    return override;
+  }
+
+  public void setOverride(String override) {
+    this.override = override;
+  }
+
+  @Pattern(regexp = "overriddenOnGetter")
+  @MandatoryInteger
+  public String getOverrideOnGetter() {
+    return overrideOnGetter;
+  }
+
+  public void setOverrideOnGetter(String overrideOnGetter) {
+    this.overrideOnGetter = overrideOnGetter;
+  }
+
+  /**
+   * Composite validation constraint - @NotNull should still be detected!
+   */
+  @Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE })
+  @Retention(RUNTIME)
+  @Constraint(validatedBy = {})
+  @NotNull
+  @Size(min = 1)
+  @ReportAsSingleViolation
+  public @interface Mandatory {
+
+    String message() default "must be supplied!";
+
+    Class<?>[] groups() default { };
+
+    Class<? extends Payload>[] payload() default { };
+  }
+
+  /**
+   * Extra composite validation constraint - @NotNull (from @Mandatory) should still be detected.
+   */
+  @Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE })
+  @Retention(RUNTIME)
+  @Constraint(validatedBy = {})
+  @Mandatory
+  @Pattern(regexp = "[0-9]+")
+  @ReportAsSingleViolation
+  public @interface MandatoryInteger {
+
+    String message() default "must be an integer";
+
+    Class<?>[] groups() default { };
+
+    Class<? extends Payload>[] payload() default { };
+  }
+
+}


### PR DESCRIPTION
#### What's this PR do/fix?
Enables support for [composed bean validation constraints](https://docs.jboss.org/hibernate/validator/5.0/reference/en-US/html/validator-customconstraints.html#validator-customconstraints-compound). 

For example, you can define a `@Percent` constraint that is annotated with `@DecimalMin("0.0")` and `@DecimalMax("100.0")` and reuse it everywhere you have a percent field.

The current plugins only support the annotations being present on the field/getter itself, not via another constraint (meaning you'd have to write a plugin for each composed constraint, which is not ideal).
#### Are there unit tests? If not how should this be manually tested?
Please refer to `BeanValidatorsSpec`.
#### Any background context you want to provide?
This solution makes use of Spring's `AnnotationUtils.findAnnotation()`, which takes care of finding annotations (even when they're applied to other annotations), as well as preventing infinite recursion. Being a Spring extension, I thought this was more ideal than writing my own solution!
#### What are the relevant issues?

* Using Spring's AnnotationUtils to find annotations
* Added new `extractAnnotation()` method to BeanValidators as it's common to all plugins (left existing methods for backwards compatability)
* Refactored all plugins to use `extractAnnotation()` - so they now all support composed constraints