### PR TITLE
Create EntitySaveExtractor.java

### DIFF
--- a/springfox-data-rest/src/main/java/springfox/documentation/spring/data/rest/EntitySaveExtractor.java
+++ b/springfox-data-rest/src/main/java/springfox/documentation/spring/data/rest/EntitySaveExtractor.java
@@ -64,6 +64,13 @@ class EntitySaveExtractor implements EntityOperationsExtractor {
           handler,
           context.getTypeResolver(), resource);
       handlers.add(new SpringDataRestRequestHandler(context, post));
+      ActionSpecification patch = saveActionSpecification(
+          entity,
+          RequestMethod.PATCH,
+          String.format("%s%s", context.basePath(), context.resourcePath()),
+          handler,
+          context.getTypeResolver(), resource);
+      handlers.add(new SpringDataRestRequestHandler(context, patch));
     }
     return handlers;
   }


### PR DESCRIPTION
https://github.com/springfox/springfox/issues/1866

After updating from 2.6.2-SNAPSHOT to 2.7.0, SpringDataRest patch requests are not listed.
Thought I can see that they are exposed by SDR
[/api/{repository}/{id}],methods=[PATCH]
