### PR TITLE
Model classes having names containing integers are not detected as array

### DIFF
--- a/springfox-swagger1/src/main/java/springfox/documentation/swagger1/dto/DataType.java
+++ b/springfox-swagger1/src/main/java/springfox/documentation/swagger1/dto/DataType.java
@@ -27,7 +27,7 @@ import java.util.regex.Pattern;
 
 //CHECKSTYLE:OFF CyclomaticComplexityCheck
 public class DataType implements SwaggerDataType {
-  private static final Pattern containerPattern = Pattern.compile("([a-zA-Z]+)\\[([_a-zA-Z\\.\\-]+)\\]");
+  private static final Pattern containerPattern = Pattern.compile("([a-zA-Z]+)\\[([_a-zA-Z0-9\\.\\-]+)\\]");
   @JsonUnwrapped
   @JsonProperty
   private SwaggerDataType dataType;


### PR DESCRIPTION
swagger 1.2 : model classes having names containing integers are not detected as array