### PR TITLE
Add default property support on model properties

### DIFF
--- a/springfox-core/src/main/java/springfox/documentation/builders/ModelPropertyBuilder.java
+++ b/springfox-core/src/main/java/springfox/documentation/builders/ModelPropertyBuilder.java
@@ -42,6 +42,7 @@ public class ModelPropertyBuilder {
   private String example;
   private String pattern;
   private List<VendorExtension> vendorExtensions = newArrayList();
+  private String defaultValue;
 
   public ModelPropertyBuilder name(String name) {
     this.name = defaultIfAbsent(name, this.name);
@@ -103,6 +104,11 @@ public class ModelPropertyBuilder {
     return this;
   }
 
+  public ModelPropertyBuilder defaultValue(String defaultValue) {
+    this.defaultValue = defaultValue;
+    return this;
+  }
+
   public ModelProperty build() {
     return new ModelProperty(
         name,
@@ -116,6 +122,7 @@ public class ModelPropertyBuilder {
         allowableValues,
         example,
         pattern,
-        vendorExtensions);
+        vendorExtensions,
+        defaultValue);
   }
 }

--- a/springfox-core/src/main/java/springfox/documentation/builders/ModelPropertyBuilder.java
+++ b/springfox-core/src/main/java/springfox/documentation/builders/ModelPropertyBuilder.java
@@ -105,7 +105,7 @@ public class ModelPropertyBuilder {
   }
 
   public ModelPropertyBuilder defaultValue(String defaultValue) {
-    this.defaultValue = defaultValue;
+    this.defaultValue = defaultIfAbsent(defaultValue, this.defaultValue);
     return this;
   }
 

--- a/springfox-core/src/main/java/springfox/documentation/schema/ModelProperty.java
+++ b/springfox-core/src/main/java/springfox/documentation/schema/ModelProperty.java
@@ -42,6 +42,7 @@ public class ModelProperty {
   private final String example;
   private final String pattern;
   private final List<VendorExtension> vendorExtensions;
+  private final String defaultValue;
 
   public ModelProperty(
       String name,
@@ -55,7 +56,8 @@ public class ModelProperty {
       AllowableValues allowableValues,
       String example,
       String pattern,
-      List<VendorExtension> vendorExtensions) {
+      List<VendorExtension> vendorExtensions,
+      String defaultValue) {
 
     this.name = name;
     this.type = type;
@@ -69,6 +71,7 @@ public class ModelProperty {
     this.example = example;
     this.pattern = pattern;
     this.vendorExtensions = newArrayList(vendorExtensions);
+    this.defaultValue = defaultValue;
   }
 
   public String getName() {
@@ -126,5 +129,9 @@ public class ModelProperty {
 
   public List<VendorExtension> getVendorExtensions() {
     return vendorExtensions;
+  }
+
+  public String getDefaultValue() {
+    return defaultValue;
   }
 }

--- a/springfox-core/src/test/java/springfox/documentation/builders/ModelPropertyDefaultValueTest.java
+++ b/springfox-core/src/test/java/springfox/documentation/builders/ModelPropertyDefaultValueTest.java
@@ -1,0 +1,60 @@
+/*
+ *
+ *  Copyright 2015-2018 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+
+package springfox.documentation.builders;
+
+import org.junit.Before;
+import org.junit.Test;
+import springfox.documentation.schema.ModelProperty;
+
+import static org.junit.Assert.assertEquals;
+
+public class ModelPropertyDefaultValueTest {
+
+    ModelPropertyBuilder propertyBuilder;
+    ModelProperty modelProperty;
+
+    @Before
+    public void createNewPropertyBuilder() {
+        propertyBuilder = new ModelPropertyBuilder();
+        modelProperty = null;
+    }
+
+    @Test
+    public void testDefaultValueNull() {
+        modelProperty = propertyBuilder.build();
+        assertEquals(modelProperty.getDefaultValue(), null);
+    }
+
+    @Test
+    public void testDefaultValueEmpty() {
+        modelProperty = propertyBuilder.defaultValue("")
+                                       .build();
+        assertEquals(modelProperty.getDefaultValue(), "");
+    }
+
+    @Test
+    public void testDefaultValueString() {
+        String testValue = "TEST Default value";
+        modelProperty = propertyBuilder.defaultValue(testValue)
+                                       .build();
+        assertEquals(modelProperty.getDefaultValue(), testValue);
+    }
+
+}

--- a/springfox-swagger2/src/main/java/springfox/documentation/swagger2/mappers/ModelMapper.java
+++ b/springfox-swagger2/src/main/java/springfox/documentation/swagger2/mappers/ModelMapper.java
@@ -170,7 +170,9 @@ public abstract class ModelMapper {
       if (source.getPattern() != null) {
         stringProperty.setPattern(source.getPattern());
       }
-      property.setDefault(source.getDefaultValue());
+      if (source.getDefaultValue() != null) {
+        stringProperty.setDefault(source.getDefaultValue());
+      }
     }
 
     if (property != null) {

--- a/springfox-swagger2/src/main/java/springfox/documentation/swagger2/mappers/ModelMapper.java
+++ b/springfox-swagger2/src/main/java/springfox/documentation/swagger2/mappers/ModelMapper.java
@@ -170,6 +170,7 @@ public abstract class ModelMapper {
       if (source.getPattern() != null) {
         stringProperty.setPattern(source.getPattern());
       }
+      property.setDefault(source.getDefaultValue());
     }
 
     if (property != null) {

--- a/springfox-swagger2/src/test/groovy/springfox/documentation/swagger2/mappers/ModelMapperSpec.groovy
+++ b/springfox-swagger2/src/test/groovy/springfox/documentation/swagger2/mappers/ModelMapperSpec.groovy
@@ -387,7 +387,8 @@ class ModelMapperSpec extends SchemaSpecification {
         null,
         '',
         '',
-        []).with {
+        [],
+        '').with {
       it.updateModelRef({ rt -> new ModelRef(simpleQualifiedTypeName(stringProperty)) })
       it
     }


### PR DESCRIPTION
#### What's this PR do/fix?
Adding an option to set default property

#### Are there unit tests? If not how should this be manually tested?
There are unit tests for changes to ModelProperty and ModelPropertyBuilder.

#### Any background context you want to provide?
If you want to make use of this new feature, you need the following:
1) Write custom annotation, which contains defaultValue:
```
import java.lang.annotation.*;

@Retention(RetentionPolicy.RUNTIME)
@Target({ElementType.METHOD, ElementType.FIELD})
@Inherited
@Documented
public @interface ApiModelPropertyExtended {
    String defaultValue() default "";
}
```

2) Write custom plugin to make use of that new value:
```
import <...>.annotation.ApiModelPropertyExtended;   // the annotation we specified earlier
import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
import com.google.common.base.Optional;
import org.springframework.core.annotation.Order;
import org.springframework.stereotype.Component;
import springfox.documentation.spi.DocumentationType;
import springfox.documentation.spi.schema.ModelPropertyBuilderPlugin;
import springfox.documentation.spi.schema.contexts.ModelPropertyContext;
import springfox.documentation.swagger.common.SwaggerPluginSupport;

@Component
@Order(SwaggerPluginSupport.SWAGGER_PLUGIN_ORDER + 1000)
public class ApiModelPropertyExtendedPlugin implements ModelPropertyBuilderPlugin {

    @Override
    public void apply(ModelPropertyContext context) {

        Optional<BeanPropertyDefinition> optionalDefinition = context.getBeanPropertyDefinition();

        if (optionalDefinition.isPresent()) {

            BeanPropertyDefinition definition = optionalDefinition.get();
            ApiModelPropertyExtended annotation = null;

            if (definition.hasGetter()) {
                annotation = definition.getGetter().getAnnotation(ApiModelPropertyExtended.class);
            }

            if (annotation == null) {
                annotation = definition.getField().getAnnotation(ApiModelPropertyExtended.class);
            }

            if (annotation != null) {
                context.getBuilder()
                       .defaultValue(annotation.defaultValue())
                       .build();
            }
        }
    }

    @Override
    public boolean supports(DocumentationType documentationType) {
        return true;
    }
}
```

3) Use recently created annotation in your code:
```
import <...>.annotation.ApiModelPropertyExtended;
import io.swagger.annotations.ApiModelProperty;
<...>

public interface AccountAPI {

    @ApiModelProperty(
            name = "Account's first name",
            required = true
    )
    @ApiModelPropertyExtended(
            defaultValue = "John Doe"
    )
    String getFirstName();
<...>
```