### PR TITLE
Fix conversion of byte to integer with max / min

### DIFF
--- a/springfox-swagger2/src/main/java/springfox/documentation/swagger2/mappers/Properties.java
+++ b/springfox-swagger2/src/main/java/springfox/documentation/swagger2/mappers/Properties.java
@@ -46,6 +46,7 @@ import io.swagger.models.properties.UUIDProperty;
 import springfox.documentation.schema.ModelProperty;
 import springfox.documentation.schema.ModelReference;
 
+import java.math.BigDecimal;
 import java.util.Comparator;
 import java.util.Map;
 
@@ -149,9 +150,11 @@ class Properties {
     return new Function<String, Property>() {
       @Override
       public Property apply(String input) {
-        StringProperty byteArray = new StringProperty();
-        byteArray.setFormat("byte");
-        return byteArray;
+        final IntegerProperty integerProperty = new IntegerProperty();
+        integerProperty.setFormat("int32");
+        integerProperty.setMaximum(BigDecimal.valueOf(Byte.MAX_VALUE));
+        integerProperty.setMinimum(BigDecimal.valueOf(Byte.MIN_VALUE));
+        return integerProperty;
       }
     };
   }

--- a/springfox-swagger2/src/test/groovy/springfox/documentation/swagger2/mappers/PropertiesSpec.groovy
+++ b/springfox-swagger2/src/test/groovy/springfox/documentation/swagger2/mappers/PropertiesSpec.groovy
@@ -38,12 +38,14 @@ class PropertiesSpec extends Specification {
       property("void") == null
   }
 
-  def "byte is represented as a string with a format" () {
+  def "byte is represented as an integer with a format and minimum, maximum" () {
     when:
       def byteProp = property("byte")
     then:
-      byteProp instanceof StringProperty
-      byteProp.format == "byte"
+      byteProp instanceof IntegerProperty
+      byteProp.format == "int32"
+      byteProp.maximum == Byte.MAX_VALUE
+      byteProp.minimum == Byte.MIN_VALUE
   }
 
   def "List is represented as a string with a format" () {
@@ -96,7 +98,7 @@ class PropertiesSpec extends Specification {
       "biginteger"| BaseIntegerProperty
       "uuid"      | UUIDProperty
       "object"    | ObjectProperty
-      "byte"      | StringProperty
+      "byte"      | IntegerProperty
       "INT"       | IntegerProperty
       "LONG"      | LongProperty
       "FLOAT"     | FloatProperty
@@ -109,7 +111,7 @@ class PropertiesSpec extends Specification {
       "BIGINTEGER"| BaseIntegerProperty
       "UUID"      | UUIDProperty
       "OBJECT"    | ObjectProperty
-      "BYTE"      | StringProperty
+      "BYTE"      | IntegerProperty
       "Anything"  | RefProperty
   }
 


### PR DESCRIPTION
#### What's this PR do/fix?

A single Byte/byte is represented as a (base64 encoded) String in the generated swagger API (type: `string`, format: `byte`).

This mapping does not work.

When using a Client generated with swagger-codegen, this fails miserably because for a single value, the generated client expects an Array.

#### Any background context you want to provide?

Here is a sample entity class:
```kotlin
@Entity data class Sample(val prop: Byte = 1)
```
For this class the server sends out a JSON object as follows:
```json
{
  "prop": 1
}
```
Alas, the api-spec generated by springfox-swagger is:
```yaml
prop:
     type: string
     format: byte
```