### PR TITLE
Update PropertySourcedRequestMappingHandlerMapping.java

### DIFF
--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/PropertySourcedRequestMappingHandlerMapping.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/PropertySourcedRequestMappingHandlerMapping.java
@@ -76,7 +76,7 @@ public class PropertySourcedRequestMappingHandlerMapping extends RequestMappingH
   }
 
   private String mappingPath(final PropertySourcedMapping mapper) {
-    final String key = mapper.value();
+    final String key = mapper.propertyKey();
     return Optional.fromNullable(environment.getProperty(key))
         .transform(new Function<String, String>() {
           @Override


### PR DESCRIPTION
mappingPath method used a unresolved value as property lockup key.
So by default we were looking for "${springfox.documentation.swagger.v2.path}" property instead of "springfox.documentation.swagger.v2.path"

Because of this bug it was impossible to use springfox.documentation.swagger.v2.path property to change default mapping.
