### PR TITLE
Support explicit ordering for Tags

### DIFF
--- a/springfox-core/src/main/java/springfox/documentation/builders/ApiListingBuilder.java
+++ b/springfox-core/src/main/java/springfox/documentation/builders/ApiListingBuilder.java
@@ -52,7 +52,7 @@ public class ApiListingBuilder {
   private List<SecurityReference> securityReferences = newArrayList();
   private List<ApiDescription> apis = newArrayList();
 
-  private final Set<Tag> tags = newTreeSet(tagNameComparator());
+  private final Set<Tag> tags = newTreeSet(tagComparator());
   private final Set<String> tagNames = newHashSet();
   private final Map<String, Model> models = newHashMap();
   private final Map<String, Tag> tagLookup = newHashMap();

--- a/springfox-core/src/main/java/springfox/documentation/service/Tag.java
+++ b/springfox-core/src/main/java/springfox/documentation/service/Tag.java
@@ -20,17 +20,24 @@
 package springfox.documentation.service;
 
 import com.google.common.base.Objects;
+import org.springframework.core.Ordered;
 
 import static com.google.common.base.Preconditions.*;
 import static com.google.common.base.Strings.*;
 
-public class Tag {
+public class Tag implements Ordered {
   private final String name;
   private final String description;
+  private final int order;
 
   public Tag(String name, String description) {
+    this(name, description, Integer.MAX_VALUE);
+  }
+
+  public Tag(String name, String description, int order) {
     this.name = checkNotNull(emptyToNull(name));
     this.description = description;
+    this.order = order;
   }
 
   public String getName() {
@@ -39,6 +46,11 @@ public class Tag {
 
   public String getDescription() {
     return description;
+  }
+
+  @Override
+  public int getOrder() {
+    return order;
   }
 
   @Override

--- a/springfox-core/src/main/java/springfox/documentation/service/Tags.java
+++ b/springfox-core/src/main/java/springfox/documentation/service/Tags.java
@@ -45,16 +45,17 @@ public class Tags {
     List<Tag> tags = from(allListings)
         .transformAndConcat(collectTags())
         .toList();
-    TreeSet<Tag> tagSet = newTreeSet(tagNameComparator());
+    TreeSet<Tag> tagSet = newTreeSet(tagComparator());
     tagSet.addAll(tags);
     return tagSet;
   }
 
-  public static Comparator<Tag> tagNameComparator() {
+  public static Comparator<Tag> tagComparator() {
     return new Comparator<Tag>() {
       @Override
       public int compare(Tag first, Tag second) {
-        return first.getName().compareTo(second.getName());
+        int orderCompare = Integer.valueOf(first.getOrder()).compareTo(second.getOrder());
+        return orderCompare != 0 ? orderCompare : first.getName().compareTo(second.getName());
       }
     };
   }

--- a/springfox-core/src/test/groovy/springfox/documentation/service/TagSpec.groovy
+++ b/springfox-core/src/test/groovy/springfox/documentation/service/TagSpec.groovy
@@ -29,6 +29,7 @@ class TagSpec extends Specification {
       tag.with {
         getName()
         getDescription()
+        getOrder()
       }
   }
 

--- a/springfox-core/src/test/groovy/springfox/documentation/service/TagsSpec.groovy
+++ b/springfox-core/src/test/groovy/springfox/documentation/service/TagsSpec.groovy
@@ -5,6 +5,7 @@ import com.google.common.collect.LinkedListMultimap
 import spock.lang.Specification
 
 import static springfox.documentation.service.Tags.emptyTags
+import static springfox.documentation.service.Tags.tagComparator
 import static springfox.documentation.service.Tags.toTags
 
 class TagsSpec extends Specification {
@@ -29,4 +30,16 @@ class TagsSpec extends Specification {
       FluentIterable.from(tags).filter(emptyTags()).size() == 1
   }
 
+  def "Comparator uses tag order" (Tag tag1, Tag tag2, expected) {
+    expect:
+      assert tagComparator().compare(tag1, tag2) == expected
+    where:
+      tag1                | tag2                | expected
+      new Tag("B", "", 1) | new Tag("A", "", 2) | -1
+      new Tag("B", "", 1) | new Tag("A", "", 1) | 1
+      new Tag("A", "", 1) | new Tag("A", "", 1) | 0
+      new Tag("A", "")    | new Tag("A", "")    | 0
+      new Tag("A", "")    | new Tag("B", "")    | -1
+      new Tag("B", "")    | new Tag("A", "")    | 1
+  }
 }

--- a/springfox-spi/src/main/java/springfox/documentation/spi/service/contexts/DocumentationContextBuilder.java
+++ b/springfox-spi/src/main/java/springfox/documentation/spi/service/contexts/DocumentationContextBuilder.java
@@ -66,7 +66,7 @@ public class DocumentationContextBuilder {
   private final Set<String> produces = newHashSet();
   private final Set<String> consumes = newHashSet();
   private final Set<ResolvedType> additionalModels = newHashSet();
-  private final Set<Tag> tags = newTreeSet(Tags.tagNameComparator());
+  private final Set<Tag> tags = newTreeSet(Tags.tagComparator());
   private List<VendorExtension> vendorExtensions = new ArrayList<VendorExtension>();
 
   private TypeResolver typeResolver;


### PR DESCRIPTION
Adds support for explicitly ordering `Tag`s when manually adding tags to a `Docket`

This code addresses issue https://github.com/springfox/springfox/issues/1900 and is based heavily off rainoko's code that was linked in the issue. A unit test was added to show that ordering tags should be ordered first based on priority and second by name. In order to support a second sorting order, the comparator is kept around, even though tags implement `Ordered` now.

(In other news, I don't know if this has been reported, but running the gradle tests on windows doesn't work if you have configured git to pull with windows line endings and push with unix line endings. This is  because the test cases often compare multiline strings and they will fail because of the added `\r` thanks to windows line endings.)
