### PR TITLE
OAuth2 not initialized when clientSecret undefined

### DIFF
--- a/springfox-swagger-ui/src/web/js/springfox.js
+++ b/springfox-swagger-ui/src/web/js/springfox.js
@@ -68,7 +68,6 @@ $(function() {
 
     function oAuthIsDefined(security) {
       return security.clientId
-          && security.clientSecret
           && security.appName
           && security.realm;
     }


### PR DESCRIPTION
#### What's this PR do/fix?

fix for #1592 
OAuth2 clientSecret shouldn't be required for implicit flow

#### Are there unit tests? If not how should this be manually tested?
Manually tested, the issue is in js code

#### Any background context you want to provide?
See #1592 

#### What are the relevant issues?

When clientSecret is set to null on the server-side,
the client-side doesn't initialize any OAuth2 values.
Problem is that clientSecret is not used in some oauth2
flow (i.e. implicit flow).

The URL generated to initiate OAuth2 authentication flow
contains an undefined client_id parameter.