### PR TITLE
fix ApiParam hidden attribute

### DIFF
--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/parameter/ApiParamParameterBuilder.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/parameter/ApiParamParameterBuilder.java
@@ -55,6 +55,7 @@ public class ApiParamParameterBuilder implements ParameterBuilderPlugin {
       context.parameterBuilder().defaultValue(emptyToNull(apiParam.get().defaultValue()));
       context.parameterBuilder().allowMultiple(apiParam.get().allowMultiple());
       context.parameterBuilder().required(apiParam.get().required());
+      context.parameterBuilder().hidden(apiParam.get().hidden());
     }
   }
 


### PR DESCRIPTION
Attribute of @ApiParam  don't work in this situation:

public Page<User> listUser(@ModelAttribute UserQueryRequest request,
                                    @ApiParam(hidden = true)
                                    @PageableDefault(sort = {"createdTime"}, direction = Sort.Direction.DESC)
                                            Pageable pageable) { }
