### PR TITLE
Feature/open classes for extension for enum ref

### DIFF
--- a/springfox-schema/src/main/java/springfox/documentation/schema/DefaultModelDependencyProvider.java
+++ b/springfox-schema/src/main/java/springfox/documentation/schema/DefaultModelDependencyProvider.java
@@ -129,7 +129,7 @@ public class DefaultModelDependencyProvider implements ModelDependencyProvider {
     return parameters;
   }
 
-  private List<ResolvedType> resolvedPropertiesAndFields(ModelContext modelContext, ResolvedType resolvedType) {
+  protected List<ResolvedType> resolvedPropertiesAndFields(ModelContext modelContext, ResolvedType resolvedType) {
     if (modelContext.hasSeenBefore(resolvedType) || resolvedType.getErasedType().isEnum()) {
       return newArrayList();
     }

--- a/springfox-schema/src/main/java/springfox/documentation/schema/DefaultModelProvider.java
+++ b/springfox-schema/src/main/java/springfox/documentation/schema/DefaultModelProvider.java
@@ -72,11 +72,7 @@ public class DefaultModelProvider implements ModelProvider {
   @Override
   public com.google.common.base.Optional<Model> modelFor(ModelContext modelContext) {
     ResolvedType propertiesHost = modelContext.alternateFor(modelContext.resolvedType(resolver));
-    if (isContainerType(propertiesHost)
-        || isMapType(propertiesHost)
-        || propertiesHost.getErasedType().isEnum()
-        || isBaseType(propertiesHost)
-        || modelContext.hasSeenBefore(propertiesHost)) {
+    if (isSkipModelFor(modelContext, propertiesHost)) {
       LOG.debug("Skipping model of type {} as its either a container type, map, enum or base type, or its already "
           + "been handled", resolvedTypeSignature(propertiesHost).or("<null>"));
       return Optional.absent();
@@ -88,6 +84,14 @@ public class DefaultModelProvider implements ModelProvider {
     Map<String, ModelProperty> properties = newTreeMap();
     properties.putAll(propertiesIndex);
     return Optional.of(modelBuilder(propertiesHost, properties, modelContext));
+  }
+
+  protected boolean isSkipModelFor(ModelContext modelContext, ResolvedType propertiesHost) {
+    return isContainerType(propertiesHost)
+        || isMapType(propertiesHost)
+        || propertiesHost.getErasedType().isEnum()
+        || isBaseType(propertiesHost)
+        || modelContext.hasSeenBefore(propertiesHost);
   }
 
   private Model modelBuilder(ResolvedType propertiesHost,

--- a/springfox-schema/src/main/java/springfox/documentation/schema/TypeNameExtractor.java
+++ b/springfox-schema/src/main/java/springfox/documentation/schema/TypeNameExtractor.java
@@ -61,7 +61,7 @@ public class TypeNameExtractor {
     return innerTypeName(type, context);
   }
 
-  private ResolvedType asResolved(Type type) {
+  protected ResolvedType asResolved(Type type) {
     return typeResolver.resolve(type);
   }
 
@@ -93,7 +93,7 @@ public class TypeNameExtractor {
     return simpleTypeName(type, context);
   }
 
-  private String simpleTypeName(ResolvedType type, ModelContext context) {
+  protected String simpleTypeName(ResolvedType type, ModelContext context) {
     Class<?> erasedType = type.getErasedType();
     if (type instanceof ResolvedPrimitiveType) {
       return typeNameFor(erasedType);
@@ -112,7 +112,7 @@ public class TypeNameExtractor {
     return typeName(new ModelNameContext(type.getErasedType(), context.getDocumentationType()));
   }
 
-  private String typeName(ModelNameContext context) {
+  protected String typeName(ModelNameContext context) {
     TypeNameProviderPlugin selected =
         typeNameProviders.getPluginFor(context.getDocumentationType(), new DefaultTypeNameProvider());
     return selected.nameFor(context.getType());

--- a/springfox-schema/src/test/groovy/springfox/documentation/schema/DefaultModelDependencyProviderSpec.groovy
+++ b/springfox-schema/src/test/groovy/springfox/documentation/schema/DefaultModelDependencyProviderSpec.groovy
@@ -1,0 +1,19 @@
+package springfox.documentation.schema
+
+import com.fasterxml.classmate.ResolvedType
+import spock.lang.Specification
+import springfox.documentation.spi.schema.contexts.ModelContext
+
+import java.lang.reflect.Method
+import java.lang.reflect.Modifier
+
+class DefaultModelDependencyProviderSpec extends Specification {
+  def "DefaultModelDependencyProvider.resolvedPropertiesAndFields(ModelContext, ResolvedType) should be overridable" (){
+    given:
+      Method mapPropertiesMethod = DefaultModelDependencyProvider.class.getDeclaredMethod("resolvedPropertiesAndFields", ModelContext.class, ResolvedType.class);
+    when:
+      def modifiers = mapPropertiesMethod.getModifiers();
+    then:
+      Modifier.isProtected(modifiers);
+  }
+}

--- a/springfox-schema/src/test/groovy/springfox/documentation/schema/DefaultModelProviderSpec.groovy
+++ b/springfox-schema/src/test/groovy/springfox/documentation/schema/DefaultModelProviderSpec.groovy
@@ -1,0 +1,20 @@
+package springfox.documentation.schema
+
+import com.fasterxml.classmate.ResolvedType
+import spock.lang.Specification
+import springfox.documentation.spi.schema.contexts.ModelContext
+
+import java.lang.reflect.Method
+import java.lang.reflect.Modifier
+
+class DefaultModelProviderSpec extends Specification {
+  def "DefaultModelProvider.isSkipModelFor(ModelContext, ResolvedType) should be overridable" (){
+    given:
+      Method mapPropertiesMethod = DefaultModelProvider.class.getDeclaredMethod("isSkipModelFor", ModelContext.class, ResolvedType.class);
+    when:
+      def modifiers = mapPropertiesMethod.getModifiers();
+    then:
+      Modifier.isProtected(modifiers);
+  }
+
+}

--- a/springfox-schema/src/test/groovy/springfox/documentation/schema/TypeNameExtractorSpec.groovy
+++ b/springfox-schema/src/test/groovy/springfox/documentation/schema/TypeNameExtractorSpec.groovy
@@ -21,6 +21,9 @@ package springfox.documentation.schema
 import com.google.common.collect.ImmutableSet
 import springfox.documentation.schema.mixins.TypesForTestingSupport
 
+import java.lang.reflect.Method
+import java.lang.reflect.Modifier
+
 import static springfox.documentation.spi.DocumentationType.*
 import static springfox.documentation.spi.schema.contexts.ModelContext.*
 
@@ -73,6 +76,15 @@ class TypeNameExtractorSpec extends SchemaSpecification {
       genericClassWithGenericField() | "GenericType«ResponseEntityAlternative«SimpleType»»"
       hashMap(String, SimpleType)    | "Map«string,SimpleType»"
       hashMap(String, String)        | "Map«string,string»"
+  }
+
+  def "TypeNameExtractor.asResolved(Model) should be accessible from subclasses" (){
+    given:
+      Method mapPropertiesMethod = TypeNameExtractor.class.getDeclaredMethod("asResolved", java.lang.reflect.Type.class);
+    when:
+      def modifiers = mapPropertiesMethod.getModifiers();
+    then:
+      Modifier.isProtected(modifiers);
   }
   //TODO: test cases for parent (withAndWithout)
 }

--- a/springfox-swagger2/src/main/java/springfox/documentation/swagger2/mappers/ModelMapper.java
+++ b/springfox-swagger2/src/main/java/springfox/documentation/swagger2/mappers/ModelMapper.java
@@ -70,7 +70,7 @@ public abstract class ModelMapper {
     return map;
   }
 
-  private Model mapProperties(springfox.documentation.schema.Model source) {
+  protected Model mapProperties(springfox.documentation.schema.Model source) {
     ModelImpl model = new ModelImpl()
         .description(source.getDescription())
         .discriminator(source.getDiscriminator())

--- a/springfox-swagger2/src/test/groovy/springfox/documentation/swagger2/mappers/ModelMapperSpec.groovy
+++ b/springfox-swagger2/src/test/groovy/springfox/documentation/swagger2/mappers/ModelMapperSpec.groovy
@@ -36,6 +36,9 @@ import static com.google.common.base.Suppliers.*
 import static com.google.common.collect.Maps.*
 import static springfox.documentation.schema.ResolvedTypes.*
 import static springfox.documentation.spi.schema.contexts.ModelContext.*
+import java.lang.reflect.Method
+import java.lang.reflect.Modifier
+
 import static springfox.documentation.swagger2.mappers.ModelMapper.safeInteger
 
 @Mixin([TypesForTestingSupport, AlternateTypesSupport])
@@ -354,6 +357,15 @@ class ModelMapperSpec extends SchemaSpecification {
     then:
       mapped != null
       ['d', 'c', 'b', 'a', 'e'] == mapped['test'].properties.keySet().toList()
+  }
+
+  def "ModelMapper.mapProperties(Model) should be overridable" (){
+    given:
+      Method mapPropertiesMethod = ModelMapper.class.getDeclaredMethod("mapProperties", springfox.documentation.schema.Model.class);
+    when:
+      def modifiers = mapPropertiesMethod.getModifiers();
+    then:
+      Modifier.isProtected(modifiers);
   }
 
   def "model property positions affect the serialization order with same positions" () {


### PR DESCRIPTION
#### What's this PR do/fix?
It changed some modifiers of 4 classes from private to protected (and extracted one method), so enum type references (as proposed with #1738) could be implemented.

#### Are there unit tests? If not how should this be manually tested?
I added unit tests with separate commit - testing using reflection that methods have now `protected` modifier, so subclasses can override or invoke them.

#### What are the relevant issues?
Issue: #1738