### PR TITLE
Make ApiResourceController methods public

### DIFF
--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/ApiResourceController.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/ApiResourceController.java
@@ -49,21 +49,21 @@ public class ApiResourceController {
 
   @RequestMapping(value = "/configuration/security")
   @ResponseBody
-  ResponseEntity<SecurityConfiguration> securityConfiguration() {
+  public ResponseEntity<SecurityConfiguration> securityConfiguration() {
     return new ResponseEntity<SecurityConfiguration>(
         Optional.fromNullable(securityConfiguration).or(SecurityConfiguration.DEFAULT), HttpStatus.OK);
   }
 
   @RequestMapping(value = "/configuration/ui")
   @ResponseBody
-  ResponseEntity<UiConfiguration> uiConfiguration() {
+  public ResponseEntity<UiConfiguration> uiConfiguration() {
     return new ResponseEntity<UiConfiguration>(
         Optional.fromNullable(uiConfiguration).or(UiConfiguration.DEFAULT), HttpStatus.OK);
   }
 
   @RequestMapping
   @ResponseBody
-  ResponseEntity<List<SwaggerResource>> swaggerResources() {
+  public ResponseEntity<List<SwaggerResource>> swaggerResources() {
     return new ResponseEntity<List<SwaggerResource>>(swaggerResources.get(), HttpStatus.OK);
   }
 


### PR DESCRIPTION
#### What's this PR do/fix?

Closes #1701 

#### Are there unit tests? If not how should this be manually tested?

This PR only changes the visibility of 3 methods, it does not affect the functionality of the project in any other way.

#### Any background context you want to provide?

Context described in the issue. For convenience, I'm quoting it here:

> ApiResourceController is a public class with no public methods in it. It would be useful to make the 3 actions that it defines public.
> 
> In my use case, I need to put certain additional annotations on these methods to make them publicly visible to our routing library. I'd like to either be able to inherit from the class or delegate to the controller instance from my own controller to achieve this, but with the code as is, I have to define my class within the springfox.documentation.swagger.web package.

#### What are the relevant issues?

#1701 