### PR TITLE
Allow ApiModelProperties on methods to be discovered from superclasses

### DIFF
--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/schema/ApiModelProperties.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/schema/ApiModelProperties.java
@@ -34,6 +34,7 @@ import springfox.documentation.service.AllowableValues;
 import springfox.documentation.spring.web.DescriptionResolver;
 
 import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.List;
 
@@ -102,7 +103,7 @@ public final class ApiModelProperties {
 
   static Function<ApiModelProperty, String> toDescription(
       final DescriptionResolver descriptions) {
-    
+
     return new Function<ApiModelProperty, String>() {
       @Override
       public String apply(ApiModelProperty annotation) {
@@ -131,7 +132,14 @@ public final class ApiModelProperties {
   }
 
   public static Optional<ApiModelProperty> findApiModePropertyAnnotation(AnnotatedElement annotated) {
-    return Optional.fromNullable(AnnotationUtils.getAnnotation(annotated, ApiModelProperty.class));
+    Optional<ApiModelProperty> annotation = Optional.absent();
+
+    if (annotated instanceof Method) {
+      // If the annotated element is a method we can use this information to check superclasses as well
+      annotation = Optional.fromNullable(AnnotationUtils.findAnnotation(((Method) annotated), ApiModelProperty.class));
+    }
+
+    return annotation.or(Optional.fromNullable(AnnotationUtils.getAnnotation(annotated, ApiModelProperty.class)));
   }
 
   static Function<ApiModelProperty, Boolean> toHidden() {

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/schema/ApiModelPropertyPropertyBuilderSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/schema/ApiModelPropertyPropertyBuilderSpec.groovy
@@ -92,6 +92,7 @@ class ApiModelPropertyPropertyBuilderSpec extends Specification {
     "enumProp"      | true     | "enum Prop Getter value"   | ["ONE"]         | false
     "readOnlyProp"  | false    | "readOnly property getter" | null            | true
     "listOfStrings" | false    | "Some description"         | null            | false
+    "interfaceProp" | true     | "interface Property Field" | null            | false
   }
 
   def "ApiModelProperty annotated models get enriched with additional info given an annotated element"() {
@@ -124,7 +125,7 @@ class ApiModelPropertyPropertyBuilderSpec extends Specification {
     "enumProp"      | true     | "enum Prop Getter value"   | ["ONE"]         | false
     "readOnlyProp"  | false    | "readOnly property getter" | null            | true
     "listOfStrings" | false    | "Some description"         | null            | false
-
+    "interfaceProp" | true     | "interface Property Field" | null            | false
   }
 
   def "ApiModelProperties marked as hidden properties are respected"() {

--- a/springfox-swagger-common/src/test/java/springfox/documentation/schema/TypeWithAnnotatedGettersAndSetters.java
+++ b/springfox-swagger-common/src/test/java/springfox/documentation/schema/TypeWithAnnotatedGettersAndSetters.java
@@ -25,7 +25,7 @@ import org.joda.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 
-public class TypeWithAnnotatedGettersAndSetters {
+public class TypeWithAnnotatedGettersAndSetters implements TypeWithAnnotatedGettersAndSettersInterface {
   @ApiModelProperty(notes = "int Property Field", required = true)
   private int intProp;
   private boolean boolProp;
@@ -38,6 +38,7 @@ public class TypeWithAnnotatedGettersAndSetters {
   @ApiModelProperty(value = "Some description")
   private List<String> listOfStrings;
   private Map<String, Map<String, Foo>> mapOfMaps;
+  private int interfaceProp;
 
   public int getIntProp() {
     return intProp;
@@ -117,6 +118,14 @@ public class TypeWithAnnotatedGettersAndSetters {
 
   public void setListOfStrings(List<String> listOfStrings) {
     this.listOfStrings = listOfStrings;
+  }
+
+  public int getInterfaceProp() {
+    return interfaceProp;
+  }
+
+  public void setInterfaceProp(int interfaceProp) {
+    this.interfaceProp = interfaceProp;
   }
 
   class Foo {

--- a/springfox-swagger-common/src/test/java/springfox/documentation/schema/TypeWithAnnotatedGettersAndSettersInterface.java
+++ b/springfox-swagger-common/src/test/java/springfox/documentation/schema/TypeWithAnnotatedGettersAndSettersInterface.java
@@ -1,0 +1,27 @@
+/*
+ *
+ *  Copyright 2015 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+
+package springfox.documentation.schema;
+
+import io.swagger.annotations.ApiModelProperty;
+
+public interface TypeWithAnnotatedGettersAndSettersInterface {
+  @ApiModelProperty(notes = "interface Property Field", required = true)
+  int getInterfaceProp();
+}


### PR DESCRIPTION
#### What's this PR do/fix?
Methods that have ApiModelProperty annotations on superclasses (or interfaces) were not discovered in all cases because `ApiModelProperties#findApiModePropertyAnnotation` only looks at direct annotations.

#### Are there unit tests? If not how should this be manually tested?
Yes

#### Any background context you want to provide?
`ApiModelPropertyPropertyBuilder` seems to correctly discover annotations when the annotated element is missing, but this is not the case otherwise.

#### What are the relevant issues?
I did not create an issue.