### PR TITLE
Preserve tags order in documentation builder

### DIFF
--- a/springfox-core/src/main/java/springfox/documentation/builders/DocumentationBuilder.java
+++ b/springfox-core/src/main/java/springfox/documentation/builders/DocumentationBuilder.java
@@ -21,7 +21,6 @@ package springfox.documentation.builders;
 
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Ordering;
-import com.google.common.collect.Sets;
 import com.google.common.collect.TreeMultimap;
 import springfox.documentation.service.ApiListing;
 import springfox.documentation.service.Documentation;

--- a/springfox-core/src/main/java/springfox/documentation/builders/DocumentationBuilder.java
+++ b/springfox-core/src/main/java/springfox/documentation/builders/DocumentationBuilder.java
@@ -21,6 +21,7 @@ package springfox.documentation.builders;
 
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Ordering;
+import com.google.common.collect.Sets;
 import com.google.common.collect.TreeMultimap;
 import springfox.documentation.service.ApiListing;
 import springfox.documentation.service.Documentation;
@@ -40,7 +41,7 @@ public class DocumentationBuilder {
   private String groupName;
   private Multimap<String, ApiListing> apiListings = TreeMultimap.create(Ordering.natural(), byListingPosition());
   private ResourceListing resourceListing;
-  private Set<Tag> tags = newHashSet();
+  private Set<Tag> tags = newLinkedHashSet();
   private String basePath;
   private Set<String> produces = newHashSet();
   private Set<String> consumes = newHashSet();

--- a/springfox-core/src/test/groovy/springfox/documentation/builders/DocumentationBuilderSpec.groovy
+++ b/springfox-core/src/test/groovy/springfox/documentation/builders/DocumentationBuilderSpec.groovy
@@ -24,7 +24,10 @@ import spock.lang.Specification
 import springfox.documentation.service.ApiListing
 import springfox.documentation.service.ListVendorExtension
 import springfox.documentation.service.ResourceListing
+import springfox.documentation.service.Tag
 import springfox.documentation.service.VendorExtension
+
+import static com.google.common.collect.Sets.newLinkedHashSet
 
 class DocumentationBuilderSpec extends Specification {
   def "Setting properties on the builder with non-null values"() {
@@ -95,5 +98,25 @@ class DocumentationBuilderSpec extends Specification {
       'host'                            | 'host1'                         | 'host'
       'schemes'                         | ['http']  as Set                | 'schemes'
       'tags'                            | ['pet'] as Set                  | 'tags'
+  }
+
+  def "Setting ordered tags should preserve ordering"() {
+    given:
+    def sut = new DocumentationBuilder()
+    def tags = newLinkedHashSet()
+    def firstTag = new Tag("First", "First")
+    def secondTag = new Tag("Second", "Second")
+    def thirdTag = new Tag("Third", "Third")
+    tags.add(firstTag)
+    tags.add(secondTag)
+    tags.add(thirdTag)
+    when:
+    sut.tags(tags)
+    and:
+    def builtDocumentationTags = sut.build().getTags()
+    then:
+      assert builtDocumentationTags[0] == firstTag
+      assert builtDocumentationTags[1] == secondTag
+      assert builtDocumentationTags[2] == thirdTag
   }
 }


### PR DESCRIPTION
#### What's this PR do/fix?
DocumentationBuilder preserves Tags order
#### Are there unit tests? If not how should this be manually tested?
There is unit test for that
#### Any background context you want to provide?
Tags are ordered with treeset and name comparator. So tags are ordered alphabetically. DocumentBuilder used to use HashSet whitch not preserve order.
#### What are the relevant issues?
https://github.com/springfox/springfox/issues/1875