### PR TITLE
Fix child expansion context creation

### DIFF
--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/parameter/ExpansionContext.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/parameter/ExpansionContext.java
@@ -73,7 +73,8 @@ public class ExpansionContext {
             String parentName,
             ResolvedType paramType,
             DocumentationContext documentationContext) {
-        seenTypes.add(paramType);
-        return new ExpansionContext(parentName, paramType, documentationContext, seenTypes);
+        Set<ResolvedType> childSeenTypes = newHashSet(seenTypes);
+        childSeenTypes.add(paramType);
+        return new ExpansionContext(parentName, paramType, documentationContext, childSeenTypes);
     }
 }

--- a/springfox-spring-web/src/test/java/springfox/documentation/spring/web/dummy/controllers/BugsController.java
+++ b/springfox-spring-web/src/test/java/springfox/documentation/spring/web/dummy/controllers/BugsController.java
@@ -148,6 +148,11 @@ public class BugsController {
     throw new UnsupportedOperationException();
   }
 
+  @RequestMapping(value = "2081", method = GET)
+  public void bug2081(Bug2081 criteria) {
+      throw new UnsupportedOperationException();
+  }
+
   @ApiOperation(value = "Remove an apple from a user", notes = "Remove an apple from a user. You must specify the "
       + "user name and the apple name.", response = Void.class, consumes = "application/json, application/xml",
       produces = "application/json, application/xml")
@@ -468,6 +473,35 @@ public class BugsController {
 
     public void setExample(Example example) {
       this.example = example;
+    }
+  }
+
+  public static class Bug2081Filter {
+    String importantField;
+
+    public String getImportantField() {
+      return importantField;
+    }
+
+    public void setImportantField(String importantField) {
+      this.importantField = importantField;
+    }
+  }
+
+  public static class Bug2081 {
+    Bug2081Filter a;
+    Bug2081Filter b;
+    public Bug2081Filter getA() {
+      return a;
+    }
+    public void setA(Bug2081Filter a) {
+      this.a = a;
+    }
+    public Bug2081Filter getB() {
+      return b;
+    }
+    public void setB(Bug2081Filter b) {
+      this.b = b;
     }
   }
 }

--- a/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-bugs-different-service.json
+++ b/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-bugs-different-service.json
@@ -916,7 +916,36 @@
           }
         }
       }
-    }
+    },
+    "/bugs/2081{?a.importantField,b.importantField}": {
+       "get": {
+         "tags": [
+           "Bugs"
+         ],
+         "summary": "bug2081",
+         "operationId": "bug2081UsingGET_2",
+         "consumes":["application/json"],
+         "parameters": [
+           {
+            "name": "a.importantField",
+            "in": "query",
+            "required":false,
+            "type":"string"
+           },
+           {
+            "name":"b.importantField",
+            "in":"query",
+            "required":false,
+            "type":"string"
+           }
+          ],
+          "responses": {
+            "200": {
+             "description": "OK"
+            }
+          }
+        }
+      }
   },
   "securityDefinitions": {
     "api_key": {

--- a/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-bugs-service.json
+++ b/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-bugs-service.json
@@ -927,7 +927,36 @@
           }
         }
       }
-    }
+    },
+    "/bugs/2081{?a.importantField,b.importantField}": {
+       "get": {
+         "tags": [
+           "Bugs"
+         ],
+         "summary": "bug2081",
+         "operationId": "bug2081UsingGET_1",
+         "consumes":["application/json"],
+         "parameters": [
+           {
+            "name": "a.importantField",
+            "in": "query",
+            "required":false,
+            "type":"string"
+           },
+           {
+            "name":"b.importantField",
+            "in":"query",
+            "required":false,
+            "type":"string"
+           }
+          ],
+          "responses": {
+            "200": {
+             "description": "OK"
+            }
+          }
+        }
+      }
   },
   "securityDefinitions": {
     "api_key": {


### PR DESCRIPTION
Because currently it modifies the parent expansion context's seenTypes collections,

this cause problems with parameters like:
```
 class SomeFilter {
   LongFilter id;
   LongFilter user;
 }
```

In this case, the user field was not expanded.

#### Any background context you want to provide?
#### What are the relevant issues?
 This issue is found in  #https://github.com/jhipster/generator-jhipster/issues/6543
