### PR TITLE
Use Guava 20.0 throughout the project

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -23,7 +23,7 @@ repositories {
 dependencies {
   compile gradleApi()
   compile localGroovy() //Gradle 2.3 -> Groovy 2.3.9
-  compile "com.google.guava:guava:18.0"
+  compile "com.google.guava:guava:20.0"
   testCompile 'org.spockframework:spock-core:1.1-groovy-2.4-rc-4@jar'
   testCompile 'junit:junit:4.12'
 }


### PR DESCRIPTION
#### What's this PR do/fix?
Fixes #1833 by setting `buildSrc/build.gradle` to use [the same Guava version as `gradle/dependencies.gradle`](https://github.com/springfox/springfox/blob/00880edbcf7fb5a53be5da9e51f9695b9c08445b/gradle/dependencies.gradle#L6).
#### Are there unit tests? If not how should this be manually tested?
This can be tested with existing unit tests.
#### Any background context you want to provide?
Guava 20.0 is the last version that supports Java 1.6, so there should be no compatibility concerns.
#### What are the relevant issues?
No known issues with this pull request.