### PR TITLE
Fix for issue 1916: Consumes / Produces media-types on the document level aren't copied and merged anymore with the operation level consumes / produces media-types.

### DIFF
--- a/springfox-spi/src/main/java/springfox/documentation/spi/service/contexts/OperationContext.java
+++ b/springfox-spi/src/main/java/springfox/documentation/spi/service/contexts/OperationContext.java
@@ -24,7 +24,6 @@ import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Sets;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -43,7 +42,6 @@ import java.util.Set;
 
 import static com.google.common.collect.Lists.*;
 import static springfox.documentation.builders.BuilderDefaults.*;
-import static springfox.documentation.service.MediaTypes.*;
 
 public class OperationContext {
   private final OperationBuilder operationBuilder;
@@ -119,14 +117,12 @@ public class OperationContext {
     return getAlternateTypeProvider().alternateFor(resolved);
   }
 
-  public Set<MediaType> produces() {
-    return Sets.union(requestContext.produces(),
-        toMediaTypes(getDocumentationContext().getProduces()));
+  public Set<? extends MediaType> produces() {
+    return requestContext.produces();
   }
 
-  public Set<MediaType> consumes() {
-    return Sets.union(requestContext.consumes(),
-        toMediaTypes(getDocumentationContext().getConsumes()));
+  public Set<? extends MediaType> consumes() {
+    return requestContext.consumes();
   }
 
   public ImmutableSet<Class> getIgnorableParameterTypes() {

--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/scanners/MediaTypeReader.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/scanners/MediaTypeReader.java
@@ -31,6 +31,7 @@ import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spi.service.ApiListingBuilderPlugin;
 import springfox.documentation.spi.service.OperationBuilderPlugin;
 import springfox.documentation.spi.service.contexts.ApiListingContext;
+import springfox.documentation.spi.service.contexts.DocumentationContext;
 import springfox.documentation.spi.service.contexts.OperationContext;
 
 import java.util.List;
@@ -47,21 +48,23 @@ public class MediaTypeReader implements OperationBuilderPlugin, ApiListingBuilde
   @Override
   public void apply(OperationContext context) {
 
-    Set<String> consumesList = toSet(context.consumes());
-    Set<String> producesList = toSet(context.produces());
+    DocumentationContext documentationContext = context.getDocumentationContext();
+
+    Set<String> operationConsumesList = toSet(context.consumes());
+    Set<String> operationProducesList = toSet(context.produces());
 
     if (handlerMethodHasFileParameter(context)) {
-      consumesList = newHashSet(MediaType.MULTIPART_FORM_DATA_VALUE);
+      operationConsumesList = newHashSet(MediaType.MULTIPART_FORM_DATA_VALUE);
     }
 
-    if (producesList.isEmpty()) {
-      producesList.add(MediaType.ALL_VALUE);
+    if (operationProducesList.isEmpty() && documentationContext.getProduces().isEmpty()) {
+      operationProducesList.add(MediaType.ALL_VALUE);
     }
-    if (consumesList.isEmpty()) {
-      consumesList.add(MediaType.APPLICATION_JSON_VALUE);
+    if (operationConsumesList.isEmpty() && documentationContext.getConsumes().isEmpty()) {
+      operationConsumesList.add(MediaType.APPLICATION_JSON_VALUE);
     }
-    context.operationBuilder().consumes(consumesList);
-    context.operationBuilder().produces(producesList);
+    context.operationBuilder().consumes(operationConsumesList);
+    context.operationBuilder().produces(operationProducesList);
   }
 
   @Override
@@ -93,7 +96,7 @@ public class MediaTypeReader implements OperationBuilderPlugin, ApiListingBuilde
     return false;
   }
 
-  private Set<String> toSet(Set<MediaType> mediaTypeSet) {
+  private Set<String> toSet(Set<? extends MediaType> mediaTypeSet) {
     Set<String> mediaTypes = newHashSet();
     for (MediaType mediaType : mediaTypeSet) {
       mediaTypes.add(mediaType.toString());

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/MediaTypeReaderSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/MediaTypeReaderSpec.groovy
@@ -49,8 +49,8 @@ class MediaTypeReaderSpec extends DocumentationContextSpec {
                         'producesRequestCondition': producesRequestCondition(produces)
                   ]
             )
-    OperationContext operationContext =
-        operationContext(context(), handlerMethod, 0, requestMappingInfo)
+      OperationContext operationContext =
+            operationContext(context(), handlerMethod, 0, requestMappingInfo)
 
     when:
       sut.apply(operationContext)
@@ -68,5 +68,58 @@ class MediaTypeReaderSpec extends DocumentationContextSpec {
       ['application/json', 'application/xml'] as String[] | ['application/xml'] as String[]  | dummyHandlerMethod()
   }
 
+  @Unroll
+  def "should only set default 'application/json' consumes if no consumes is set for the operation and document context"() {
+    given:
+      contextBuilder.consumes(newHashSet(documentConsumes))
+      RequestMappingInfo requestMappingInfo =
+              requestMappingInfo('/somePath',
+                      [
+                              'consumesRequestCondition': consumesRequestCondition(operationConsumes)
+                      ]
+              )
+      OperationContext operationContext =
+              operationContext(context(), dummyHandlerMethod(), 0, requestMappingInfo)
+
+    when:
+      sut.apply(operationContext)
+      def operation = operationContext.operationBuilder().build()
+
+    then:
+      operation.consumes == newHashSet(expectedOperationConsumes)
+
+    where:
+      documentConsumes                  | operationConsumes                 | expectedOperationConsumes
+      [] as String[]                    | [] as String[]                    | ['application/json'] as String[]
+      ['application/xml'] as String[]   | [] as String[]                    | [] as String[]
+      [] as String[]                    | ['application/xml'] as String[]   | ['application/xml'] as String[]
+  }
+
+  @Unroll
+  def "should only set default '*/*' produces if no produces is set for the operation and document context"() {
+    given:
+    contextBuilder.produces(newHashSet(documentProduces))
+    RequestMappingInfo requestMappingInfo =
+            requestMappingInfo('/somePath',
+                    [
+                            'producesRequestCondition': producesRequestCondition(operationProduces)
+                    ]
+            )
+    OperationContext operationContext =
+            operationContext(context(), dummyHandlerMethod(), 0, requestMappingInfo)
+
+    when:
+    sut.apply(operationContext)
+    def operation = operationContext.operationBuilder().build()
+
+    then:
+    operation.produces == newHashSet(expectedOperationProduces)
+
+    where:
+    documentProduces                  | operationProduces                 | expectedOperationProduces
+    [] as String[]                    | [] as String[]                    | ['*/*'] as String[]
+    ['application/xml'] as String[]   | [] as String[]                    | [] as String[]
+    [] as String[]                    | ['application/xml'] as String[]   | ['application/xml'] as String[]
+  }
 
 }

--- a/springfox-spring-web/src/test/java/springfox/documentation/spring/web/dummy/controllers/ConsumesProducesService.java
+++ b/springfox-spring-web/src/test/java/springfox/documentation/spring/web/dummy/controllers/ConsumesProducesService.java
@@ -1,0 +1,43 @@
+package springfox.documentation.spring.web.dummy.controllers;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+@Controller
+@Api(description = "Services to demonstrate produces/consumes override behaviour on document and operation level")
+@RequestMapping(path = "/consumes-produces")
+public class ConsumesProducesService {
+
+    @GetMapping("/without-operation-produces")
+    @ApiOperation("Does not have operation produces defined")
+    public String withoutOperationProduces() {
+        throw new UnsupportedOperationException();
+    }
+
+    @GetMapping(value = "/with-operation-produces", produces = MediaType.APPLICATION_XML_VALUE)
+    @ApiOperation("Does have operation produces defined")
+    public String withOperationProduces() {
+        throw new UnsupportedOperationException();
+    }
+
+    @PostMapping("/without-operation-consumes")
+    @ApiOperation("Does not have operation consumes defined")
+    public void withoutOperationConsumes(@RequestBody String test) {
+        throw new UnsupportedOperationException();
+    }
+
+    @PostMapping(value = "/with-operation-consumes", consumes = MediaType.APPLICATION_XML_VALUE)
+    @ApiOperation("Does have operation consumes defined")
+    public void withOperationConsumes(@RequestBody String test) {
+        throw new UnsupportedOperationException();
+    }
+
+    @PostMapping(value = "/with-operation-consumes-produces", consumes = MediaType.APPLICATION_XML_VALUE, produces = MediaType.APPLICATION_XML_VALUE)
+    @ApiOperation("Does have operation consumes and produces defined")
+    public void withOperationConsumesAndProduces(@RequestBody String test) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/springfox-spring-web/src/test/java/springfox/documentation/spring/web/dummy/controllers/ConsumesProducesService.java
+++ b/springfox-spring-web/src/test/java/springfox/documentation/spring/web/dummy/controllers/ConsumesProducesService.java
@@ -1,3 +1,22 @@
+/*
+ *
+ *  Copyright 2015 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+
 package springfox.documentation.spring.web.dummy.controllers;
 
 import io.swagger.annotations.Api;

--- a/swagger-contract-tests/src/test/groovy/springfox/test/contract/swaggertests/FunctionContractSpec.groovy
+++ b/swagger-contract-tests/src/test/groovy/springfox/test/contract/swaggertests/FunctionContractSpec.groovy
@@ -40,8 +40,8 @@ import springfox.bean.validators.configuration.BeanValidatorPluginsConfiguration
 import springfox.documentation.schema.AlternateTypeRuleConvention
 import springfox.documentation.spring.web.plugins.JacksonSerializerConvention
 
-import static org.skyscreamer.jsonassert.JSONCompareMode.*
-import static org.springframework.boot.test.context.SpringBootTest.*
+import static org.skyscreamer.jsonassert.JSONCompareMode.NON_EXTENSIBLE
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @ContextConfiguration(classes = Config)
@@ -89,6 +89,8 @@ class FunctionContractSpec extends Specification implements FileAccess {
       'declaration-groovy-service.json'                             | 'groovyService'
       'declaration-enum-service.json'                               | 'enumService'
       'declaration-spring-data-rest.json'                           | 'spring-data-rest'
+      'declaration-consumes-produces-not-on-document-context.json'  | 'consumesProducesNotOnDocumentContext'
+      'declaration-consumes-produces-on-document-context.json'      | 'consumesProducesOnDocumentContext'
   }
 
   def "should list swagger resources for swagger 2.0"() {

--- a/swagger-contract-tests/src/test/groovy/springfox/test/contract/swaggertests/Swagger2TestConfig.groovy
+++ b/swagger-contract-tests/src/test/groovy/springfox/test/contract/swaggertests/Swagger2TestConfig.groovy
@@ -38,8 +38,8 @@ import springfox.test.contract.swagger.Bug1767ListingScanner
 import java.nio.ByteBuffer
 
 import static com.google.common.base.Predicates.*
-import static springfox.documentation.builders.PathSelectors.*
-import static springfox.documentation.schema.AlternateTypeRules.*
+import static springfox.documentation.builders.PathSelectors.regex
+import static springfox.documentation.schema.AlternateTypeRules.newRule
 
 @Configuration
 @EnableSwagger2
@@ -272,6 +272,30 @@ public class Swagger2TestConfig {
         .select()
         .paths(regex("/features/.*"))
         .build()
+  }
+
+  @Bean
+  public Docket consumesProducesNotOnDocumentContext(List<SecurityScheme> authorizationTypes) {
+    return new Docket(DocumentationType.SWAGGER_2)
+            .groupName("consumesProducesNotOnDocumentContext")
+            .useDefaultResponseMessages(false)
+            .securitySchemes(authorizationTypes)
+            .select()
+            .paths(regex("/consumes-produces/.*"))
+            .build()
+  }
+
+  @Bean
+  public Docket consumesProducesOnDocumentContext(List<SecurityScheme> authorizationTypes) {
+    return new Docket(DocumentationType.SWAGGER_2)
+            .groupName("consumesProducesOnDocumentContext")
+            .useDefaultResponseMessages(false)
+            .securitySchemes(authorizationTypes)
+            .consumes(['text/plain'] as Set)
+            .produces(['application/json'] as Set)
+            .select()
+            .paths(regex("/consumes-produces/.*"))
+            .build()
   }
 
   @Bean

--- a/swagger-contract-tests/src/test/resources/contract/swagger/resource-listing.json
+++ b/swagger-contract-tests/src/test/resources/contract/swagger/resource-listing.json
@@ -42,6 +42,11 @@
       "position": 0
     },
     {
+      "description": "Services to demonstrate produces/consumes override behaviour on document and operation level",
+      "path": "/default/consumes-produces-service",
+      "position": 0
+    },
+    {
       "description": "Controller With No Request Mapping Service",
       "path": "/default/controller-with-no-request-mapping-service",
       "position": 0

--- a/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-bugs-different-service.json
+++ b/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-bugs-different-service.json
@@ -38,10 +38,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -61,10 +57,6 @@
         "summary": "bug1209",
         "operationId": "bug1209UsingPOST_2",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -96,10 +88,6 @@
         "summary": "bug1306",
         "operationId": "bug1306UsingPOST_2",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -139,10 +127,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -161,10 +145,6 @@
         "summary": "issue1376Input",
         "operationId": "issue1376InputUsingPOST_4",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -193,10 +173,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "url",
@@ -222,10 +198,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -245,10 +217,6 @@
         "summary": "issue1420",
         "operationId": "issue1420UsingGET_2",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "responses": {
@@ -271,10 +239,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -293,10 +257,6 @@
         "summary": "mapOfLists",
         "operationId": "mapOfListsUsingGET_2",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "responses": {
@@ -325,10 +285,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -355,10 +311,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -380,10 +332,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "responses": {
           "200": {
             "description": "OK"
@@ -399,10 +347,6 @@
         "summary": "fileCustomType",
         "operationId": "fileCustomTypeUsingGET_2",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -431,10 +375,6 @@
         "summary": "filesCustomType",
         "operationId": "filesCustomTypeUsingGET_2",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -468,10 +408,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "in": "body",
@@ -498,10 +434,6 @@
         "summary": "payloadWithByteBuffer",
         "operationId": "payloadWithByteBufferUsingGET_2",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -566,10 +498,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "offset",
@@ -598,10 +526,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -620,10 +544,6 @@
         "summary": "Retrieve all the companies",
         "operationId": "getAllPagedUsingGET_2",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -704,10 +624,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "responses": {
           "200": {
             "description": "list of ids",
@@ -729,10 +645,6 @@
         "summary": "1750b",
         "operationId": "bug1750bUsingGET_2",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "responses": {
@@ -776,10 +688,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -798,10 +706,6 @@
         "summary": "bug1778",
         "operationId": "bug1778UsingGET_2",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -835,10 +739,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "in": "body",
@@ -865,10 +765,6 @@
         "summary": "modelWithListOfEnumsAsModelAttribute",
         "operationId": "modelWithListOfEnumsAsModelAttributeUsingPOST_2",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -909,10 +805,8 @@
           "application/json"
         ],
         "produces": [
-          "application/xml",
           "application/atom+xml",
-          "application/json;charset=UTF-8",
-          "application/json"
+          "application/json;charset=UTF-8"
         ],
         "responses": {
           "200": {
@@ -929,10 +823,6 @@
         "summary": "test",
         "operationId": "testUsingGET_2",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [

--- a/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-bugs-service.json
+++ b/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-bugs-service.json
@@ -38,10 +38,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -61,10 +57,6 @@
         "summary": "bug1209",
         "operationId": "bug1209UsingPOST_1",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -96,10 +88,6 @@
         "summary": "bug1306",
         "operationId": "bug1306UsingPOST_1",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -139,10 +127,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -161,10 +145,6 @@
         "summary": "issue1376Input",
         "operationId": "issue1376InputUsingPOST_2",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -193,10 +173,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "url",
@@ -222,10 +198,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -245,10 +217,6 @@
         "summary": "issue1420",
         "operationId": "issue1420UsingGET_1",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "responses": {
@@ -271,10 +239,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -293,10 +257,6 @@
         "summary": "mapOfLists",
         "operationId": "mapOfListsUsingGET_1",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "responses": {
@@ -325,10 +285,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -355,10 +311,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -378,10 +330,6 @@
         "summary": "bug1627",
         "operationId": "bug1627UsingGET_1",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -412,10 +360,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "in": "body",
@@ -442,10 +386,6 @@
         "summary": "filesCustomType",
         "operationId": "filesCustomTypeUsingGET_1",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -479,10 +419,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "in": "body",
@@ -509,10 +445,6 @@
         "summary": "payloadWithByteBuffer",
         "operationId": "payloadWithByteBufferUsingGET_1",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -577,10 +509,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "offset",
@@ -609,10 +537,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -631,10 +555,6 @@
         "summary": "Retrieve all the companies",
         "operationId": "getAllPagedUsingGET_1",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -715,10 +635,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "responses": {
           "200": {
             "description": "list of ids",
@@ -740,10 +656,6 @@
         "summary": "1750b",
         "operationId": "bug1750bUsingGET_1",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "responses": {
@@ -787,10 +699,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -809,10 +717,6 @@
         "summary": "bug1778",
         "operationId": "bug1778UsingGET_1",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -846,10 +750,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "in": "body",
@@ -876,10 +776,6 @@
         "summary": "modelWithListOfEnumsAsModelAttribute",
         "operationId": "modelWithListOfEnumsAsModelAttributeUsingPOST_1",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -920,10 +816,8 @@
           "application/json"
         ],
         "produces": [
-          "application/xml",
           "application/atom+xml",
-          "application/json;charset=UTF-8",
-          "application/json"
+          "application/json;charset=UTF-8"
         ],
         "responses": {
           "200": {
@@ -940,10 +834,6 @@
         "summary": "test",
         "operationId": "testUsingGET_1",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [

--- a/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-business-service.json
+++ b/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-business-service.json
@@ -36,7 +36,6 @@
           "application/json"
         ],
         "produces": [
-          "application/xml",
           "application/json",
           "*/*"
         ],
@@ -70,7 +69,6 @@
           "application/json"
         ],
         "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -118,7 +116,6 @@
           "application/json"
         ],
         "produces": [
-          "application/xml",
           "application/json"
         ],
         "responses": {
@@ -142,7 +139,6 @@
           "application/json"
         ],
         "produces": [
-          "application/xml",
           "application/json",
           "*/*"
         ],
@@ -183,7 +179,6 @@
           "application/json"
         ],
         "produces": [
-          "application/xml",
           "application/json",
           "*/*"
         ],
@@ -217,7 +212,6 @@
           "application/json"
         ],
         "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -260,7 +254,6 @@
           "application/json"
         ],
         "produces": [
-          "application/xml",
           "application/json",
           "*/*"
         ],

--- a/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-concrete-controller.json
+++ b/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-concrete-controller.json
@@ -34,10 +34,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "in": "body",
@@ -64,10 +60,6 @@
         "summary": "delete",
         "operationId": "deleteUsingDELETE_1",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -100,10 +92,6 @@
         "summary": "get",
         "operationId": "getUsingGET_1",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [

--- a/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-consumes-produces-not-on-document-context.json
+++ b/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-consumes-produces-not-on-document-context.json
@@ -1,0 +1,179 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "description": "Api Documentation",
+    "version": "1.0",
+    "title": "Api Documentation",
+    "termsOfService": "urn:tos",
+    "contact": {},
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0"
+    }
+  },
+  "host": "localhost:__PORT__",
+  "basePath": "/",
+  "tags": [
+    {
+      "name": "consumes-produces-service",
+      "description": "Services to demonstrate produces/consumes override behaviour on document and operation level"
+    }
+  ],
+  "paths": {
+    "/consumes-produces/with-operation-consumes": {
+      "post": {
+        "tags": [
+          "consumes-produces-service"
+        ],
+        "summary": "Does have operation consumes defined",
+        "operationId": "withOperationConsumesUsingPOST_1",
+        "consumes": [
+          "application/xml"
+        ],
+        "produces": [
+          "*/*"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "test",
+            "description": "test",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/consumes-produces/with-operation-consumes-produces": {
+      "post": {
+        "tags": [
+          "consumes-produces-service"
+        ],
+        "summary": "Does have operation consumes and produces defined",
+        "operationId": "withOperationConsumesAndProducesUsingPOST_1",
+        "consumes": [
+          "application/xml"
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "test",
+            "description": "test",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/consumes-produces/with-operation-produces": {
+      "get": {
+        "tags": [
+          "consumes-produces-service"
+        ],
+        "summary": "Does have operation produces defined",
+        "operationId": "withOperationProducesUsingGET_1",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/consumes-produces/without-operation-consumes": {
+      "post": {
+        "tags": [
+          "consumes-produces-service"
+        ],
+        "summary": "Does not have operation consumes defined",
+        "operationId": "withoutOperationConsumesUsingPOST_1",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "*/*"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "test",
+            "description": "test",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/consumes-produces/without-operation-produces": {
+      "get": {
+        "tags": [
+          "consumes-produces-service"
+        ],
+        "summary": "Does not have operation produces defined",
+        "operationId": "withoutOperationProducesUsingGET_1",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "*/*"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  },
+  "securityDefinitions": {
+    "api_key": {
+      "type": "apiKey",
+      "name": "api_key",
+      "in": "header"
+    },
+    "petstore_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "http://petstore.swagger.io/api/oauth/dialog",
+      "flow": "implicit",
+      "scopes": {
+        "write:pets": "modify pets in your account",
+        "read:pets": "read your pets"
+      }
+    }
+  }
+}

--- a/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-consumes-produces-on-document-context.json
+++ b/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-consumes-produces-on-document-context.json
@@ -1,0 +1,167 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "description": "Api Documentation",
+    "version": "1.0",
+    "title": "Api Documentation",
+    "termsOfService": "urn:tos",
+    "contact": {},
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0"
+    }
+  },
+  "host": "localhost:__PORT__",
+  "basePath": "/",
+  "tags": [
+    {
+      "name": "consumes-produces-service",
+      "description": "Services to demonstrate produces/consumes override behaviour on document and operation level"
+    }
+  ],
+  "consumes": [
+    "text/plain"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/consumes-produces/with-operation-consumes": {
+      "post": {
+        "tags": [
+          "consumes-produces-service"
+        ],
+        "summary": "Does have operation consumes defined",
+        "operationId": "withOperationConsumesUsingPOST_2",
+        "consumes": [
+          "application/xml"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "test",
+            "description": "test",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/consumes-produces/with-operation-consumes-produces": {
+      "post": {
+        "tags": [
+          "consumes-produces-service"
+        ],
+        "summary": "Does have operation consumes and produces defined",
+        "operationId": "withOperationConsumesAndProducesUsingPOST_2",
+        "consumes": [
+          "application/xml"
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "test",
+            "description": "test",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/consumes-produces/with-operation-produces": {
+      "get": {
+        "tags": [
+          "consumes-produces-service"
+        ],
+        "summary": "Does have operation produces defined",
+        "operationId": "withOperationProducesUsingGET_2",
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/consumes-produces/without-operation-consumes": {
+      "post": {
+        "tags": [
+          "consumes-produces-service"
+        ],
+        "summary": "Does not have operation consumes defined",
+        "operationId": "withoutOperationConsumesUsingPOST_2",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "test",
+            "description": "test",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/consumes-produces/without-operation-produces": {
+      "get": {
+        "tags": [
+          "consumes-produces-service"
+        ],
+        "summary": "Does not have operation produces defined",
+        "operationId": "withoutOperationProducesUsingGET_2",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  },
+  "securityDefinitions": {
+    "api_key": {
+      "type": "apiKey",
+      "name": "api_key",
+      "in": "header"
+    },
+    "petstore_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "http://petstore.swagger.io/api/oauth/dialog",
+      "flow": "implicit",
+      "scopes": {
+        "write:pets": "modify pets in your account",
+        "read:pets": "read your pets"
+      }
+    }
+  }
+}

--- a/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-enum-service.json
+++ b/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-enum-service.json
@@ -35,10 +35,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -66,10 +62,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -92,10 +84,6 @@
         "summary": "Example with wrapped enum collection",
         "operationId": "getCollectionValueUsingGET_1",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "responses": {

--- a/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-fancy-pet-service.json
+++ b/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-fancy-pet-service.json
@@ -35,10 +35,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "in": "body",

--- a/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-feature-demonstration-service-codeGen.json
+++ b/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-feature-demonstration-service-codeGen.json
@@ -35,9 +35,7 @@
           "application/json"
         ],
         "produces": [
-          "application/xml",
           "application/vnd.com.fancy-pet+json",
-          "application/json",
           "application/vnd.com.pet+json"
         ],
         "parameters": [
@@ -69,10 +67,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "in": "body",
@@ -102,10 +96,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "base64Encoded",
@@ -131,10 +121,6 @@
         "summary": "serializablePetEntity",
         "operationId": "serializablePetEntityUsingGET_2",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -166,10 +152,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "itemId",
@@ -195,10 +177,6 @@
         "summary": "updateSerializablePet",
         "operationId": "updateSerializablePetUsingPUT_2",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -236,10 +214,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "files",
@@ -270,10 +244,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "responses": {
           "200": {
             "description": "OK"
@@ -287,10 +257,6 @@
         "summary": "allMethodAllowed",
         "operationId": "allMethodAllowedUsingHEAD_2",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "responses": {
@@ -308,10 +274,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "responses": {
           "200": {
             "description": "OK"
@@ -325,10 +287,6 @@
         "summary": "allMethodAllowed",
         "operationId": "allMethodAllowedUsingPUT_2",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "responses": {
@@ -346,10 +304,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "responses": {
           "200": {
             "description": "OK"
@@ -363,10 +317,6 @@
         "summary": "allMethodAllowed",
         "operationId": "allMethodAllowedUsingOPTIONS_2",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "responses": {
@@ -384,10 +334,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "responses": {
           "200": {
             "description": "OK"
@@ -403,10 +349,6 @@
         "summary": "arrayOfArrays",
         "operationId": "arrayOfArraysUsingPOST_1",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -455,10 +397,6 @@
         "summary": "getBare",
         "operationId": "getBareUsingPOST_2",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -564,10 +502,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "input",
@@ -594,10 +528,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "input",
@@ -622,10 +552,6 @@
         "summary": "updateDate",
         "operationId": "updateDateUsingPOST_2",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -655,10 +581,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -677,10 +599,6 @@
         "summary": "getEffectives",
         "operationId": "getEffectivesUsingGET_2",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "responses": {
@@ -706,10 +624,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -728,10 +642,6 @@
         "summary": "updateListOfExamples",
         "operationId": "updateListOfExamplesUsingPUT_2",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -762,10 +672,6 @@
         "summary": "updateListOfIntegers",
         "operationId": "updateListOfIntegersUsingPUT_2",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -799,10 +705,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -824,10 +726,6 @@
         "summary": "mapOfMapOfExample",
         "operationId": "mapOfMapOfExampleUsingGET_2",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "responses": {
@@ -856,10 +754,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -878,10 +772,6 @@
         "summary": "getModelAttribute",
         "operationId": "getModelAttributeUsingGET_2",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -961,10 +851,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "in": "body",
@@ -991,10 +877,6 @@
         "summary": "propertyWithObjectNode",
         "operationId": "propertyWithObjectNodeUsingPOST_2",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -1025,10 +907,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "enumType",
@@ -1057,10 +935,6 @@
         "summary": "updateBazes",
         "operationId": "updateBazesUsingPOST_2",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -1100,10 +974,6 @@
         "description": "Returns a pet when ID < 10. ID > 10 or non-integers will simulate API error conditions",
         "operationId": "getPetByIdUsingGET_3",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [

--- a/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-feature-demonstration-service.json
+++ b/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-feature-demonstration-service.json
@@ -35,9 +35,7 @@
           "application/json"
         ],
         "produces": [
-          "application/xml",
           "application/vnd.com.fancy-pet+json",
-          "application/json",
           "application/vnd.com.pet+json"
         ],
         "parameters": [
@@ -69,10 +67,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "in": "body",
@@ -102,10 +96,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "base64Encoded",
@@ -131,10 +121,6 @@
         "summary": "serializablePetEntity",
         "operationId": "serializablePetEntityUsingGET_1",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -166,10 +152,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "itemId",
@@ -195,10 +177,6 @@
         "summary": "updateSerializablePet",
         "operationId": "updateSerializablePetUsingPUT_1",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -236,10 +214,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "files",
@@ -270,10 +244,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "responses": {
           "200": {
             "description": "OK"
@@ -287,10 +257,6 @@
         "summary": "allMethodAllowed",
         "operationId": "allMethodAllowedUsingHEAD_1",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "responses": {
@@ -308,10 +274,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "responses": {
           "200": {
             "description": "OK"
@@ -325,10 +287,6 @@
         "summary": "allMethodAllowed",
         "operationId": "allMethodAllowedUsingPUT_1",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "responses": {
@@ -346,10 +304,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "responses": {
           "200": {
             "description": "OK"
@@ -363,10 +317,6 @@
         "summary": "allMethodAllowed",
         "operationId": "allMethodAllowedUsingOPTIONS_1",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "responses": {
@@ -384,10 +334,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "responses": {
           "200": {
             "description": "OK"
@@ -403,10 +349,6 @@
         "summary": "arrayOfArrays",
         "operationId": "arrayOfArraysUsingPOST",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -455,10 +397,6 @@
         "summary": "getBare",
         "operationId": "getBareUsingPOST_1",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -564,10 +502,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "input",
@@ -594,10 +528,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "input",
@@ -622,10 +552,6 @@
         "summary": "updateDate",
         "operationId": "updateDateUsingPOST_1",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -655,10 +581,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -677,10 +599,6 @@
         "summary": "getEffectives",
         "operationId": "getEffectivesUsingGET_1",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "responses": {
@@ -706,10 +624,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -728,10 +642,6 @@
         "summary": "updateListOfExamples",
         "operationId": "updateListOfExamplesUsingPUT_1",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -762,10 +672,6 @@
         "summary": "updateListOfIntegers",
         "operationId": "updateListOfIntegersUsingPUT_1",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -799,10 +705,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -824,10 +726,6 @@
         "summary": "mapOfMapOfExample",
         "operationId": "mapOfMapOfExampleUsingGET_1",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "responses": {
@@ -856,10 +754,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -878,10 +772,6 @@
         "summary": "getModelAttribute",
         "operationId": "getModelAttributeUsingGET_1",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -961,10 +851,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "in": "body",
@@ -991,10 +877,6 @@
         "summary": "propertyWithObjectNode",
         "operationId": "propertyWithObjectNodeUsingPOST_1",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -1025,10 +907,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "enumType",
@@ -1057,10 +935,6 @@
         "summary": "updateBazes",
         "operationId": "updateBazesUsingPOST_1",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -1100,10 +974,6 @@
         "description": "Returns a pet when ID < 10. ID > 10 or non-integers will simulate API error conditions",
         "operationId": "getPetByIdUsingGET_2",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [

--- a/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-groovy-service.json
+++ b/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-groovy-service.json
@@ -35,10 +35,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -55,10 +51,6 @@
         "summary": "updateGroovyModel",
         "operationId": "updateGroovyModelUsingPUT_1",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [

--- a/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-inherited-service-impl.json
+++ b/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-inherited-service-impl.json
@@ -36,7 +36,6 @@
           "application/json"
         ],
         "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -66,10 +65,6 @@
         "summary": "getSomething",
         "operationId": "getSomethingUsingGET_1",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [

--- a/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-pet-service.json
+++ b/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-pet-service.json
@@ -39,10 +39,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "name",
@@ -73,10 +69,6 @@
         "summary": "echo",
         "operationId": "echoUsingPOST_1",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -117,10 +109,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "status",
@@ -158,10 +146,6 @@
         "description": "Multiple tags can be provided with comma-separated strings. Use tag1, tag2, tag3 for testing.",
         "operationId": "findPetsByTagsUsingGET_1",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -227,10 +211,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "type",
@@ -260,10 +240,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -288,10 +264,6 @@
         "summary": "siblings",
         "operationId": "siblingsUsingPOST_1",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -338,10 +310,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "in": "body",
@@ -376,10 +344,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "in": "body",
@@ -412,10 +376,6 @@
         "summary": "transformPetNameToPetMapToOpenMap",
         "operationId": "transformPetNameToPetMapToOpenMapUsingPOST_1",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -482,10 +442,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "a",
@@ -519,10 +475,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "name",
@@ -551,10 +503,6 @@
         "description": "Returns a pet when ID < 10. ID > 10 or non-integers will simulate API error conditions",
         "operationId": "getPetByIdUsingGET_4",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -588,10 +536,6 @@
         "consumes": [
           "multipart/form-data"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "petId",
@@ -623,10 +567,6 @@
         "summary": "updatePic",
         "operationId": "updatePicUsingGET_1",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [

--- a/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-root-controller.json
+++ b/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-root-controller.json
@@ -108,10 +108,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "in": "body",
@@ -150,10 +146,6 @@
         "summary": "Update an existing pet",
         "operationId": "updatePetUsingPUT",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -205,10 +197,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "status",
@@ -254,10 +242,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "tags",
@@ -301,10 +285,6 @@
         "description": "Returns a pet when ID < 10. ID > 10 or non-integers will simulate API error conditions",
         "operationId": "getPetByIdUsingGET",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -2227,10 +2207,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "input",
@@ -2534,10 +2510,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "input",
@@ -2736,10 +2708,6 @@
         "summary": "groomingFunctionThatReturnsVoid",
         "operationId": "groomingFunctionThatReturnsVoidUsingDELETE",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [

--- a/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-spring-data-rest.json
+++ b/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-spring-data-rest.json
@@ -46,10 +46,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "in": "body",
@@ -81,10 +77,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "id",
@@ -111,10 +103,6 @@
         "summary": "saveAddress",
         "operationId": "saveAddressUsingPUT_2",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -154,10 +142,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "id",
@@ -181,10 +165,6 @@
         "summary": "saveAddress",
         "operationId": "saveAddressUsingPATCH_2",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -227,9 +207,7 @@
           "application/json"
         ],
         "produces": [
-          "application/xml",
-          "application/hal+json",
-          "application/json"
+          "application/hal+json"
         ],
         "parameters": [
           {
@@ -259,10 +237,6 @@
         "consumes": [
           "text/uri-list",
           "application/x-spring-data-compact+json"
-        ],
-        "produces": [
-          "application/xml",
-          "application/json"
         ],
         "parameters": [
           {
@@ -302,10 +276,6 @@
           "text/uri-list",
           "application/x-spring-data-compact+json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "id",
@@ -344,10 +314,6 @@
           "text/uri-list",
           "application/x-spring-data-compact+json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "id",
@@ -373,10 +339,6 @@
         "consumes": [
           "text/uri-list",
           "application/x-spring-data-compact+json"
-        ],
-        "produces": [
-          "application/xml",
-          "application/json"
         ],
         "parameters": [
           {
@@ -418,9 +380,8 @@
           "application/json"
         ],
         "produces": [
-          "application/xml",
-          "application/hal+json",
           "application/json",
+          "application/hal+json",
           "text/uri-list",
           "application/x-spring-data-compact+json"
         ],
@@ -467,10 +428,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "in": "body",
@@ -502,10 +459,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "id",
@@ -532,10 +485,6 @@
         "summary": "saveCategory",
         "operationId": "saveCategoryUsingPUT_2",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -575,10 +524,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "id",
@@ -602,10 +547,6 @@
         "summary": "saveCategory",
         "operationId": "saveCategoryUsingPATCH_2",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -648,9 +589,7 @@
           "application/json"
         ],
         "produces": [
-          "application/xml",
-          "application/hal+json",
-          "application/json"
+          "application/hal+json"
         ],
         "parameters": [
           {
@@ -680,10 +619,6 @@
         "consumes": [
           "text/uri-list",
           "application/x-spring-data-compact+json"
-        ],
-        "produces": [
-          "application/xml",
-          "application/json"
         ],
         "parameters": [
           {
@@ -726,10 +661,6 @@
           "text/uri-list",
           "application/x-spring-data-compact+json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "id",
@@ -771,10 +702,6 @@
           "text/uri-list",
           "application/x-spring-data-compact+json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "id",
@@ -800,10 +727,6 @@
         "consumes": [
           "text/uri-list",
           "application/x-spring-data-compact+json"
-        ],
-        "produces": [
-          "application/xml",
-          "application/json"
         ],
         "parameters": [
           {
@@ -847,10 +770,6 @@
         "consumes": [
           "application/hal+json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "id",
@@ -887,10 +806,6 @@
           "text/uri-list",
           "application/x-spring-data-compact+json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "id",
@@ -926,9 +841,8 @@
           "application/json"
         ],
         "produces": [
-          "application/xml",
-          "application/hal+json",
           "application/json",
+          "application/hal+json",
           "text/uri-list",
           "application/x-spring-data-compact+json"
         ],
@@ -975,10 +889,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "in": "body",
@@ -1011,10 +921,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "name",
@@ -1044,10 +950,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "id",
@@ -1074,10 +976,6 @@
         "summary": "savePerson",
         "operationId": "savePersonUsingPUT_2",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -1117,10 +1015,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "id",
@@ -1144,10 +1038,6 @@
         "summary": "savePerson",
         "operationId": "savePersonUsingPATCH_2",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -1190,9 +1080,7 @@
           "application/json"
         ],
         "produces": [
-          "application/xml",
-          "application/hal+json",
-          "application/json"
+          "application/hal+json"
         ],
         "parameters": [
           {
@@ -1222,10 +1110,6 @@
         "consumes": [
           "text/uri-list",
           "application/x-spring-data-compact+json"
-        ],
-        "produces": [
-          "application/xml",
-          "application/json"
         ],
         "parameters": [
           {
@@ -1265,10 +1149,6 @@
           "text/uri-list",
           "application/x-spring-data-compact+json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "id",
@@ -1307,10 +1187,6 @@
           "text/uri-list",
           "application/x-spring-data-compact+json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "id",
@@ -1336,10 +1212,6 @@
         "consumes": [
           "text/uri-list",
           "application/x-spring-data-compact+json"
-        ],
-        "produces": [
-          "application/xml",
-          "application/json"
         ],
         "parameters": [
           {
@@ -1381,9 +1253,7 @@
           "application/json"
         ],
         "produces": [
-          "application/xml",
-          "application/hal+json",
-          "application/json"
+          "application/hal+json"
         ],
         "parameters": [
           {
@@ -1413,10 +1283,6 @@
         "consumes": [
           "text/uri-list",
           "application/x-spring-data-compact+json"
-        ],
-        "produces": [
-          "application/xml",
-          "application/json"
         ],
         "parameters": [
           {
@@ -1456,10 +1322,6 @@
           "text/uri-list",
           "application/x-spring-data-compact+json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "id",
@@ -1498,10 +1360,6 @@
           "text/uri-list",
           "application/x-spring-data-compact+json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "id",
@@ -1527,10 +1385,6 @@
         "consumes": [
           "text/uri-list",
           "application/x-spring-data-compact+json"
-        ],
-        "produces": [
-          "application/xml",
-          "application/json"
         ],
         "parameters": [
           {
@@ -1572,9 +1426,7 @@
           "application/json"
         ],
         "produces": [
-          "application/xml",
-          "application/hal+json",
-          "application/json"
+          "application/hal+json"
         ],
         "parameters": [
           {
@@ -1604,10 +1456,6 @@
         "consumes": [
           "text/uri-list",
           "application/x-spring-data-compact+json"
-        ],
-        "produces": [
-          "application/xml",
-          "application/json"
         ],
         "parameters": [
           {
@@ -1650,10 +1498,6 @@
           "text/uri-list",
           "application/x-spring-data-compact+json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "id",
@@ -1695,10 +1539,6 @@
           "text/uri-list",
           "application/x-spring-data-compact+json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "id",
@@ -1724,10 +1564,6 @@
         "consumes": [
           "text/uri-list",
           "application/x-spring-data-compact+json"
-        ],
-        "produces": [
-          "application/xml",
-          "application/json"
         ],
         "parameters": [
           {
@@ -1771,10 +1607,6 @@
         "consumes": [
           "application/hal+json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "id",
@@ -1811,10 +1643,6 @@
           "text/uri-list",
           "application/x-spring-data-compact+json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "id",
@@ -1850,9 +1678,8 @@
           "application/json"
         ],
         "produces": [
-          "application/xml",
-          "application/hal+json",
           "application/json",
+          "application/hal+json",
           "text/uri-list",
           "application/x-spring-data-compact+json"
         ],
@@ -1899,10 +1726,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "in": "body",
@@ -1934,10 +1757,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "id",
@@ -1964,10 +1783,6 @@
         "summary": "saveTag",
         "operationId": "saveTagUsingPUT_2",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -2007,10 +1822,6 @@
         "consumes": [
           "application/json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "id",
@@ -2034,10 +1845,6 @@
         "summary": "saveTag",
         "operationId": "saveTagUsingPATCH_2",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -2080,9 +1887,7 @@
           "application/json"
         ],
         "produces": [
-          "application/xml",
-          "application/hal+json",
-          "application/json"
+          "application/hal+json"
         ],
         "parameters": [
           {
@@ -2112,10 +1917,6 @@
         "consumes": [
           "text/uri-list",
           "application/x-spring-data-compact+json"
-        ],
-        "produces": [
-          "application/xml",
-          "application/json"
         ],
         "parameters": [
           {
@@ -2158,10 +1959,6 @@
           "text/uri-list",
           "application/x-spring-data-compact+json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "id",
@@ -2203,10 +2000,6 @@
           "text/uri-list",
           "application/x-spring-data-compact+json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "id",
@@ -2232,10 +2025,6 @@
         "consumes": [
           "text/uri-list",
           "application/x-spring-data-compact+json"
-        ],
-        "produces": [
-          "application/xml",
-          "application/json"
         ],
         "parameters": [
           {
@@ -2279,10 +2068,6 @@
         "consumes": [
           "application/hal+json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "id",
@@ -2319,10 +2104,6 @@
           "text/uri-list",
           "application/x-spring-data-compact+json"
         ],
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "name": "id",
@@ -2358,9 +2139,8 @@
           "application/json"
         ],
         "produces": [
-          "application/xml",
-          "application/hal+json",
           "application/json",
+          "application/hal+json",
           "text/uri-list",
           "application/x-spring-data-compact+json"
         ],

--- a/swagger-contract-tests/src/test/resources/contract/swagger2/swagger.json
+++ b/swagger-contract-tests/src/test/resources/contract/swagger2/swagger.json
@@ -325,7 +325,6 @@
           "application/json"
         ],
         "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -395,7 +394,6 @@
           "application/json"
         ],
         "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -435,7 +433,6 @@
           "application/json"
         ],
         "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -476,7 +473,6 @@
           "application/json"
         ],
         "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -511,7 +507,6 @@
           "application/json"
         ],
         "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -549,7 +544,6 @@
           "application/json"
         ],
         "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -587,7 +581,6 @@
           "application/json"
         ],
         "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -630,7 +623,6 @@
           "application/json"
         ],
         "produces": [
-          "application/xml",
           "application/json"
         ],
         "responses": {
@@ -654,7 +646,6 @@
           "application/json"
         ],
         "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -692,7 +683,6 @@
           "application/json"
         ],
         "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -780,7 +770,6 @@
           "application/json"
         ],
         "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -816,10 +805,6 @@
         "summary": "test",
         "operationId": "testUsingPOST_1",
         "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/xml",
           "application/json"
         ],
         "responses": {

--- a/swagger-contract-tests/src/test/resources/contract/swagger2/swaggerTemplated.json
+++ b/swagger-contract-tests/src/test/resources/contract/swagger2/swaggerTemplated.json
@@ -40,7 +40,6 @@
           "application/json"
         ],
         "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [
@@ -76,7 +75,6 @@
           "application/json"
         ],
         "produces": [
-          "application/xml",
           "application/json"
         ],
         "parameters": [


### PR DESCRIPTION
This is a possible fix for issue 1916. It removes the merging of the document level and operation level consumes and produces media types on the in the OperationContext. This results in a "more" valid swagger specification because now the document level media types are only defined on the document level and only when these media-types are overwritten on the operation level, they will be set on the operation level. This behaviour is according to the Swagger v2 specification and it also works just fine within the Swagger UI.

However we do want to provide some default values when no media-types are defined on the document and operation level. Thus I changed the MediaTypeReader to reflect this.

I also fixed the contract tests, because many of these didn't produce the correct specification anymore. TBH: I didn't check every specification by hand because many many failed due to this change. For most of them I just made sure that the expected specification matched the produces specification.
