### PR TITLE
custom the web page title as swagger.title when had set it

### DIFF
--- a/springfox-swagger-ui/src/web/js/springfox.js
+++ b/springfox-swagger-ui/src/web/js/springfox.js
@@ -88,7 +88,8 @@ $(function() {
         $('pre code').each(function(i, e) {
           hljs.highlightBlock(e)
         });
-
+        //custome the weg page title as swagger.title when had set it
+         document.title = $('.info_title').html() || document.title;
       },
       onFailure: function(data) {
         log("Unable to Load SwaggerUI");


### PR DESCRIPTION
custom the web page title as swagger.title when had set it

#### What's this PR do/fix?
When I am developing, I will open a lot of interface documents page, but I can not for which of them which is, only one page to open, so it will modify the code, easy to view from the browser tabs title 
#### Are there unit tests? If not how should this be manually tested?
#### Any background context you want to provide?
#### What are the relevant issues?
