### PR TITLE
Fix Swagger version error in documentation

### DIFF
--- a/docs/asciidoc/current-documentation.adoc
+++ b/docs/asciidoc/current-documentation.adoc
@@ -79,7 +79,7 @@ By default the swagger service descriptions are generated at the following urls
 |=======================
 |Swagger version  | Documentation Url           | Group
 |1.2              | /api-docs                   | implicit *default* group
-|2.0              | /api-docs?group=external    | *external* group via docket.groupName()
+|1.2              | /api-docs?group=external    | *external* group via docket.groupName()
 |2.0              | /v2/api-docs                | implicit *default* group
 |2.0              | /v2/api-docs?group=external | *external* group via docket.groupName()
 |=======================


### PR DESCRIPTION
In `Customizing the swagger endpoints` section, second line in the first table has Swagger version `2.0`, but it should be `1.2`.
