### PR TITLE
Minor update of Docket's JavaDoc

### DIFF
--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/plugins/Docket.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/plugins/Docket.java
@@ -61,7 +61,7 @@ import static springfox.documentation.builders.BuilderDefaults.*;
 import static springfox.documentation.schema.AlternateTypeRules.*;
 
 /**
- * A builder which is intended to be the primary interface into the swagger-springmvc framework.
+ * A builder which is intended to be the primary interface into the Springfox framework.
  * Provides sensible defaults and convenience methods for configuration.
  */
 public class Docket implements DocumentationPlugin {


### PR DESCRIPTION
#### What's this PR do/fix?
Replace the use of the framework's legacy name in the Javadoc with 'Springfox'
#### Are there unit tests? If not how should this be manually tested?
#### Any background context you want to provide?
#### What are the relevant issues?
