### PR TITLE
add @SwaggerExampleObject annotation.

### DIFF
--- a/springfox-core/src/main/java/springfox/documentation/builders/ModelBuilder.java
+++ b/springfox-core/src/main/java/springfox/documentation/builders/ModelBuilder.java
@@ -40,7 +40,7 @@ public class ModelBuilder {
   private String baseModel;
   private String discriminator;
   private ResolvedType modelType;
-  private String example;
+  private Object example;
   private Xml xml;
 
   private Map<String, ModelProperty> properties = newHashMap();
@@ -142,7 +142,7 @@ public class ModelBuilder {
    * @param example - example of the model
    * @return this
    */
-  public ModelBuilder example(String example) {
+  public ModelBuilder example(Object example) {
     this.example = defaultIfAbsent(example, this.example);
     return this;
   }

--- a/springfox-core/src/main/java/springfox/documentation/schema/Model.java
+++ b/springfox-core/src/main/java/springfox/documentation/schema/Model.java
@@ -35,7 +35,7 @@ public class Model {
   private final String baseModel;
   private final String discriminator;
   private final List<String> subTypes;
-  private final String example;
+  private final Object example;
   private final Xml xml;
 
   public Model(
@@ -48,7 +48,7 @@ public class Model {
       String baseModel,
       String discriminator,
       List<String> subTypes,
-      String example,
+      Object example,
       Xml xml) {
 
     this.id = id;
@@ -100,7 +100,7 @@ public class Model {
     return type;
   }
 
-  public String getExample() {
+  public Object getExample() {
     return example;
   }
 

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/annotations/SwaggerExampleObject.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/annotations/SwaggerExampleObject.java
@@ -1,0 +1,31 @@
+/*
+ *
+ *  Copyright 2015 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+
+package springfox.documentation.swagger.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SwaggerExampleObject {
+    Class example();
+}

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/schema/ApiModelBuilder.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/schema/ApiModelBuilder.java
@@ -28,6 +28,7 @@ import org.springframework.stereotype.Component;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spi.schema.ModelBuilderPlugin;
 import springfox.documentation.spi.schema.contexts.ModelContext;
+import springfox.documentation.swagger.annotations.SwaggerExampleObject;
 import springfox.documentation.swagger.common.SwaggerPluginSupport;
 
 import static springfox.documentation.swagger.common.SwaggerPluginSupport.*;
@@ -48,6 +49,15 @@ public class ApiModelBuilder implements ModelBuilderPlugin {
     ApiModel annotation = AnnotationUtils.findAnnotation(forClass(context), ApiModel.class);
     if (annotation != null) {
       context.getBuilder().description(annotation.description());
+    }
+    SwaggerExampleObject exampleObjectAnnotation =
+            AnnotationUtils.findAnnotation(forClass(context), SwaggerExampleObject.class);
+    if (exampleObjectAnnotation != null) {
+      Class clazz = exampleObjectAnnotation.example();
+      try {
+        context.getBuilder().example(clazz.newInstance());
+      } catch (Exception ignored) {
+      }
     }
   }
 


### PR DESCRIPTION
#### What's this PR do/fix?
Add new `@SwaggerExampleObject` annotation. It allows to specify class with non-argument constructor which create example object. So we can create example not only string type. Later swagger will serialize this object in standard way.
#### Are there unit tests? If not how should this be manually tested?
Unfortunately no
#### Any background context you want to provide?
There is example project https://github.com/gena-moscow/springfox-example-object
#### What are the relevant issues?
Inheritance, parent class support