### PR TITLE
JacksonEnumDeterminer to handle JsonFormat.Shape.Object

### DIFF
--- a/springfox-schema/src/main/java/springfox/documentation/schema/DefaultModelDependencyProvider.java
+++ b/springfox-schema/src/main/java/springfox/documentation/schema/DefaultModelDependencyProvider.java
@@ -29,6 +29,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import springfox.documentation.schema.property.ModelPropertiesProvider;
+import springfox.documentation.spi.schema.EnumTypeDeterminer;
 import springfox.documentation.spi.schema.contexts.ModelContext;
 
 import java.util.List;
@@ -49,16 +50,18 @@ public class DefaultModelDependencyProvider implements ModelDependencyProvider {
   private final TypeResolver typeResolver;
   private final ModelPropertiesProvider propertiesProvider;
   private final TypeNameExtractor nameExtractor;
+  private final EnumTypeDeterminer enumTypeDeterminer;
 
   @Autowired
   public DefaultModelDependencyProvider(
       TypeResolver typeResolver,
       @Qualifier("cachedModelProperties") ModelPropertiesProvider propertiesProvider,
-      TypeNameExtractor nameExtractor) {
+      TypeNameExtractor nameExtractor, EnumTypeDeterminer enumTypeDeterminer) {
 
     this.typeResolver = typeResolver;
     this.propertiesProvider = propertiesProvider;
     this.nameExtractor = nameExtractor;
+    this.enumTypeDeterminer = enumTypeDeterminer;
   }
 
   @Override
@@ -130,7 +133,7 @@ public class DefaultModelDependencyProvider implements ModelDependencyProvider {
   }
 
   private List<ResolvedType> resolvedPropertiesAndFields(ModelContext modelContext, ResolvedType resolvedType) {
-    if (modelContext.hasSeenBefore(resolvedType) || resolvedType.getErasedType().isEnum()) {
+    if (modelContext.hasSeenBefore(resolvedType) || enumTypeDeterminer.isEnum(resolvedType.getErasedType())) {
       return newArrayList();
     }
     modelContext.seen(resolvedType);

--- a/springfox-schema/src/main/java/springfox/documentation/schema/DefaultModelProvider.java
+++ b/springfox-schema/src/main/java/springfox/documentation/schema/DefaultModelProvider.java
@@ -32,6 +32,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import springfox.documentation.schema.plugins.SchemaPluginsManager;
 import springfox.documentation.schema.property.ModelPropertiesProvider;
+import springfox.documentation.spi.schema.EnumTypeDeterminer;
 import springfox.documentation.spi.schema.contexts.ModelContext;
 
 import java.util.ArrayList;
@@ -55,26 +56,29 @@ public class DefaultModelProvider implements ModelProvider {
   private final ModelDependencyProvider dependencyProvider;
   private final SchemaPluginsManager schemaPluginsManager;
   private final TypeNameExtractor typeNameExtractor;
+  private final EnumTypeDeterminer enumTypeDeterminer;
 
   @Autowired
   public DefaultModelProvider(TypeResolver resolver,
       @Qualifier("cachedModelProperties") ModelPropertiesProvider propertiesProvider,
       @Qualifier("cachedModelDependencies") ModelDependencyProvider dependencyProvider,
       SchemaPluginsManager schemaPluginsManager,
-      TypeNameExtractor typeNameExtractor) {
+      TypeNameExtractor typeNameExtractor, EnumTypeDeterminer enumTypeDeterminer) {
     this.resolver = resolver;
     this.propertiesProvider = propertiesProvider;
     this.dependencyProvider = dependencyProvider;
     this.schemaPluginsManager = schemaPluginsManager;
     this.typeNameExtractor = typeNameExtractor;
+    this.enumTypeDeterminer=enumTypeDeterminer;
   }
 
   @Override
   public com.google.common.base.Optional<Model> modelFor(ModelContext modelContext) {
     ResolvedType propertiesHost = modelContext.alternateFor(modelContext.resolvedType(resolver));
+
     if (isContainerType(propertiesHost)
         || isMapType(propertiesHost)
-        || propertiesHost.getErasedType().isEnum()
+        || enumTypeDeterminer.isEnum(propertiesHost.getErasedType())
         || isBaseType(propertiesHost)
         || modelContext.hasSeenBefore(propertiesHost)) {
       LOG.debug("Skipping model of type {} as its either a container type, map, enum or base type, or its already "

--- a/springfox-schema/src/main/java/springfox/documentation/schema/JacksonEnumTypeDeterminer.java
+++ b/springfox-schema/src/main/java/springfox/documentation/schema/JacksonEnumTypeDeterminer.java
@@ -1,0 +1,21 @@
+package springfox.documentation.schema;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import org.springframework.stereotype.Component;
+import springfox.documentation.spi.schema.EnumTypeDeterminer;
+
+@Component
+public class JacksonEnumTypeDeterminer implements EnumTypeDeterminer{
+    public boolean isEnum(Class<?> type) {
+        if(type.isEnum()){
+            JsonFormat annotation = type.getAnnotation(JsonFormat.class);
+            if(annotation!=null) {
+                return !annotation.shape().equals(JsonFormat.Shape.OBJECT);
+            }else{
+                return true;
+            }
+        }else{
+            return false;
+        }
+    }
+}

--- a/springfox-schema/src/main/java/springfox/documentation/schema/JacksonEnumTypeDeterminer.java
+++ b/springfox-schema/src/main/java/springfox/documentation/schema/JacksonEnumTypeDeterminer.java
@@ -1,3 +1,22 @@
+/*
+ *
+ *  Copyright 2015-2016 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+
 package springfox.documentation.schema;
 
 import com.fasterxml.jackson.annotation.JsonFormat;

--- a/springfox-schema/src/main/java/springfox/documentation/schema/TypeNameExtractor.java
+++ b/springfox-schema/src/main/java/springfox/documentation/schema/TypeNameExtractor.java
@@ -29,6 +29,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.plugin.core.PluginRegistry;
 import org.springframework.stereotype.Component;
 import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.schema.EnumTypeDeterminer;
 import springfox.documentation.spi.schema.GenericTypeNamingStrategy;
 import springfox.documentation.spi.schema.TypeNameProviderPlugin;
 import springfox.documentation.spi.schema.contexts.ModelContext;
@@ -43,14 +44,17 @@ import static springfox.documentation.schema.Types.*;
 public class TypeNameExtractor {
   private final TypeResolver typeResolver;
   private final PluginRegistry<TypeNameProviderPlugin, DocumentationType> typeNameProviders;
+  private final EnumTypeDeterminer enumTypeDeterminer;
 
   @Autowired
   public TypeNameExtractor(TypeResolver typeResolver,
                            @Qualifier("typeNameProviderPluginRegistry")
-                           PluginRegistry<TypeNameProviderPlugin, DocumentationType> typeNameProviders) {
+                           PluginRegistry<TypeNameProviderPlugin, DocumentationType> typeNameProviders,
+                           EnumTypeDeterminer enumTypeDeterminer) {
 
     this.typeResolver = typeResolver;
     this.typeNameProviders = typeNameProviders;
+    this.enumTypeDeterminer=enumTypeDeterminer;
   }
 
   public String typeName(ModelContext context) {
@@ -97,7 +101,7 @@ public class TypeNameExtractor {
     Class<?> erasedType = type.getErasedType();
     if (type instanceof ResolvedPrimitiveType) {
       return typeNameFor(erasedType);
-    } else if (erasedType.isEnum()) {
+    } else if (enumTypeDeterminer.isEnum(erasedType)) {
       return "string";
     } else if (type instanceof ResolvedArrayType) {
       GenericTypeNamingStrategy namingStrategy = context.getGenericNamingStrategy();

--- a/springfox-schema/src/test/groovy/springfox/documentation/schema/JacksonEnumTypeDeterminerSpec.groovy
+++ b/springfox-schema/src/test/groovy/springfox/documentation/schema/JacksonEnumTypeDeterminerSpec.groovy
@@ -19,7 +19,6 @@
 
 package springfox.documentation.schema
 
-import com.fasterxml.classmate.TypeResolver
 import spock.lang.Shared
 import spock.lang.Specification
 

--- a/springfox-schema/src/test/groovy/springfox/documentation/schema/JacksonEnumTypeDeterminerSpec.groovy
+++ b/springfox-schema/src/test/groovy/springfox/documentation/schema/JacksonEnumTypeDeterminerSpec.groovy
@@ -1,0 +1,33 @@
+/*
+ *
+ *  Copyright 2015-2016 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+
+package springfox.documentation.schema
+
+import com.fasterxml.classmate.TypeResolver
+import spock.lang.Shared
+import spock.lang.Specification
+
+class JacksonEnumTypeDeterminerSpec extends Specification {
+    @Shared def enumTypeDeterminerSpec = new JacksonEnumTypeDeterminer();
+    def "detects enum type" () {
+        expect:
+        enumTypeDeterminerSpec.isEnum(ExampleEnum.ONE.class) == true
+        enumTypeDeterminerSpec.isEnum(EnumJsonFormatObject.ONE.class) == false
+    }
+}

--- a/springfox-schema/src/test/groovy/springfox/documentation/schema/ModelReferenceProviderSpec.groovy
+++ b/springfox-schema/src/test/groovy/springfox/documentation/schema/ModelReferenceProviderSpec.groovy
@@ -56,7 +56,7 @@ class ModelReferenceProviderSpec extends Specification {
   def aTypeNameExtractor(TypeResolver resolver) {
     PluginRegistry<TypeNameProviderPlugin, DocumentationType> modelNameRegistry =
         OrderAwarePluginRegistry.create([new DefaultTypeNameProvider()])
-    def typeNameExtractor = new TypeNameExtractor(resolver, modelNameRegistry)
+    def typeNameExtractor = new TypeNameExtractor(resolver, modelNameRegistry, new JacksonEnumTypeDeterminer())
     typeNameExtractor
   }
 

--- a/springfox-schema/src/test/groovy/springfox/documentation/schema/SchemaSpecification.groovy
+++ b/springfox-schema/src/test/groovy/springfox/documentation/schema/SchemaSpecification.groovy
@@ -38,7 +38,7 @@ class SchemaSpecification extends Specification {
     PluginRegistry<TypeNameProviderPlugin, DocumentationType> modelNameRegistry =
         OrderAwarePluginRegistry.create([new DefaultTypeNameProvider()])
     typeNameExtractor =
-            new TypeNameExtractor(new TypeResolver(), modelNameRegistry)
+            new TypeNameExtractor(new TypeResolver(), modelNameRegistry, new JacksonEnumTypeDeterminer())
     modelProvider = defaultModelProvider()
     modelDependencyProvider = defaultModelDependencyProvider()
   }

--- a/springfox-schema/src/test/groovy/springfox/documentation/schema/plugins/SchemaPluginsManagerSpec.groovy
+++ b/springfox-schema/src/test/groovy/springfox/documentation/schema/plugins/SchemaPluginsManagerSpec.groovy
@@ -60,7 +60,7 @@ class SchemaPluginsManagerSpec extends Specification {
     namePlugin.supports(SPRING_WEB) >> true
 
     sut = new SchemaPluginsManager(propRegistry, modelRegistry)
-    typeNames = new TypeNameExtractor(new TypeResolver(), modelNameRegistry)
+    typeNames = new TypeNameExtractor(new TypeResolver(), modelNameRegistry, new JacksonEnumTypeDeterminer())
   }
 
   def "enriches model property when plugins are found"() {

--- a/springfox-schema/src/test/groovy/springfox/documentation/schema/property/OptimizedModelPropertiesProviderSpec.groovy
+++ b/springfox-schema/src/test/groovy/springfox/documentation/schema/property/OptimizedModelPropertiesProviderSpec.groovy
@@ -46,7 +46,7 @@ class OptimizedModelPropertiesProviderSpec extends Specification {
       BeanPropertyNamingStrategy namingStrategy = new ObjectMapperBeanPropertyNamingStrategy()
       PluginRegistry<TypeNameProviderPlugin, DocumentationType> modelNameRegistry =
           OrderAwarePluginRegistry.create([new DefaultTypeNameProvider()])
-      TypeNameExtractor typeNameExtractor = new TypeNameExtractor(typeResolver, modelNameRegistry)
+      TypeNameExtractor typeNameExtractor = new TypeNameExtractor(typeResolver, modelNameRegistry, new JacksonEnumTypeDeterminer())
       OptimizedModelPropertiesProvider sut = new OptimizedModelPropertiesProvider(
           new AccessorsProvider(typeResolver),
           new FieldProvider(typeResolver),
@@ -91,7 +91,8 @@ class OptimizedModelPropertiesProviderSpec extends Specification {
           OrderAwarePluginRegistry.create([new DefaultTypeNameProvider()])
       TypeNameExtractor typeNameExtractor = new TypeNameExtractor(
           typeResolver,
-          modelNameRegistry)
+          modelNameRegistry,
+          new JacksonEnumTypeDeterminer())
       OptimizedModelPropertiesProvider sut = new OptimizedModelPropertiesProvider(
           new AccessorsProvider(typeResolver),
           new FieldProvider(typeResolver),
@@ -139,7 +140,8 @@ class OptimizedModelPropertiesProviderSpec extends Specification {
               [new DefaultTypeNameProvider()])
       TypeNameExtractor typeNameExtractor = new TypeNameExtractor(
           typeResolver,
-          modelNameRegistry)
+          modelNameRegistry,
+          new JacksonEnumTypeDeterminer())
       OptimizedModelPropertiesProvider sut = new OptimizedModelPropertiesProvider(
           new AccessorsProvider(typeResolver),
           new FieldProvider(typeResolver),
@@ -189,7 +191,8 @@ class OptimizedModelPropertiesProviderSpec extends Specification {
           OrderAwarePluginRegistry.create([new DefaultTypeNameProvider()])
       TypeNameExtractor typeNameExtractor = new TypeNameExtractor(
           typeResolver,
-          modelNameRegistry)
+          modelNameRegistry,
+          new JacksonEnumTypeDeterminer())
       OptimizedModelPropertiesProvider sut = new OptimizedModelPropertiesProvider(
           new AccessorsProvider(typeResolver),
           new FieldProvider(typeResolver),

--- a/springfox-schema/src/test/java/springfox/documentation/schema/EnumJsonFormatObject.java
+++ b/springfox-schema/src/test/java/springfox/documentation/schema/EnumJsonFormatObject.java
@@ -1,0 +1,27 @@
+package springfox.documentation.schema;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+/**
+ * Created by yeh on 22.05.2017.
+ */
+
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+public enum EnumJsonFormatObject {
+    ONE("One", "This in an enum for number 1"), TWO("Two", "This in an enum for number 2");
+
+    private String name;
+    private String description;
+    EnumJsonFormatObject(String name, String description){
+        this.name=name;
+        this.description=description;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/springfox-schema/src/test/java/springfox/documentation/schema/EnumJsonFormatObject.java
+++ b/springfox-schema/src/test/java/springfox/documentation/schema/EnumJsonFormatObject.java
@@ -1,3 +1,22 @@
+/*
+ *
+ *  Copyright 2015-2016 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+
 package springfox.documentation.schema;
 
 import com.fasterxml.jackson.annotation.JsonFormat;

--- a/springfox-spi/src/main/java/springfox/documentation/spi/schema/EnumTypeDeterminer.java
+++ b/springfox-spi/src/main/java/springfox/documentation/spi/schema/EnumTypeDeterminer.java
@@ -1,0 +1,24 @@
+/*
+ *
+ *  Copyright 2015 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+
+package springfox.documentation.spi.schema;
+
+public interface EnumTypeDeterminer {
+    boolean isEnum(Class<?> type);
+}

--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/operation/OperationParameterReader.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/operation/OperationParameterReader.java
@@ -32,6 +32,7 @@ import springfox.documentation.builders.ParameterBuilder;
 import springfox.documentation.service.Parameter;
 import springfox.documentation.service.ResolvedMethodParameter;
 import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.schema.EnumTypeDeterminer;
 import springfox.documentation.spi.service.OperationBuilderPlugin;
 import springfox.documentation.spi.service.contexts.OperationContext;
 import springfox.documentation.spi.service.contexts.ParameterContext;
@@ -57,9 +58,12 @@ public class OperationParameterReader implements OperationBuilderPlugin {
   @Autowired
   private DocumentationPluginsManager pluginsManager;
 
+  private EnumTypeDeterminer enumTypeDeterminer;
+
   @Autowired
-  public OperationParameterReader(ModelAttributeParameterExpander expander) {
+  public OperationParameterReader(ModelAttributeParameterExpander expander, EnumTypeDeterminer enumTypeDeterminer) {
     this.expander = expander;
+    this.enumTypeDeterminer=enumTypeDeterminer;
   }
 
   @Override
@@ -145,7 +149,7 @@ public class OperationParameterReader implements OperationBuilderPlugin {
     return !parameter.hasParameterAnnotation(RequestBody.class)
         && !parameter.hasParameterAnnotation(RequestPart.class)
         && !isBaseType(typeNameFor(resolvedParamType.getErasedType()))
-        && !resolvedParamType.getErasedType().isEnum()
+        && !enumTypeDeterminer.isEnum(resolvedParamType.getErasedType())
         && !isContainerType(resolvedParamType)
         && !isMapType(resolvedParamType);
 

--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/parameter/ExpandedParameterBuilder.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/parameter/ExpandedParameterBuilder.java
@@ -33,6 +33,7 @@ import springfox.documentation.schema.ModelReference;
 import springfox.documentation.service.AllowableListValues;
 import springfox.documentation.service.AllowableValues;
 import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.schema.EnumTypeDeterminer;
 import springfox.documentation.spi.service.ExpandedParameterBuilderPlugin;
 import springfox.documentation.spi.service.contexts.ParameterExpansionContext;
 
@@ -49,10 +50,12 @@ import static springfox.documentation.schema.Types.*;
 @Order(Ordered.HIGHEST_PRECEDENCE)
 public class ExpandedParameterBuilder implements ExpandedParameterBuilderPlugin {
   private final TypeResolver resolver;
+  private final EnumTypeDeterminer enumTypeDeterminer;
 
   @Autowired
-  public ExpandedParameterBuilder(TypeResolver resolver) {
+  public ExpandedParameterBuilder(TypeResolver resolver, EnumTypeDeterminer enumTypeDeterminer) {
     this.resolver = resolver;
+    this.enumTypeDeterminer=enumTypeDeterminer;
   }
 
   @Override
@@ -71,13 +74,13 @@ public class ExpandedParameterBuilder implements ExpandedParameterBuilderPlugin 
       ResolvedType elementType = collectionElementType(resolved);
       String itemTypeName = typeNameFor(elementType.getErasedType());
       AllowableValues itemAllowables = null;
-      if (elementType.getErasedType().isEnum()) {
+      if (enumTypeDeterminer.isEnum(elementType.getErasedType())) {
         itemAllowables = Enums.allowableValues(elementType.getErasedType());
         itemTypeName = "string";
       }
       typeName = containerType(resolved);
       itemModel = new ModelRef(itemTypeName, itemAllowables);
-    } else if (resolved.getErasedType().isEnum()) {
+    } else if (enumTypeDeterminer.isEnum(resolved.getErasedType())) {
         typeName = "string";
     }
     context.getParameterBuilder()
@@ -105,7 +108,7 @@ public class ExpandedParameterBuilder implements ExpandedParameterBuilderPlugin 
   private AllowableValues allowableValues(final Field field) {
 
     AllowableValues allowable = null;
-    if (field.getType().isEnum()) {
+    if (enumTypeDeterminer.isEnum(field.getType())) {
       allowable = new AllowableListValues(getEnumValues(field.getType()), "LIST");
     }
 

--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/parameter/ParameterDataTypeReader.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/parameter/ParameterDataTypeReader.java
@@ -34,6 +34,7 @@ import springfox.documentation.schema.ModelReference;
 import springfox.documentation.schema.TypeNameExtractor;
 import springfox.documentation.service.ResolvedMethodParameter;
 import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.schema.EnumTypeDeterminer;
 import springfox.documentation.spi.schema.contexts.ModelContext;
 import springfox.documentation.spi.service.ParameterBuilderPlugin;
 import springfox.documentation.spi.service.contexts.ParameterContext;
@@ -50,12 +51,14 @@ public class ParameterDataTypeReader implements ParameterBuilderPlugin {
   private static final Logger LOG = LoggerFactory.getLogger(ParameterDataTypeReader.class);
   private final TypeNameExtractor nameExtractor;
   private final TypeResolver resolver;
+  private EnumTypeDeterminer enumTypeDeterminer;
 
 
   @Autowired
-  public ParameterDataTypeReader(TypeNameExtractor nameExtractor, TypeResolver resolver) {
+  public ParameterDataTypeReader(TypeNameExtractor nameExtractor, TypeResolver resolver, EnumTypeDeterminer enumTypeDeterminer) {
     this.nameExtractor = nameExtractor;
     this.resolver = resolver;
+    this.enumTypeDeterminer=enumTypeDeterminer;
   }
 
   @Override
@@ -106,6 +109,6 @@ public class ParameterDataTypeReader implements ParameterBuilderPlugin {
 
   private boolean treatAsAString(ResolvedType parameterType) {
     return !(isBaseType(typeNameFor(parameterType.getErasedType()))
-        || parameterType.getErasedType().isEnum());
+        || enumTypeDeterminer.isEnum(parameterType.getErasedType()));
   }
 }

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/schema/ReturnTypesSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/schema/ReturnTypesSpec.groovy
@@ -43,7 +43,7 @@ class ReturnTypesSpec extends Specification {
   def setup() {
     PluginRegistry<TypeNameProviderPlugin, DocumentationType> modelNameRegistry =
         OrderAwarePluginRegistry.create([new DefaultTypeNameProvider()])
-    sut = new TypeNameExtractor(new TypeResolver(), modelNameRegistry)
+    sut = new TypeNameExtractor(new TypeResolver(), modelNameRegistry, new JacksonEnumTypeDeterminer())
   }
 
    def "model types"() {

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/mixins/ModelProviderForServiceSupport.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/mixins/ModelProviderForServiceSupport.groovy
@@ -33,6 +33,7 @@ import springfox.documentation.schema.property.OptimizedModelPropertiesProvider
 import springfox.documentation.schema.property.bean.AccessorsProvider
 import springfox.documentation.schema.property.field.FieldProvider
 import springfox.documentation.spi.DocumentationType
+import springfox.documentation.spi.schema.EnumTypeDeterminer
 import springfox.documentation.spi.schema.TypeNameProviderPlugin
 
 @SuppressWarnings("GrMethodMayBeStatic")
@@ -41,11 +42,12 @@ class ModelProviderForServiceSupport {
   def typeNameExtractor() {
     PluginRegistry<TypeNameProviderPlugin, DocumentationType> modelNameRegistry =
         OrderAwarePluginRegistry.create([new DefaultTypeNameProvider()])
-    new TypeNameExtractor(new TypeResolver(),  modelNameRegistry)
+    new TypeNameExtractor(new TypeResolver(), modelNameRegistry, new JacksonEnumTypeDeterminer())
   }
 
   ModelProvider modelProvider(SchemaPluginsManager pluginsManager = defaultSchemaPlugins(),
-                              TypeResolver typeResolver = new TypeResolver()) {
+                              TypeResolver typeResolver = new TypeResolver(),
+                              EnumTypeDeterminer enumTypeDeterminer= new JacksonEnumTypeDeterminer()) {
 
     def objectMapper = new ObjectMapper()
     def typeNameExtractor = typeNameExtractor()
@@ -60,14 +62,14 @@ class ModelProviderForServiceSupport {
 
     modelPropertiesProvider.onApplicationEvent(event)
     def modelDependenciesProvider = new DefaultModelDependencyProvider(typeResolver,
-            modelPropertiesProvider, typeNameExtractor)
+            modelPropertiesProvider, typeNameExtractor, enumTypeDeterminer)
     new DefaultModelProvider(typeResolver, modelPropertiesProvider, modelDependenciesProvider,
-            pluginsManager, typeNameExtractor)
+            pluginsManager, typeNameExtractor, enumTypeDeterminer)
   }
 
   ModelProvider modelProviderWithSnakeCaseNamingStrategy(SchemaPluginsManager pluginsManager = defaultSchemaPlugins(),
       TypeResolver typeResolver = new TypeResolver()) {
-
+      EnumTypeDeterminer enumTypeDeterminer=new JacksonEnumTypeDeterminer();
     def objectMapper = new ObjectMapper()
     def typeNameExtractor = typeNameExtractor()
     objectMapper.setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES)
@@ -81,9 +83,9 @@ class ModelProviderForServiceSupport {
         pluginsManager, typeNameExtractor)
     modelPropertiesProvider.onApplicationEvent(event)
     def modelDependenciesProvider = new DefaultModelDependencyProvider(typeResolver,
-            modelPropertiesProvider, typeNameExtractor)
+            modelPropertiesProvider, typeNameExtractor, enumTypeDeterminer)
     new DefaultModelProvider(typeResolver, modelPropertiesProvider, modelDependenciesProvider,
-            pluginsManager, typeNameExtractor)
+            pluginsManager, typeNameExtractor, enumTypeDeterminer)
   }
 
 

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/mixins/ServicePluginsSupport.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/mixins/ServicePluginsSupport.groovy
@@ -19,6 +19,7 @@
 
 package springfox.documentation.spring.web.mixins
 import com.fasterxml.classmate.TypeResolver
+import springfox.documentation.schema.JacksonEnumTypeDeterminer
 import springfox.documentation.service.PathDecorator
 import springfox.documentation.spi.service.*
 import springfox.documentation.spring.web.paths.OperationPathDecorator
@@ -40,10 +41,11 @@ class ServicePluginsSupport {
 
   DocumentationPluginsManager defaultWebPlugins() {
     def resolver = new TypeResolver()
+    def enumTypeDeterminer=new JacksonEnumTypeDeterminer();
     def plugins = new DocumentationPluginsManager()
     plugins.apiListingPlugins = create(newArrayList(new MediaTypeReader(), new ApiListingReader()))
     plugins.documentationPlugins = create([])
-    plugins.parameterExpanderPlugins = create([new ExpandedParameterBuilder(resolver)])
+    plugins.parameterExpanderPlugins = create([new ExpandedParameterBuilder(resolver, enumTypeDeterminer)])
     plugins.parameterPlugins = create([new ParameterNameReader()])
     plugins.operationBuilderPlugins = create([])
     plugins.resourceGroupingStrategies = create([])
@@ -69,10 +71,11 @@ class ServicePluginsSupport {
                                              new QueryStringUriTemplateDecorator()]) {
 
     def resolver = new TypeResolver()
+    def enumTypeDeterminer=new JacksonEnumTypeDeterminer();
     def plugins = new DocumentationPluginsManager()
     plugins.apiListingPlugins = create(newArrayList(new MediaTypeReader()))
     plugins.documentationPlugins = create(documentationPlugins)
-    plugins.parameterExpanderPlugins = create([new ExpandedParameterBuilder(resolver)])
+    plugins.parameterExpanderPlugins = create([new ExpandedParameterBuilder(resolver, enumTypeDeterminer)])
     plugins.parameterPlugins = create(paramPlugins)
     plugins.operationBuilderPlugins = create(operationPlugins)
     plugins.resourceGroupingStrategies = create(groupingStrategyPlugins)

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/operation/DefaultResponseMessageReaderSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/operation/DefaultResponseMessageReaderSpec.groovy
@@ -25,6 +25,7 @@ import org.springframework.plugin.core.OrderAwarePluginRegistry
 import org.springframework.plugin.core.PluginRegistry
 import org.springframework.web.bind.annotation.RequestMethod
 import springfox.documentation.schema.DefaultTypeNameProvider
+import springfox.documentation.schema.JacksonEnumTypeDeterminer
 import springfox.documentation.schema.TypeNameExtractor
 import springfox.documentation.schema.mixins.SchemaPluginsSupport
 import springfox.documentation.service.ResponseMessage
@@ -42,7 +43,7 @@ class DefaultResponseMessageReaderSpec extends DocumentationContextSpec {
   def setup() {
     PluginRegistry<TypeNameProviderPlugin, DocumentationType> modelNameRegistry =
         OrderAwarePluginRegistry.create([new DefaultTypeNameProvider()])
-    def typeNameExtractor = new TypeNameExtractor(new TypeResolver(),  modelNameRegistry)
+    def typeNameExtractor = new TypeNameExtractor(new TypeResolver(), modelNameRegistry, new JacksonEnumTypeDeterminer())
     sut = new ResponseMessagesReader(typeNameExtractor)
   }
 

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/operation/OperationResponseClassReaderSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/operation/OperationResponseClassReaderSpec.groovy
@@ -23,6 +23,7 @@ import com.fasterxml.classmate.TypeResolver
 import org.springframework.plugin.core.OrderAwarePluginRegistry
 import org.springframework.plugin.core.PluginRegistry
 import springfox.documentation.schema.DefaultTypeNameProvider
+import springfox.documentation.schema.JacksonEnumTypeDeterminer
 import springfox.documentation.schema.TypeNameExtractor
 import springfox.documentation.schema.mixins.SchemaPluginsSupport
 import springfox.documentation.spi.DocumentationType
@@ -41,7 +42,7 @@ class OperationResponseClassReaderSpec extends DocumentationContextSpec {
   def setup() {
     PluginRegistry<TypeNameProviderPlugin, DocumentationType> modelNameRegistry =
         OrderAwarePluginRegistry.create([new DefaultTypeNameProvider()])
-    def typeNameExtractor = new TypeNameExtractor(new TypeResolver(),  modelNameRegistry)
+    def typeNameExtractor = new TypeNameExtractor(new TypeResolver(), modelNameRegistry, new JacksonEnumTypeDeterminer())
 
     sut = new OperationResponseClassReader(typeNameExtractor)
   }

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/parameter/ExpandedParameterBuilderSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/parameter/ExpandedParameterBuilderSpec.groovy
@@ -6,6 +6,7 @@ import spock.lang.Specification
 import spock.lang.Unroll
 import springfox.documentation.builders.ParameterBuilder
 import springfox.documentation.schema.ExampleEnum
+import springfox.documentation.schema.JacksonEnumTypeDeterminer
 import springfox.documentation.schema.property.field.FieldProvider
 import springfox.documentation.spi.DocumentationType
 import springfox.documentation.spi.service.contexts.ParameterExpansionContext
@@ -13,7 +14,7 @@ import springfox.documentation.spi.service.contexts.ParameterExpansionContext
 class ExpandedParameterBuilderSpec extends Specification {
   def "List of enums are expanded correctly" () {
     given:
-      ExpandedParameterBuilder sut = new ExpandedParameterBuilder(new TypeResolver())
+      ExpandedParameterBuilder sut = new ExpandedParameterBuilder(new TypeResolver(), new JacksonEnumTypeDeterminer())
     and:
       ParameterExpansionContext context = new ParameterExpansionContext(
         "Test",
@@ -37,7 +38,7 @@ class ExpandedParameterBuilderSpec extends Specification {
   @Unroll
   def "List of scalar type for #field is expanded correctly" () {
     given:
-      ExpandedParameterBuilder sut = new ExpandedParameterBuilder(new TypeResolver())
+      ExpandedParameterBuilder sut = new ExpandedParameterBuilder(new TypeResolver(), new JacksonEnumTypeDeterminer())
     and:
       ParameterExpansionContext context = new ParameterExpansionContext(
         "Test",

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/parameter/ModelAttributeParameterExpanderSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/parameter/ModelAttributeParameterExpanderSpec.groovy
@@ -21,7 +21,9 @@ package springfox.documentation.spring.web.readers.parameter
 
 import com.fasterxml.classmate.TypeResolver
 import org.joda.time.LocalDateTime
+import springfox.documentation.schema.JacksonEnumTypeDeterminer
 import springfox.documentation.schema.property.field.FieldProvider
+import springfox.documentation.spi.schema.EnumTypeDeterminer
 import springfox.documentation.spring.web.dummy.models.Example
 import springfox.documentation.spring.web.dummy.models.ModelAttributeComplexTypeExample
 import springfox.documentation.spring.web.dummy.models.ModelAttributeExample
@@ -37,12 +39,14 @@ import static springfox.documentation.schema.AlternateTypeRules.*
 @Mixin([ServicePluginsSupport])
 class ModelAttributeParameterExpanderSpec extends DocumentationContextSpec {
   TypeResolver typeResolver
+  EnumTypeDeterminer enumTypeDeterminer;
   ModelAttributeParameterExpander sut
 
   def setup() {
     typeResolver = new TypeResolver()
+    enumTypeDeterminer=new JacksonEnumTypeDeterminer();
     plugin.alternateTypeRules(newRule(typeResolver.resolve(LocalDateTime), typeResolver.resolve(String)))
-    sut = new ModelAttributeParameterExpander(new FieldProvider(typeResolver))
+    sut = new ModelAttributeParameterExpander(new FieldProvider(typeResolver), enumTypeDeterminer)
     sut.pluginsManager = defaultWebPlugins()
   }
 
@@ -129,7 +133,7 @@ class ModelAttributeParameterExpanderSpec extends DocumentationContextSpec {
   def "Should return empty set when there is an exception"() {
     given:
     ModelAttributeParameterExpander expander =
-        new ModelAttributeParameterExpander(new FieldProvider(typeResolver)) {
+        new ModelAttributeParameterExpander(new FieldProvider(typeResolver), enumTypeDeterminer) {
           @Override
           def BeanInfo getBeanInfo(Class<?> clazz) throws IntrospectionException {
             throw new IntrospectionException("Fail")

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/parameter/OperationParameterReaderSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/parameter/OperationParameterReaderSpec.groovy
@@ -23,9 +23,11 @@ import com.fasterxml.classmate.TypeResolver
 import org.joda.time.LocalDateTime
 import org.springframework.validation.BindingResult
 import spock.lang.Unroll
+import springfox.documentation.schema.JacksonEnumTypeDeterminer
 import springfox.documentation.schema.property.field.FieldProvider
 import springfox.documentation.service.Parameter
 import springfox.documentation.spi.DocumentationType
+import springfox.documentation.spi.schema.EnumTypeDeterminer
 import springfox.documentation.spi.service.contexts.OperationContext
 import springfox.documentation.spring.web.dummy.DummyModels
 import springfox.documentation.spring.web.dummy.models.Example
@@ -50,6 +52,7 @@ class OperationParameterReaderSpec extends DocumentationContextSpec {
   def pluginsManager = defaultWebPlugins()
   def setup() {
     def typeResolver = new TypeResolver()
+    def enumTypeDeterminer = new JacksonEnumTypeDeterminer();
     plugin
             .ignoredParameterTypes(ServletRequest, ServletResponse, HttpServletRequest,
               HttpServletResponse, BindingResult, ServletContext,
@@ -60,9 +63,9 @@ class OperationParameterReaderSpec extends DocumentationContextSpec {
 
 
 
-    def expander = new ModelAttributeParameterExpander(new FieldProvider(typeResolver))
+    def expander = new ModelAttributeParameterExpander(new FieldProvider(typeResolver), enumTypeDeterminer)
     expander.pluginsManager = pluginsManager
-    sut = new OperationParameterReader(expander)
+    sut = new OperationParameterReader(expander, enumTypeDeterminer)
     sut.pluginsManager = pluginsManager
   }
 
@@ -187,7 +190,7 @@ class OperationParameterReaderSpec extends DocumentationContextSpec {
 
   def "OperationParameterReader supports all documentationTypes"() {
     given:
-      def sut = new OperationParameterReader(Mock(ModelAttributeParameterExpander))
+      def sut = new OperationParameterReader(Mock(ModelAttributeParameterExpander), Mock(EnumTypeDeterminer))
       sut.pluginsManager = defaultWebPlugins()
     expect:
       sut.supports(DocumentationType.SPRING_WEB)

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/parameter/ParameterDataTypeReaderSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/parameter/ParameterDataTypeReaderSpec.groovy
@@ -29,6 +29,7 @@ import spock.lang.Unroll
 import springfox.documentation.builders.ParameterBuilder
 import springfox.documentation.schema.DefaultGenericTypeNamingStrategy
 import springfox.documentation.schema.DefaultTypeNameProvider
+import springfox.documentation.schema.JacksonEnumTypeDeterminer
 import springfox.documentation.schema.TypeNameExtractor
 import springfox.documentation.schema.mixins.SchemaPluginsSupport
 import springfox.documentation.service.AllowableListValues
@@ -47,9 +48,9 @@ import springfox.documentation.spring.web.plugins.DocumentationContextSpec
 class ParameterDataTypeReaderSpec extends DocumentationContextSpec {
   PluginRegistry<TypeNameProviderPlugin, DocumentationType> modelNameRegistry =
       OrderAwarePluginRegistry.create([new DefaultTypeNameProvider()])
-  def typeNameExtractor = new TypeNameExtractor(new TypeResolver(),  modelNameRegistry)
+  def typeNameExtractor = new TypeNameExtractor(new TypeResolver(), modelNameRegistry, new JacksonEnumTypeDeterminer())
 
-  ParameterDataTypeReader sut = new ParameterDataTypeReader(typeNameExtractor, new TypeResolver())
+  ParameterDataTypeReader sut = new ParameterDataTypeReader(typeNameExtractor, new TypeResolver(), new JacksonEnumTypeDeterminer())
 
   def "Should support all documentation types"() {
     expect:
@@ -147,8 +148,8 @@ class ParameterDataTypeReaderSpec extends DocumentationContextSpec {
     when:
       PluginRegistry<TypeNameProviderPlugin, DocumentationType> modelNameRegistry =
         OrderAwarePluginRegistry.create([new DefaultTypeNameProvider()])
-      def typeNameExtractor = new TypeNameExtractor(new TypeResolver(),  modelNameRegistry)
-      def sut = new ParameterDataTypeReader(typeNameExtractor, new TypeResolver())
+      def typeNameExtractor = new TypeNameExtractor(new TypeResolver(), modelNameRegistry, new JacksonEnumTypeDeterminer())
+      def sut = new ParameterDataTypeReader(typeNameExtractor, new TypeResolver(), new JacksonEnumTypeDeterminer())
       sut.apply(parameterContext)
     then:
       parameterContext.parameterBuilder().build().modelRef.type == "List"

--- a/springfox-spring-web/src/test/java/springfox/documentation/spring/web/dummy/controllers/FeatureDemonstrationService.java
+++ b/springfox-spring-web/src/test/java/springfox/documentation/spring/web/dummy/controllers/FeatureDemonstrationService.java
@@ -39,7 +39,6 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.util.UriComponentsBuilder;
-import springfox.documentation.schema.EnumJsonFormatObject;
 import springfox.documentation.spring.web.dummy.models.*;
 
 import java.math.BigDecimal;

--- a/springfox-spring-web/src/test/java/springfox/documentation/spring/web/dummy/controllers/FeatureDemonstrationService.java
+++ b/springfox-spring-web/src/test/java/springfox/documentation/spring/web/dummy/controllers/FeatureDemonstrationService.java
@@ -39,17 +39,8 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.util.UriComponentsBuilder;
-import springfox.documentation.spring.web.dummy.models.Business;
-import springfox.documentation.spring.web.dummy.models.EnumType;
-import springfox.documentation.spring.web.dummy.models.Example;
-import springfox.documentation.spring.web.dummy.models.FancyPet;
-import springfox.documentation.spring.web.dummy.models.ModelAttributeExample;
-import springfox.documentation.spring.web.dummy.models.ModelWithArrayOfArrays;
-import springfox.documentation.spring.web.dummy.models.ModelWithMapProperty;
-import springfox.documentation.spring.web.dummy.models.ModelWithObjectNode;
-import springfox.documentation.spring.web.dummy.models.NestedType;
-import springfox.documentation.spring.web.dummy.models.Pet;
-import springfox.documentation.spring.web.dummy.models.PetWithSerializer;
+import springfox.documentation.schema.EnumJsonFormatObject;
+import springfox.documentation.spring.web.dummy.models.*;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -96,6 +87,12 @@ public class FeatureDemonstrationService {
     return new ResponseEntity<List<Example>>(newArrayList(new Example("Hello", 1, EnumType.ONE,
         new NestedType("test"))),
         HttpStatus.OK);
+  }
+
+  //No request body annotation or swagger annotation
+  @RequestMapping(value = "/enumObject", method = RequestMethod.GET)
+  public ResponseEntity<EnumObjectType> getEnumAsObject() {
+    return ResponseEntity.ok(EnumObjectType.ONE);
   }
 
   //No request body annotation or swagger annotation

--- a/springfox-spring-web/src/test/java/springfox/documentation/spring/web/dummy/models/EnumObjectType.java
+++ b/springfox-spring-web/src/test/java/springfox/documentation/spring/web/dummy/models/EnumObjectType.java
@@ -1,0 +1,46 @@
+/*
+ *
+ *  Copyright 2015-2016 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+
+package springfox.documentation.spring.web.dummy.models;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+/**
+ * Created by yeh on 22.05.2017.
+ */
+
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+public enum EnumObjectType {
+    ONE("One", "This in an enum for number 1"), TWO("Two", "This in an enum for number 2");
+
+    private String name;
+    private String description;
+    EnumObjectType(String name, String description){
+        this.name=name;
+        this.description=description;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/parameter/ApiParamParameterBuilder.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/parameter/ApiParamParameterBuilder.java
@@ -30,6 +30,7 @@ import springfox.documentation.schema.Collections;
 import springfox.documentation.schema.Enums;
 import springfox.documentation.service.AllowableValues;
 import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.schema.EnumTypeDeterminer;
 import springfox.documentation.spi.service.ParameterBuilderPlugin;
 import springfox.documentation.spi.service.contexts.ParameterContext;
 import springfox.documentation.spring.web.DescriptionResolver;
@@ -43,10 +44,12 @@ import static springfox.documentation.swagger.common.SwaggerPluginSupport.*;
 @Order(SwaggerPluginSupport.SWAGGER_PLUGIN_ORDER)
 public class ApiParamParameterBuilder implements ParameterBuilderPlugin {
   private final DescriptionResolver descriptions;
+  private EnumTypeDeterminer enumTypeDeterminer;
 
   @Autowired
-  public ApiParamParameterBuilder(DescriptionResolver descriptions) {
+  public ApiParamParameterBuilder(DescriptionResolver descriptions, EnumTypeDeterminer enumTypeDeterminer) {
     this.descriptions = descriptions;
+    this.enumTypeDeterminer=enumTypeDeterminer;
   }
 
   @Override
@@ -82,7 +85,7 @@ public class ApiParamParameterBuilder implements ParameterBuilderPlugin {
     if (!isNullOrEmpty(allowableValueString)) {
       allowableValues = ApiModelProperties.allowableValueFromString(allowableValueString);
     } else {
-      if (parameterType.getErasedType().isEnum()) {
+      if (enumTypeDeterminer.isEnum(parameterType.getErasedType())) {
         allowableValues = Enums.allowableValues(parameterType.getErasedType());
       }
       if (Collections.isContainerType(parameterType)) {

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/parameter/SwaggerExpandedParameterBuilder.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/parameter/SwaggerExpandedParameterBuilder.java
@@ -29,6 +29,7 @@ import org.springframework.stereotype.Component;
 import springfox.documentation.service.AllowableListValues;
 import springfox.documentation.service.AllowableValues;
 import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.schema.EnumTypeDeterminer;
 import springfox.documentation.spi.service.ExpandedParameterBuilderPlugin;
 import springfox.documentation.spi.service.contexts.ParameterExpansionContext;
 import springfox.documentation.spring.web.DescriptionResolver;
@@ -49,10 +50,12 @@ import static springfox.documentation.swagger.schema.ApiModelProperties.*;
 @Order(SwaggerPluginSupport.SWAGGER_PLUGIN_ORDER)
 public class SwaggerExpandedParameterBuilder implements ExpandedParameterBuilderPlugin {
   private final DescriptionResolver descriptions;
+  private EnumTypeDeterminer enumTypeDeterminer;
 
   @Autowired
-  public SwaggerExpandedParameterBuilder(DescriptionResolver descriptions) {
+  public SwaggerExpandedParameterBuilder(DescriptionResolver descriptions, EnumTypeDeterminer enumTypeDeterminer) {
     this.descriptions = descriptions;
+    this.enumTypeDeterminer=enumTypeDeterminer;
   }
 
   @Override
@@ -102,12 +105,11 @@ public class SwaggerExpandedParameterBuilder implements ExpandedParameterBuilder
   private AllowableValues allowableValues(final Optional<String> optionalAllowable, final Field field) {
 
     AllowableValues allowable = null;
-    if (field.getType().isEnum()) {
+    if (enumTypeDeterminer.isEnum(field.getType())) {
       allowable = new AllowableListValues(getEnumValues(field.getType()), "LIST");
     } else if (optionalAllowable.isPresent()) {
       allowable = ApiModelProperties.allowableValueFromString(optionalAllowable.get());
     }
-
     return allowable;
   }
 

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/mixins/SwaggerPluginsSupport.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/mixins/SwaggerPluginsSupport.groovy
@@ -22,6 +22,7 @@ package springfox.documentation.swagger.mixins
 import com.fasterxml.classmate.TypeResolver
 import org.springframework.mock.env.MockEnvironment
 import org.springframework.plugin.core.PluginRegistry
+import springfox.documentation.schema.JacksonEnumTypeDeterminer
 import springfox.documentation.schema.plugins.SchemaPluginsManager
 import springfox.documentation.spi.DocumentationType
 import springfox.documentation.spi.schema.ModelBuilderPlugin
@@ -58,12 +59,13 @@ class SwaggerPluginsSupport {
 
   DocumentationPluginsManager swaggerServicePlugins(List<DefaultsProviderPlugin> swaggerDefaultsPlugins) {
     def resolver = new TypeResolver()
+    def enumTypeDeterminer = new JacksonEnumTypeDeterminer();
     def plugins = new DocumentationPluginsManager()
     plugins.apiListingPlugins = create(newArrayList(new MediaTypeReader(), new SwaggerApiListingReader()))
     plugins.documentationPlugins = create([])
     def descriptions = new DescriptionResolver(new MockEnvironment())
     plugins.parameterExpanderPlugins =
-        create([new ExpandedParameterBuilder(resolver), new SwaggerExpandedParameterBuilder(descriptions)])
+        create([new ExpandedParameterBuilder(resolver, enumTypeDeterminer), new SwaggerExpandedParameterBuilder(descriptions, enumTypeDeterminer)])
     plugins.parameterPlugins = create([new ParameterNameReader(),
                                        new ParameterNameReader()])
     plugins.operationBuilderPlugins = create([])

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/operation/OperationImplicitParamsReaderSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/operation/OperationImplicitParamsReaderSpec.groovy
@@ -21,6 +21,7 @@ package springfox.documentation.swagger.readers.operation
 
 import com.fasterxml.classmate.TypeResolver
 import org.springframework.mock.env.MockEnvironment
+import springfox.documentation.schema.JacksonEnumTypeDeterminer
 import springfox.documentation.schema.property.field.FieldProvider
 import springfox.documentation.spi.DocumentationType
 import springfox.documentation.spi.service.contexts.OperationContext
@@ -40,11 +41,11 @@ class OperationImplicitParamsReaderSpec extends DocumentationContextSpec {
         operationContext(context(), handlerMethod, 0)
 
       def resolver = new TypeResolver()
-
+    def enumTypeDeterminer=new JacksonEnumTypeDeterminer();
       def plugins = defaultWebPlugins()
-      def expander = new ModelAttributeParameterExpander(new FieldProvider(resolver))
+      def expander = new ModelAttributeParameterExpander(new FieldProvider(resolver), enumTypeDeterminer)
       expander.pluginsManager = plugins
-      OperationParameterReader sut = new OperationParameterReader(expander)
+      OperationParameterReader sut = new OperationParameterReader(expander, enumTypeDeterminer)
       sut.pluginsManager = plugins
       def env = new DescriptionResolver(new MockEnvironment())
       OperationImplicitParametersReader operationImplicitParametersReader = new OperationImplicitParametersReader(env)

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/operation/SwaggerOperationResponseClassReaderSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/operation/SwaggerOperationResponseClassReaderSpec.groovy
@@ -24,6 +24,7 @@ import org.springframework.plugin.core.OrderAwarePluginRegistry
 import org.springframework.plugin.core.PluginRegistry
 import spock.lang.Unroll
 import springfox.documentation.schema.DefaultTypeNameProvider
+import springfox.documentation.schema.JacksonEnumTypeDeterminer
 import springfox.documentation.schema.TypeNameExtractor
 import springfox.documentation.spi.DocumentationType
 import springfox.documentation.spi.schema.TypeNameProviderPlugin
@@ -39,7 +40,7 @@ class SwaggerOperationResponseClassReaderSpec extends DocumentationContextSpec {
     given:
       PluginRegistry<TypeNameProviderPlugin, DocumentationType> modelNameRegistry =
         OrderAwarePluginRegistry.create([new DefaultTypeNameProvider()])
-      def typeNameExtractor = new TypeNameExtractor(new TypeResolver(),  modelNameRegistry)
+      def typeNameExtractor = new TypeNameExtractor(new TypeResolver(), modelNameRegistry, new JacksonEnumTypeDeterminer())
       OperationContext operationContext =
         operationContext(context(), handlerMethod)
 

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/operation/SwaggerResponseMessageReaderSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/operation/SwaggerResponseMessageReaderSpec.groovy
@@ -24,6 +24,7 @@ import org.springframework.plugin.core.OrderAwarePluginRegistry
 import org.springframework.plugin.core.PluginRegistry
 import spock.lang.Unroll
 import springfox.documentation.schema.DefaultTypeNameProvider
+import springfox.documentation.schema.JacksonEnumTypeDeterminer
 import springfox.documentation.schema.ModelRef
 import springfox.documentation.schema.ModelReference
 import springfox.documentation.schema.TypeNameExtractor
@@ -48,7 +49,7 @@ class SwaggerResponseMessageReaderSpec extends DocumentationContextSpec {
         OrderAwarePluginRegistry.create([new DefaultTypeNameProvider()])
 
       def resolver = new TypeResolver()
-      def typeNameExtractor = new TypeNameExtractor(resolver,  modelNameRegistry)
+      def typeNameExtractor = new TypeNameExtractor(resolver,  modelNameRegistry, new JacksonEnumTypeDeterminer())
 
     when:
       new SwaggerResponseMessageReader(typeNameExtractor, resolver).apply(operationContext)
@@ -76,7 +77,7 @@ class SwaggerResponseMessageReaderSpec extends DocumentationContextSpec {
           OrderAwarePluginRegistry.create([new DefaultTypeNameProvider()])
 
       def resolver = new TypeResolver()
-      def typeNameExtractor = new TypeNameExtractor(resolver,  modelNameRegistry)
+      def typeNameExtractor = new TypeNameExtractor(resolver,  modelNameRegistry, new JacksonEnumTypeDeterminer())
 
     when:
       new SwaggerResponseMessageReader(typeNameExtractor, resolver).apply(operationContext)
@@ -105,7 +106,7 @@ class SwaggerResponseMessageReaderSpec extends DocumentationContextSpec {
           OrderAwarePluginRegistry.create([new DefaultTypeNameProvider()])
 
       def resolver = new TypeResolver()
-      def typeNameExtractor = new TypeNameExtractor(resolver,  modelNameRegistry)
+      def typeNameExtractor = new TypeNameExtractor(resolver,  modelNameRegistry, new JacksonEnumTypeDeterminer())
 
     when:
       new SwaggerResponseMessageReader(typeNameExtractor, resolver).apply(operationContext)
@@ -166,7 +167,7 @@ class SwaggerResponseMessageReaderSpec extends DocumentationContextSpec {
         OrderAwarePluginRegistry.create([new DefaultTypeNameProvider()])
 
       def resolver = new TypeResolver()
-      def typeNameExtractor = new TypeNameExtractor(resolver,  modelNameRegistry)
+      def typeNameExtractor = new TypeNameExtractor(resolver,  modelNameRegistry, new JacksonEnumTypeDeterminer())
 
     when:
       def sut = new SwaggerResponseMessageReader(typeNameExtractor, resolver)

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/parameter/ApiParamParameterBuilderSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/parameter/ApiParamParameterBuilderSpec.groovy
@@ -27,10 +27,12 @@ import org.springframework.mock.env.MockEnvironment
 import spock.lang.Unroll
 import springfox.documentation.builders.ParameterBuilder
 import springfox.documentation.schema.DefaultGenericTypeNamingStrategy
+import springfox.documentation.schema.JacksonEnumTypeDeterminer
 import springfox.documentation.service.AllowableListValues
 import springfox.documentation.service.AllowableRangeValues
 import springfox.documentation.service.ResolvedMethodParameter
 import springfox.documentation.spi.DocumentationType
+import springfox.documentation.spi.schema.EnumTypeDeterminer
 import springfox.documentation.spi.service.contexts.OperationContext
 import springfox.documentation.spi.service.contexts.ParameterContext
 import springfox.documentation.spring.web.DescriptionResolver
@@ -56,7 +58,9 @@ class ApiParamParameterBuilderSpec extends DocumentationContextSpec implements A
           Mock(OperationContext))
 
     when:
-      ApiParamParameterBuilder operationCommand = new ApiParamParameterBuilder();
+      DescriptionResolver descriptions = new DescriptionResolver(new MockEnvironment())
+      EnumTypeDeterminer enumTypeDeterminer=new JacksonEnumTypeDeterminer()
+      ApiParamParameterBuilder operationCommand = new ApiParamParameterBuilder(descriptions, enumTypeDeterminer);
       operationCommand.apply(parameterContext)
       AllowableListValues allowableValues = parameterContext.parameterBuilder().build().allowableValues as AllowableListValues
     then:
@@ -125,7 +129,9 @@ class ApiParamParameterBuilderSpec extends DocumentationContextSpec implements A
 
   def "supports all swagger types" () {
     given:
-      ApiParamParameterBuilder sut = new ApiParamParameterBuilder()
+      DescriptionResolver descriptions = new DescriptionResolver(new MockEnvironment())
+      EnumTypeDeterminer enumTypeDeterminer=new JacksonEnumTypeDeterminer()
+      ApiParamParameterBuilder sut = new ApiParamParameterBuilder(descriptions, enumTypeDeterminer)
     expect:
       sut.supports(documentationType)
     where:
@@ -134,7 +140,8 @@ class ApiParamParameterBuilderSpec extends DocumentationContextSpec implements A
 
   def stubbedParamBuilder(ApiParam apiParamAnnotation) {
     def descriptions = new DescriptionResolver(new MockEnvironment())
-    new ApiParamParameterBuilder(descriptions) {
+    def enumTypeDeterminer=new JacksonEnumTypeDeterminer()
+    new ApiParamParameterBuilder(descriptions, enumTypeDeterminer) {
     }
   }
 

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/parameter/ModelAttributeParameterExpanderSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/parameter/ModelAttributeParameterExpanderSpec.groovy
@@ -23,9 +23,11 @@ import com.fasterxml.classmate.TypeResolver
 import org.joda.time.LocalDateTime
 import org.springframework.beans.factory.annotation.Autowired
 import springfox.documentation.schema.AlternateTypeRule
+import springfox.documentation.schema.JacksonEnumTypeDeterminer
 import springfox.documentation.schema.WildcardType
 import springfox.documentation.schema.property.field.FieldProvider
 import springfox.documentation.spi.DocumentationType
+import springfox.documentation.spi.schema.EnumTypeDeterminer
 import springfox.documentation.spi.service.DefaultsProviderPlugin
 import springfox.documentation.spi.service.contexts.Defaults
 import springfox.documentation.spi.service.contexts.DocumentationContextBuilder
@@ -44,12 +46,14 @@ import static springfox.documentation.schema.AlternateTypeRules.*
 @Mixin([SwaggerPluginsSupport])
 class ModelAttributeParameterExpanderSpec extends DocumentationContextSpec {
   TypeResolver typeResolver
+  EnumTypeDeterminer enumTypeDeterminer;
   ModelAttributeParameterExpander sut
 
   def setup() {
     typeResolver = new TypeResolver()
+    enumTypeDeterminer=new JacksonEnumTypeDeterminer();
     plugin.alternateTypeRules(newRule(typeResolver.resolve(LocalDateTime), typeResolver.resolve(String)))
-    sut = new ModelAttributeParameterExpander(new FieldProvider(typeResolver))
+    sut = new ModelAttributeParameterExpander(new FieldProvider(typeResolver) ,enumTypeDeterminer)
     sut.pluginsManager = swaggerServicePlugins([new SwaggerDefaults(new Defaults(), new TypeResolver(),
         Mock(ServletContext))])
   }

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/parameter/ParameterMultiplesReaderSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/parameter/ParameterMultiplesReaderSpec.groovy
@@ -27,6 +27,7 @@ import org.springframework.mock.env.MockEnvironment
 import spock.lang.Unroll
 import springfox.documentation.builders.ParameterBuilder
 import springfox.documentation.schema.DefaultGenericTypeNamingStrategy
+import springfox.documentation.schema.JacksonEnumTypeDeterminer
 import springfox.documentation.service.ResolvedMethodParameter
 import springfox.documentation.spi.service.contexts.OperationContext
 import springfox.documentation.spi.service.contexts.ParameterContext
@@ -39,6 +40,7 @@ import springfox.documentation.spring.web.plugins.DocumentationContextSpec
 @Mixin([RequestMappingSupport, ModelProviderForServiceSupport])
 class ParameterMultiplesReaderSpec extends DocumentationContextSpec implements ApiParamAnnotationSupport {
   def descriptions = new DescriptionResolver(new MockEnvironment())
+  def enumTypeDeterminer=new JacksonEnumTypeDeterminer()
   @Unroll
   def "param multiples for swagger reader"() {
     given:
@@ -71,7 +73,7 @@ class ParameterMultiplesReaderSpec extends DocumentationContextSpec implements A
   }
 
   def stubbedParamBuilder(ApiParam apiParamAnnotation) {
-    new ApiParamParameterBuilder(descriptions) {
+    new ApiParamParameterBuilder(descriptions, enumTypeDeterminer) {
     }
   }
 }

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/parameter/ParameterNameReaderSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/parameter/ParameterNameReaderSpec.groovy
@@ -23,6 +23,7 @@ import com.fasterxml.classmate.TypeResolver
 import org.springframework.mock.env.MockEnvironment
 import springfox.documentation.builders.ParameterBuilder
 import springfox.documentation.schema.DefaultGenericTypeNamingStrategy
+import springfox.documentation.schema.JacksonEnumTypeDeterminer
 import springfox.documentation.service.ResolvedMethodParameter
 import springfox.documentation.spi.DocumentationType
 import springfox.documentation.spi.service.contexts.OperationContext
@@ -34,10 +35,12 @@ import springfox.documentation.spring.web.plugins.DocumentationContextSpec
 
 @Mixin([RequestMappingSupport, ModelProviderForServiceSupport])
 class ParameterNameReaderSpec extends DocumentationContextSpec implements ApiParamAnnotationSupport {
+  def descriptions = new DescriptionResolver(new MockEnvironment())
+  def enumTypeDeterminer=new JacksonEnumTypeDeterminer()
 
   def "Should all swagger documentation types"() {
     given:
-      def sut = new ApiParamParameterBuilder()
+      def sut = new ApiParamParameterBuilder(descriptions, enumTypeDeterminer)
     expect:
       !sut.supports(DocumentationType.SPRING_WEB)
       sut.supports(DocumentationType.SWAGGER_12)
@@ -68,7 +71,8 @@ class ParameterNameReaderSpec extends DocumentationContextSpec implements ApiPar
 
   def nameReader(annotation) {
     def descriptions = new DescriptionResolver(new MockEnvironment())
-    new ApiParamParameterBuilder(descriptions) {
+    def enumTypeDeterminer=new JacksonEnumTypeDeterminer()
+    new ApiParamParameterBuilder(descriptions, enumTypeDeterminer) {
     }
   }
 }

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/parameter/ParameterReaderSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/parameter/ParameterReaderSpec.groovy
@@ -25,6 +25,7 @@ import org.springframework.mock.env.MockEnvironment
 import spock.lang.Unroll
 import springfox.documentation.builders.ParameterBuilder
 import springfox.documentation.schema.DefaultGenericTypeNamingStrategy
+import springfox.documentation.schema.JacksonEnumTypeDeterminer
 import springfox.documentation.service.ResolvedMethodParameter
 import springfox.documentation.spi.DocumentationType
 import springfox.documentation.spi.service.contexts.OperationContext
@@ -37,6 +38,7 @@ import springfox.documentation.spring.web.plugins.DocumentationContextSpec
 @Mixin([RequestMappingSupport, ModelProviderForServiceSupport])
 class ParameterReaderSpec extends DocumentationContextSpec implements ApiParamAnnotationSupport {
   def descriptions = new DescriptionResolver(new MockEnvironment())
+  def enumTypeDeterminer=new JacksonEnumTypeDeterminer()
 
   @Unroll("property #resultProperty expected: #expected")
   def "should set basic properties based on ApiParam annotation or a sensible default"() {
@@ -67,7 +69,7 @@ class ParameterReaderSpec extends DocumentationContextSpec implements ApiParamAn
   }
 
   def stubbedParamBuilder(ApiParam apiParamAnnotation) {
-    new ApiParamParameterBuilder(descriptions) {
+    new ApiParamParameterBuilder(descriptions, enumTypeDeterminer) {
     }
   }
 }

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/parameter/ParameterRequiredReaderSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/parameter/ParameterRequiredReaderSpec.groovy
@@ -23,6 +23,7 @@ import com.fasterxml.classmate.TypeResolver
 import org.springframework.mock.env.MockEnvironment
 import springfox.documentation.builders.ParameterBuilder
 import springfox.documentation.schema.DefaultGenericTypeNamingStrategy
+import springfox.documentation.schema.JacksonEnumTypeDeterminer
 import springfox.documentation.service.ResolvedMethodParameter
 import springfox.documentation.spi.service.contexts.OperationContext
 import springfox.documentation.spi.service.contexts.ParameterContext
@@ -33,6 +34,7 @@ import springfox.documentation.spring.web.plugins.DocumentationContextSpec
 @Mixin([RequestMappingSupport])
 class ParameterRequiredReaderSpec extends DocumentationContextSpec implements ApiParamAnnotationSupport {
   def descriptions = new DescriptionResolver(new MockEnvironment())
+  def enumTypeDeterminer=new JacksonEnumTypeDeterminer()
   
   def "parameters required using default reader"() {
     given:
@@ -80,6 +82,6 @@ class ParameterRequiredReaderSpec extends DocumentationContextSpec implements Ap
   }
 
   def stubbedParamBuilder() {
-    new ApiParamParameterBuilder(descriptions)
+    new ApiParamParameterBuilder(descriptions, enumTypeDeterminer)
   }
 }

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/parameter/SwaggerExpandedParameterBuilderSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/parameter/SwaggerExpandedParameterBuilderSpec.groovy
@@ -26,6 +26,7 @@ import org.springframework.mock.env.MockEnvironment
 import spock.lang.Specification
 import springfox.documentation.builders.ParameterBuilder
 import springfox.documentation.schema.ExampleEnum
+import springfox.documentation.schema.JacksonEnumTypeDeterminer
 import springfox.documentation.schema.property.field.FieldProvider
 import springfox.documentation.spi.DocumentationType
 import springfox.documentation.spi.service.contexts.ParameterExpansionContext
@@ -35,7 +36,7 @@ class SwaggerExpandedParameterBuilderSpec extends Specification {
   def "Swagger parameter expander expands as expected" () {
     given:
       def env = new DescriptionResolver(new MockEnvironment())
-      SwaggerExpandedParameterBuilder sut = new SwaggerExpandedParameterBuilder(env)
+      SwaggerExpandedParameterBuilder sut = new SwaggerExpandedParameterBuilder(env, new JacksonEnumTypeDeterminer())
     and:
       ParameterExpansionContext context = new ParameterExpansionContext("Test", "", field,
           DocumentationType.SWAGGER_12, new ParameterBuilder())

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/schema/ApiModelPropertyPropertyBuilderSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/schema/ApiModelPropertyPropertyBuilderSpec.groovy
@@ -156,7 +156,7 @@ class ApiModelPropertyPropertyBuilderSpec extends Specification {
           ImmutableSet.builder().build())
       PluginRegistry<TypeNameProviderPlugin, DocumentationType> modelNameRegistry =
         OrderAwarePluginRegistry.create([new DefaultTypeNameProvider()])
-      def typeNameExtractor = new TypeNameExtractor(resolver,  modelNameRegistry)
+      def typeNameExtractor = new TypeNameExtractor(resolver,  modelNameRegistry, new JacksonEnumTypeDeterminer())
       def context = new ModelPropertyContext(new ModelPropertyBuilder(),
               properties.find { it.name == property }.getter.annotated, resolver,
               DocumentationType.SWAGGER_12)
@@ -193,7 +193,7 @@ class ApiModelPropertyPropertyBuilderSpec extends Specification {
           ImmutableSet.builder().build())
       PluginRegistry<TypeNameProviderPlugin, DocumentationType> modelNameRegistry =
         OrderAwarePluginRegistry.create([new DefaultTypeNameProvider()])
-      def typeNameExtractor = new TypeNameExtractor(resolver,  modelNameRegistry)
+      def typeNameExtractor = new TypeNameExtractor(resolver,  modelNameRegistry, new JacksonEnumTypeDeterminer())
       def context = new ModelPropertyContext(new ModelPropertyBuilder(),
               properties.find { it.name == property }.getter.annotated, resolver,
               DocumentationType.SWAGGER_12)

--- a/springfox-swagger1/src/test/groovy/springfox/documentation/swagger1/readers/parameter/OperationParameterReaderSpec.groovy
+++ b/springfox-swagger1/src/test/groovy/springfox/documentation/swagger1/readers/parameter/OperationParameterReaderSpec.groovy
@@ -24,6 +24,7 @@ import org.springframework.validation.BindingResult
 import org.springframework.web.bind.annotation.RequestMethod
 import org.springframework.web.method.HandlerMethod
 import springfox.documentation.builders.OperationBuilder
+import springfox.documentation.schema.JacksonEnumTypeDeterminer
 import springfox.documentation.schema.property.field.FieldProvider
 import springfox.documentation.service.Parameter
 import springfox.documentation.spi.service.contexts.Defaults
@@ -57,6 +58,7 @@ class OperationParameterReaderSpec extends DocumentationContextSpec {
 
   def setup() {
     def typeResolver = new TypeResolver()
+    def enumTypeDeterminer=new JacksonEnumTypeDeterminer();
     pluginsManager = swaggerServicePlugins([new SwaggerDefaultConfiguration(new Defaults(), typeResolver, Mock(ServletContext))])
     plugin
             .ignoredParameterTypes(ServletRequest, ServletResponse, HttpServletRequest,
@@ -65,10 +67,10 @@ class OperationParameterReaderSpec extends DocumentationContextSpec {
             .alternateTypeRules(newRule(typeResolver.resolve(LocalDateTime), typeResolver.resolve(String)))
             .configure(contextBuilder)
 
-    def expander = new ModelAttributeParameterExpander(new FieldProvider(new TypeResolver()))
+    def expander = new ModelAttributeParameterExpander(new FieldProvider(new TypeResolver()), new JacksonEnumTypeDeterminer())
     expander.pluginsManager = pluginsManager
 
-    sut = new OperationParameterReader(expander)
+    sut = new OperationParameterReader(expander, enumTypeDeterminer)
     sut.pluginsManager = pluginsManager
   }
 

--- a/swagger-contract-tests/src/test/resources/contract/swagger/declaration-feature-demonstration-service.json
+++ b/swagger-contract-tests/src/test/resources/contract/swagger/declaration-feature-demonstration-service.json
@@ -1292,6 +1292,45 @@
       "path": "/features/effectives"
     },
     {
+      "description": "getEnumObject",
+      "operations": [
+        {
+          "method": "GET",
+          "summary": "getEnumObject",
+          "nickname": "getEnumObjectUsingGET",
+          "produces": [
+            "*/*"
+          ],
+          "consumes": [
+            "application/json"
+          ],
+          "parameters": [],
+          "responseMessages": [
+            {
+              "code": 200,
+              "message": "OK",
+              "responseModel": "EnumObjectType"
+            },
+            {
+              "code": 401,
+              "message": "Unauthorized"
+            },
+            {
+              "code": 403,
+              "message": "Forbidden"
+            },
+            {
+              "code": 404,
+              "message": "Not Found"
+            }
+          ],
+          "deprecated": "false",
+          "type": "EnumObjectType"
+        }
+      ],
+      "path": "/features/enumObject"
+    },
+    {
       "description": "updateListOfExamples",
       "operations": [
         {
@@ -1925,6 +1964,20 @@
         },
         "readOnlyString": {
           "description": "A read only string",
+          "required": false,
+          "type": "string"
+        }
+      }
+    },
+    "EnumObjectType": {
+      "description": "",
+      "id": "EnumObjectType",
+      "properties": {
+        "name": {
+          "required": false,
+          "type": "string"
+        },
+        "description": {
           "required": false,
           "type": "string"
         }

--- a/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-feature-demonstration-service.json
+++ b/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-feature-demonstration-service.json
@@ -696,6 +696,29 @@
         }
       }
     },
+    "/features/enumObject": {
+      "get": {
+        "tags": [
+          "enum-object-demonstration-service"
+        ],
+        "summary": "getEnumObject",
+        "operationId": "getEnumObjectUsingGET",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "*/*"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/EnumObjectType"
+            }
+          }
+        }
+      }
+    },
     "/features/examples": {
       "put": {
         "tags": [

--- a/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-root-controller.json
+++ b/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-root-controller.json
@@ -1752,10 +1752,30 @@
           "200": {
             "description": "OK",
             "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Example"
-              }
+              "$ref": "#/definitions/Example"
+            }
+          }
+        }
+      }
+    },
+    "/features/enumObject": {
+      "get": {
+        "tags": [
+          "enum-object-demonstration-service"
+        ],
+        "summary": "getEnumObject",
+        "operationId": "getEnumObjectUsingGET",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "*/*"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/EnumObjectType"
             }
           }
         }
@@ -3272,6 +3292,17 @@
           "type": "string"
         },
         "propertyWithNoSetterMethod": {
+          "type": "string"
+        }
+      }
+    },
+    "EnumObjectType": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
           "type": "string"
         }
       }


### PR DESCRIPTION
#### What's this PR do/fix?
Handles JsonFormat.Shape.Object when used on Enums properly. to Threat them as objects instead of Enums
#### Are there unit tests? If not how should this be manually tested?
Yes
#### Any background context you want to provide?
Mabye it's a good idea to provide integration tests
#### What are the relevant issues?
https://github.com/springfox/springfox/issues/1818
