### PR TITLE
Swagger ui 3.x suggested improvements

### DIFF
--- a/springfox-spring-config/src/main/java/springfox/springconfig/Swagger2SpringBoot.java
+++ b/springfox-spring-config/src/main/java/springfox/springconfig/Swagger2SpringBoot.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2015 the original author or authors.
+ *  Copyright 2015-2018 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -30,10 +30,10 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.context.request.async.DeferredResult;
+import springfox.documentation.builders.ParameterBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.builders.ResponseMessageBuilder;
-import springfox.documentation.builders.ParameterBuilder;
 import springfox.documentation.schema.ModelRef;
 import springfox.documentation.schema.WildcardType;
 import springfox.documentation.service.ApiKey;
@@ -43,16 +43,21 @@ import springfox.documentation.service.Tag;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spi.service.contexts.SecurityContext;
 import springfox.documentation.spring.web.plugins.Docket;
-import springfox.documentation.swagger.web.ApiKeyVehicle;
+import springfox.documentation.swagger.web.DocExpansion;
+import springfox.documentation.swagger.web.ModelRendering;
+import springfox.documentation.swagger.web.OperationsSorter;
 import springfox.documentation.swagger.web.SecurityConfiguration;
+import springfox.documentation.swagger.web.SecurityConfigurationBuilder;
+import springfox.documentation.swagger.web.TagsSorter;
 import springfox.documentation.swagger.web.UiConfiguration;
+import springfox.documentation.swagger.web.UiConfigurationBuilder;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 import springfox.petstore.controller.PetController;
 
 import java.util.List;
 
-import static com.google.common.collect.Lists.*;
-import static springfox.documentation.schema.AlternateTypeRules.*;
+import static com.google.common.collect.Lists.newArrayList;
+import static springfox.documentation.schema.AlternateTypeRules.newRule;
 
 @SpringBootApplication
 @EnableSwagger2//<1>
@@ -92,7 +97,7 @@ public class Swagger2SpringBoot {
         .securityContexts(newArrayList(securityContext()))//<15>
         .enableUrlTemplating(true)//<21>
         .globalOperationParameters(//<22>
-            newArrayList(new ParameterBuilder() 
+            newArrayList(new ParameterBuilder()
                 .name("someGlobalParameter")
                 .description("Description of someGlobalParameter")
                 .modelRef(new ModelRef("string"))
@@ -129,27 +134,34 @@ public class Swagger2SpringBoot {
 
   @Bean
   SecurityConfiguration security() {
-    return new SecurityConfiguration(//<19>
-        "test-app-client-id",
-        "test-app-client-secret",
-        "test-app-realm",
-        "test-app",
-        "apiKey",
-        ApiKeyVehicle.HEADER, //<23>
-        "api_key", //<24>
-        "," /*scope separator*/);
+    return SecurityConfigurationBuilder.builder()//<19>
+        .clientId("test-app-client-id")
+        .clientSecret("test-app-client-secret")
+        .realm("test-app-realm")
+        .appName("test-app")
+        .scopeSeparator(",")
+        .additionalQueryStringParams(null)
+        .useBasicAuthenticationWithAccessCodeGrant(false)
+        .build();
   }
 
   @Bean
   UiConfiguration uiConfig() {
-    return new UiConfiguration(//<20>
-        "validatorUrl",// url
-        "none",       // docExpansion          => none | list
-        "alpha",      // apiSorter             => alpha
-        "schema",     // defaultModelRendering => schema
-        UiConfiguration.Constants.DEFAULT_SUBMIT_METHODS,
-        false,        // enableJsonEditor      => true | false
-        true,         // showRequestHeaders    => true | false
-        60000L);      // requestTimeout => in milliseconds, defaults to null (uses jquery xh timeout)
+    return UiConfigurationBuilder.builder()//<20>
+        .deepLinking(true)
+        .displayOperationId(false)
+        .defaultModelsExpandDepth(1)
+        .defaultModelExpandDepth(1)
+        .defaultModelRendering(ModelRendering.EXAMPLE)
+        .displayRequestDuration(false)
+        .docExpansion(DocExpansion.NONE)
+        .filter(false)
+        .maxDisplayedTags(null)
+        .operationsSorter(OperationsSorter.ALPHA)
+        .showExtensions(false)
+        .tagsSorter(TagsSorter.ALPHA)
+        .validatorUrl(null)
+        .build();
   }
+
 }

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/ApiKeyVehicle.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/ApiKeyVehicle.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2018 the original author or authors.
+ *  Copyright 2015 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -18,29 +18,17 @@
  */
 package springfox.documentation.swagger.web;
 
-import com.fasterxml.jackson.annotation.JsonValue;
-
-public enum OperationsSorter {
-  ALPHA("alpha"),
-  METHOD("method");
+public enum ApiKeyVehicle {
+  HEADER("header"),
+  QUERY_PARAM("query");
 
   private final String value;
 
-  OperationsSorter(String value) {
+  ApiKeyVehicle(String value) {
     this.value = value;
   }
 
-  @JsonValue
   public String getValue() {
     return value;
-  }
-
-  public static OperationsSorter of(String name) {
-    for (OperationsSorter operationsSorter : OperationsSorter.values()) {
-      if (operationsSorter.value.equals(name)) {
-        return operationsSorter;
-      }
-    }
-    return null;
   }
 }

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/ApiResourceController.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/ApiResourceController.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2015 the original author or authors.
+ *  Copyright 2015-2018 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -51,14 +51,14 @@ public class ApiResourceController {
   @ResponseBody
   public ResponseEntity<SecurityConfiguration> securityConfiguration() {
     return new ResponseEntity<SecurityConfiguration>(
-        Optional.fromNullable(securityConfiguration).or(SecurityConfiguration.DEFAULT), HttpStatus.OK);
+        Optional.fromNullable(securityConfiguration).or(SecurityConfigurationBuilder.builder().build()), HttpStatus.OK);
   }
 
   @RequestMapping(value = "/configuration/ui")
   @ResponseBody
   public ResponseEntity<UiConfiguration> uiConfiguration() {
     return new ResponseEntity<UiConfiguration>(
-        Optional.fromNullable(uiConfiguration).or(UiConfiguration.DEFAULT), HttpStatus.OK);
+        Optional.fromNullable(uiConfiguration).or(UiConfigurationBuilder.builder().build()), HttpStatus.OK);
   }
 
   @RequestMapping
@@ -66,5 +66,4 @@ public class ApiResourceController {
   public ResponseEntity<List<SwaggerResource>> swaggerResources() {
     return new ResponseEntity<List<SwaggerResource>>(swaggerResources.get(), HttpStatus.OK);
   }
-
 }

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/DocExpansion.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/DocExpansion.java
@@ -35,4 +35,13 @@ public enum DocExpansion {
   public String getValue() {
     return value;
   }
+
+  public static DocExpansion of(String name) {
+    for (DocExpansion docExpansion : DocExpansion.values()) {
+      if (docExpansion.value.equals(name)) {
+        return docExpansion;
+      }
+    }
+    return null;
+  }
 }

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/DocExpansion.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/DocExpansion.java
@@ -1,0 +1,38 @@
+/*
+ *
+ *  Copyright 2018 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package springfox.documentation.swagger.web;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum DocExpansion {
+  NONE("none"),
+  LIST("list"),
+  FULL("full");
+
+  private final String value;
+
+  DocExpansion(String value) {
+    this.value = value;
+  }
+
+  @JsonValue
+  public String getValue() {
+    return value;
+  }
+}

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/InMemorySwaggerResourcesProvider.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/InMemorySwaggerResourcesProvider.java
@@ -82,7 +82,7 @@ public class InMemorySwaggerResourcesProvider implements SwaggerResourcesProvide
   private SwaggerResource resource(String swaggerGroup, String baseUrl) {
     SwaggerResource swaggerResource = new SwaggerResource();
     swaggerResource.setName(swaggerGroup);
-    swaggerResource.setLocation(swaggerLocation(baseUrl, swaggerGroup));
+    swaggerResource.setUrl(swaggerLocation(baseUrl, swaggerGroup));
     return swaggerResource;
   }
 

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/ModelRendering.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/ModelRendering.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2015 the original author or authors.
+ *  Copyright 2018 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -18,16 +18,19 @@
  */
 package springfox.documentation.swagger.web;
 
-public enum ApiKeyVehicle {
-  HEADER("header"),
-  QUERY_PARAM("query");
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum ModelRendering {
+  EXAMPLE("example"),
+  MODEL("model");
 
   private final String value;
 
-  ApiKeyVehicle(String value) {
+  ModelRendering(String value) {
     this.value = value;
   }
 
+  @JsonValue
   public String getValue() {
     return value;
   }

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/ModelRendering.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/ModelRendering.java
@@ -34,4 +34,13 @@ public enum ModelRendering {
   public String getValue() {
     return value;
   }
+
+  public static ModelRendering of(String name) {
+    for (ModelRendering modelRendering : ModelRendering.values()) {
+      if (modelRendering.value.equals(name)) {
+        return modelRendering;
+      }
+    }
+    return null;
+  }
 }

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/OperationsSorter.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/OperationsSorter.java
@@ -1,0 +1,37 @@
+/*
+ *
+ *  Copyright 2018 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package springfox.documentation.swagger.web;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum OperationsSorter {
+  ALPHA("alpha"),
+  METHOD("method");
+
+  private final String value;
+
+  OperationsSorter(String value) {
+    this.value = value;
+  }
+
+  @JsonValue
+  public String getValue() {
+    return value;
+  }
+}

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/SecurityConfiguration.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/SecurityConfiguration.java
@@ -21,45 +21,65 @@ package springfox.documentation.swagger.web;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Map;
+
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class SecurityConfiguration {
-  static final SecurityConfiguration DEFAULT = new SecurityConfiguration();
 
+  /*--------------------------------------------*\
+   * OAuth2
+  \*--------------------------------------------*/
   private final String clientId;
   private final String clientSecret;
   private final String realm;
   private final String appName;
-  private final String apiKey;
-  private final ApiKeyVehicle apiKeyVehicle;
   private final String scopeSeparator;
-  private final String apiKeyName;
+  private final Map<String, Object> additionalQueryStringParams;
+  private final Boolean useBasicAuthenticationWithAccessCodeGrant;
 
-  private SecurityConfiguration() {
-    this(null, null, null, null, null, ApiKeyVehicle.HEADER, "api_key", ",");
-  }
-
+  /**
+   * Default constructor
+   *
+   * @param clientId                                  Default clientId.
+   * @param clientSecret                              Default clientSecret.
+   * @param realm                                     Realm query parameter (for oauth1) added to authorizationUrl and
+   *                                                  tokenUrl.
+   * @param appName                                   Application name, displayed in authorization popup.
+   * @param scopeSeparator                            Scope separator for passing scopes, encoded before calling,
+   *                                                  default value is a space (encoded value %20).
+   * @param additionalQueryStringParams               Additional query parameters added to authorizationUrl and
+   *                                                  tokenUrl.
+   * @param useBasicAuthenticationWithAccessCodeGrant Only activated for the accessCode flow. During the
+   *                                                  authorization_code request to the tokenUrl, pass the Client
+   *                                                  Password using the HTTP Basic Authentication scheme (Authorization
+   *                                                  header with Basic base64encoded[client_id:client_secret]). The
+   *                                                  default is false.
+   */
   public SecurityConfiguration(
       String clientId,
       String clientSecret,
       String realm,
       String appName,
-      String apiKey,
-      ApiKeyVehicle apiKeyVehicle,
-      String apiKeyName,
-      String scopeSeparator) {
+      String scopeSeparator,
+      Map<String, Object> additionalQueryStringParams,
+      Boolean useBasicAuthenticationWithAccessCodeGrant) {
     this.clientId = clientId;
     this.clientSecret = clientSecret;
     this.realm = realm;
     this.appName = appName;
-    this.apiKey = apiKey;
-    this.apiKeyVehicle = apiKeyVehicle;
-    this.apiKeyName = apiKeyName;
     this.scopeSeparator = scopeSeparator;
+    this.additionalQueryStringParams = additionalQueryStringParams;
+    this.useBasicAuthenticationWithAccessCodeGrant = useBasicAuthenticationWithAccessCodeGrant;
   }
 
   @JsonProperty("clientId")
   public String getClientId() {
     return clientId;
+  }
+
+  @JsonProperty("clientSecret")
+  public String getClientSecret() {
+    return clientSecret;
   }
 
   @JsonProperty("realm")
@@ -72,28 +92,18 @@ public class SecurityConfiguration {
     return appName;
   }
 
-  @JsonProperty("apiKey")
-  public String getApiKey() {
-    return apiKey;
-  }
-
-  @JsonProperty("apiKeyName")
-  public String getApiKeyName() {
-    return apiKeyName;
-  }
-
-  @JsonProperty("clientSecret")
-  public String getClientSecret() {
-    return clientSecret;
-  }
-
   @JsonProperty("scopeSeparator")
   public String scopeSeparator() {
     return scopeSeparator;
   }
 
-  @JsonProperty("apiKeyVehicle")
-  public String getApiKeyVehicle() {
-    return apiKeyVehicle.getValue();
+  @JsonProperty("additionalQueryStringParams")
+  public Map<String, Object> getAdditionalQueryStringParams() {
+    return additionalQueryStringParams;
+  }
+
+  @JsonProperty("useBasicAuthenticationWithAccessCodeGrant")
+  public Boolean getUseBasicAuthenticationWithAccessCodeGrant() {
+    return useBasicAuthenticationWithAccessCodeGrant;
   }
 }

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/SecurityConfiguration.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/SecurityConfiguration.java
@@ -18,6 +18,7 @@
  */
 package springfox.documentation.swagger.web;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -25,6 +26,25 @@ import java.util.Map;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class SecurityConfiguration {
+  /**
+   * @deprecated @since 2.8.0. Use the {@link SecurityConfigurationBuilder} instead
+   */
+  static final SecurityConfiguration DEFAULT = new SecurityConfiguration();
+
+  /**
+   * @deprecated @since 2.8.0. This field is unused
+   */
+  private String apiKey;
+
+  /**
+   * @deprecated @since 2.8.0. This field is unused
+   */
+  private ApiKeyVehicle apiKeyVehicle;
+
+  /**
+   * @deprecated @since 2.8.0. This field is unused
+   */
+  private String apiKeyName;
 
   /*--------------------------------------------*\
    * OAuth2
@@ -36,6 +56,39 @@ public class SecurityConfiguration {
   private final String scopeSeparator;
   private final Map<String, Object> additionalQueryStringParams;
   private final Boolean useBasicAuthenticationWithAccessCodeGrant;
+
+  /**
+   * @deprecated @since 2.8.0. Use the {@link SecurityConfigurationBuilder} instead
+   */
+  private SecurityConfiguration() {
+    this(null, null, null, null, null, ApiKeyVehicle.HEADER, "api_key", ",");
+  }
+
+  /**
+   * @deprecated @since 2.8.0. Use the {@link SecurityConfigurationBuilder} instead
+   */
+  @Deprecated
+  public SecurityConfiguration(
+      String clientId,
+      String clientSecret,
+      String realm,
+      String appName,
+      String apiKey,
+      ApiKeyVehicle apiKeyVehicle,
+      String apiKeyName,
+      String scopeSeparator) {
+    this.clientId = clientId;
+    this.clientSecret = clientSecret;
+    this.realm = realm;
+    this.appName = appName;
+    this.apiKey = apiKey;
+    this.apiKeyVehicle = apiKeyVehicle;
+    this.apiKeyName = apiKeyName;
+    this.scopeSeparator = scopeSeparator;
+
+    this.additionalQueryStringParams = null;
+    this.useBasicAuthenticationWithAccessCodeGrant = null;
+  }
 
   /**
    * Default constructor
@@ -70,6 +123,33 @@ public class SecurityConfiguration {
     this.scopeSeparator = scopeSeparator;
     this.additionalQueryStringParams = additionalQueryStringParams;
     this.useBasicAuthenticationWithAccessCodeGrant = useBasicAuthenticationWithAccessCodeGrant;
+  }
+
+  /**
+   * @deprecated @since 2.8.0
+   */
+  @Deprecated
+  @JsonIgnore
+  public String getApiKey() {
+    return apiKey;
+  }
+
+  /**
+   * @deprecated @since 2.8.0
+   */
+  @Deprecated
+  @JsonIgnore
+  public String getApiKeyName() {
+    return apiKeyName;
+  }
+
+  /**
+   * @deprecated @since 2.8.0
+   */
+  @Deprecated
+  @JsonIgnore
+  public String getApiKeyVehicle() {
+    return apiKeyVehicle.getValue();
   }
 
   @JsonProperty("clientId")

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/SecurityConfigurationBuilder.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/SecurityConfigurationBuilder.java
@@ -1,0 +1,117 @@
+/*
+ *
+ *  Copyright 2018 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package springfox.documentation.swagger.web;
+
+import java.util.Map;
+
+import static springfox.documentation.builders.BuilderDefaults.defaultIfAbsent;
+
+public class SecurityConfigurationBuilder {
+
+  /*--------------------------------------------*\
+   * OAuth2
+  \*--------------------------------------------*/
+  private String clientId;
+  private String clientSecret;
+  private String realm;
+  private String appName;
+  private String scopeSeparator;
+  private Map<String, Object> additionalQueryStringParams;
+  private Boolean useBasicAuthenticationWithAccessCodeGrant;
+
+  private SecurityConfigurationBuilder() {
+  }
+
+  public static SecurityConfigurationBuilder builder() {
+    return new SecurityConfigurationBuilder();
+  }
+
+  public SecurityConfiguration build() {
+    return new SecurityConfiguration(
+        defaultIfAbsent(clientId, null),
+        defaultIfAbsent(clientSecret, null),
+        defaultIfAbsent(realm, null),
+        defaultIfAbsent(appName, null),
+        defaultIfAbsent(scopeSeparator, null),
+        defaultIfAbsent(additionalQueryStringParams, null),
+        defaultIfAbsent(useBasicAuthenticationWithAccessCodeGrant, null)
+    );
+  }
+
+  /**
+   * @param clientId Default clientId.
+   */
+  public SecurityConfigurationBuilder clientId(String clientId) {
+    this.clientId = clientId;
+    return this;
+  }
+
+  /**
+   * @param clientSecret Default clientSecret.
+   */
+  public SecurityConfigurationBuilder clientSecret(String clientSecret) {
+    this.clientSecret = clientSecret;
+    return this;
+  }
+
+  /**
+   * @param realm Realm query parameter (for oauth1) added to authorizationUrl and tokenUrl.
+   */
+  public SecurityConfigurationBuilder realm(String realm) {
+    this.realm = realm;
+    return this;
+  }
+
+  /**
+   * @param appName Application name, displayed in authorization popup.
+   */
+  public SecurityConfigurationBuilder appName(String appName) {
+    this.appName = appName;
+    return this;
+  }
+
+  /**
+   * @param scopeSeparator Scope separator for passing scopes, encoded before calling, default value is a space (encoded
+   *                       value %20).
+   */
+  public SecurityConfigurationBuilder scopeSeparator(String scopeSeparator) {
+    this.scopeSeparator = scopeSeparator;
+    return this;
+  }
+
+  /**
+   * @param additionalQueryStringParams Additional query parameters added to authorizationUrl and tokenUrl.
+   */
+  public SecurityConfigurationBuilder additionalQueryStringParams(Map<String, Object> additionalQueryStringParams) {
+    this.additionalQueryStringParams = additionalQueryStringParams;
+    return this;
+  }
+
+  /**
+   * @param useBasicAuthenticationWithAccessCodeGrant Only activated for the accessCode flow. During the
+   *                                                  authorization_code request to the tokenUrl, pass the Client
+   *                                                  Password using the HTTP Basic Authentication scheme (Authorization
+   *                                                  header with Basic base64encoded[client_id:client_secret]). The
+   *                                                  default is false.
+   */
+  public SecurityConfigurationBuilder useBasicAuthenticationWithAccessCodeGrant(Boolean useBasicAuthenticationWithAccessCodeGrant) {
+    this.useBasicAuthenticationWithAccessCodeGrant = useBasicAuthenticationWithAccessCodeGrant;
+    return this;
+  }
+}

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/SwaggerResource.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/SwaggerResource.java
@@ -25,7 +25,7 @@ import com.google.common.collect.ComparisonChain;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class SwaggerResource implements Comparable<SwaggerResource> {
   private String name;
-  private String location;
+  private String url;
   private String swaggerVersion;
 
   @JsonProperty("name")
@@ -37,13 +37,13 @@ public class SwaggerResource implements Comparable<SwaggerResource> {
     this.name = name;
   }
 
-  @JsonProperty("location")
-  public String getLocation() {
-    return location;
+  @JsonProperty("url")
+  public String getUrl() {
+    return url;
   }
 
-  public void setLocation(String location) {
-    this.location = location;
+  public void setUrl(String url) {
+    this.url = url;
   }
 
   @JsonProperty("swaggerVersion")

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/TagsSorter.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/TagsSorter.java
@@ -1,0 +1,36 @@
+/*
+ *
+ *  Copyright 2018 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package springfox.documentation.swagger.web;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum TagsSorter {
+  ALPHA("alpha");
+
+  private final String value;
+
+  TagsSorter(String value) {
+    this.value = value;
+  }
+
+  @JsonValue
+  public String getValue() {
+    return value;
+  }
+}

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/TagsSorter.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/TagsSorter.java
@@ -33,4 +33,13 @@ public enum TagsSorter {
   public String getValue() {
     return value;
   }
+
+  public static TagsSorter of(String name) {
+    for (TagsSorter tagsSorter : TagsSorter.values()) {
+      if (tagsSorter.value.equals(name)) {
+        return tagsSorter;
+      }
+    }
+    return null;
+  }
 }

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/UiConfiguration.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/UiConfiguration.java
@@ -18,11 +18,47 @@
  */
 package springfox.documentation.swagger.web;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class UiConfiguration {
+  /**
+   * @deprecated @since 2.8.0. Use the {@link UiConfigurationBuilder} instead
+   */
+  @Deprecated
+  static final UiConfiguration DEFAULT = new UiConfiguration(null);
+
+  /**
+   * @deprecated @since 2.8.0. This field is unused
+   */
+  @Deprecated
+  private String apisSorter;
+
+  /**
+   * @deprecated @since 2.8.0. This field is unused
+   */
+  @Deprecated
+  private Long requestTimeout;
+
+  /**
+   * @deprecated @since 2.8.0. This field is unused
+   */
+  @Deprecated
+  private String[] supportedSubmitMethods;
+
+  /**
+   * @deprecated @since 2.8.0. This field is unused
+   */
+  @Deprecated
+  private boolean jsonEditor;
+
+  /**
+   * @deprecated @since 2.8.0. This field is unused
+   */
+  @Deprecated
+  private boolean showRequestHeaders;
 
   /*--------------------------------------------*\
    * Display
@@ -44,6 +80,120 @@ public class UiConfiguration {
    * Network
   \*--------------------------------------------*/
   private final String validatorUrl;
+
+  /**
+   * @deprecated @since 2.8.0. Use the {@link UiConfigurationBuilder} instead
+   */
+  public UiConfiguration(String validatorUrl) {
+    this(validatorUrl, "none", "alpha", "schema", Constants.DEFAULT_SUBMIT_METHODS, false, true, null);
+  }
+
+  /**
+   * @deprecated @since 2.8.0. Use the {@link UiConfigurationBuilder} instead
+   */
+  public UiConfiguration(String validatorUrl, String[] supportedSubmitMethods) {
+    this(validatorUrl, "none", "alpha", "schema", supportedSubmitMethods, false, true, null);
+  }
+
+  /** * Use the default constructor instead (with requestTimeout)
+   * {@link UiConfiguration#UiConfiguration(String, String, String, String, String[], boolean, boolean, Long)} )}
+   *
+   * @param validatorUrl           By default, Swagger-UI attempts to validate specs against swagger.io's online
+   *                               validator. You can use this parameter to set a different validator URL, for example
+   *                               for locally deployed validators (Validator Badge). Setting it to null will disable
+   *                               validation. This parameter is relevant for Swagger 2.0 specs only.
+   * @param docExpansion           Controls how the API listing is displayed. It can be set to 'none' (default),
+   *                               'list' (shows operations for each resource), or 'full' (fully expanded: shows
+   *                               operations and their details).
+   * @param apisSorter             Apply a sort to the API/tags list. It can be 'alpha' (sort by name) or a function
+   *                               (see Array.prototype.sort() to know how sort function works). Default is the order
+   *                               returned by the server unchanged.
+   * @param defaultModelRendering  Controls how models are shown when the API is first rendered. (The user can
+   *                               always switch the rendering for a given model by clicking the 'Model' and 'Model
+   *                               Schema' links.) It can be set to 'model' or 'schema', and the default is 'schema'.
+   * @param supportedSubmitMethods An array of of the HTTP operations that will have the 'Try it out!' option. An
+   *                               empty array disables all operations. This does not filter the operations from the
+   *                               display.
+   * @param jsonEditor             Enables a graphical view for editing complex bodies. Defaults to false.
+   * @param showRequestHeaders     Whether or not to show the headers that were sent when making a request via the
+   *                               'Try it out!' option. Defaults to false.
+   * @deprecated @since 2.6.1. Use the {@link UiConfigurationBuilder} instead
+   */
+  @Deprecated
+  public UiConfiguration(
+      String validatorUrl,
+      String docExpansion,
+      String apisSorter,
+      String defaultModelRendering,
+      String[] supportedSubmitMethods,
+      boolean jsonEditor,
+      boolean showRequestHeaders) {
+    this(
+        validatorUrl,
+        docExpansion,
+        apisSorter,
+        defaultModelRendering,
+        supportedSubmitMethods,
+        jsonEditor,
+        showRequestHeaders,
+        null);
+  }
+
+  /**
+   * Default constructor
+   *
+   * @param validatorUrl           By default, Swagger-UI attempts to validate specs against swagger.io's online
+   *                               validator. You can use this parameter to set a different validator URL, for example
+   *                               for locally deployed validators (Validator Badge). Setting it to null will disable
+   *                               validation. This parameter is relevant for Swagger 2.0 specs only.
+   * @param docExpansion           Controls how the API listing is displayed. It can be set to 'none' (default),
+   *                               'list' (shows operations for each resource), or 'full' (fully expanded: shows
+   *                               operations and their details).
+   * @param apisSorter             Apply a sort to the API/tags list. It can be 'alpha' (sort by name) or a function
+   *                               (see Array.prototype.sort() to know how sort function works). Default is the order
+   *                               returned by the server unchanged.
+   * @param defaultModelRendering  Controls how models are shown when the API is first rendered. (The user can
+   *                               always switch the rendering for a given model by clicking the 'Model' and 'Model
+   *                               Schema' links.) It can be set to 'model' or 'schema', and the default is 'schema'.
+   * @param supportedSubmitMethods An array of of the HTTP operations that will have the 'Try it out!' option. An
+   *                               empty array disables all operations. This does not filter the operations from the
+   *                               display.
+   * @param jsonEditor             Enables a graphical view for editing complex bodies. Defaults to false.
+   * @param showRequestHeaders     Whether or not to show the headers that were sent when making a request via the
+   *                               'Try it out!' option. Defaults to false.
+   * @param requestTimeout         - XHR timeout
+   * @deprecated @since 2.8.0. Use the {@link UiConfigurationBuilder} instead
+   */
+  @Deprecated
+  public UiConfiguration(
+      String validatorUrl,
+      String docExpansion,
+      String apisSorter,
+      String defaultModelRendering,
+      String[] supportedSubmitMethods,
+      boolean jsonEditor,
+      boolean showRequestHeaders,
+      Long requestTimeout) {
+    this.validatorUrl = validatorUrl;
+    this.docExpansion = DocExpansion.of(docExpansion);
+    this.apisSorter = apisSorter;
+    this.defaultModelRendering = ModelRendering.of(defaultModelRendering);
+    this.requestTimeout = requestTimeout;
+    this.jsonEditor = jsonEditor;
+    this.showRequestHeaders = showRequestHeaders;
+    this.supportedSubmitMethods = supportedSubmitMethods;
+
+    this.deepLinking = true;
+    this.displayOperationId = false;
+    this.defaultModelsExpandDepth = 1;
+    this.defaultModelExpandDepth = 1;
+    this.displayRequestDuration = false;
+    this.filter = false;
+    this.maxDisplayedTags = null;
+    this.operationsSorter = OperationsSorter.of(apisSorter);
+    this.showExtensions = false;
+    this.tagsSorter = TagsSorter.of(apisSorter);
+  }
 
   /**
    * Default constructor
@@ -112,6 +262,51 @@ public class UiConfiguration {
     this.validatorUrl = validatorUrl;
   }
 
+  /**
+   * @deprecated @since 2.8.0
+   */
+  @Deprecated
+  @JsonIgnore
+  public String getApisSorter() {
+    return apisSorter;
+  }
+
+  /**
+   * @deprecated @since 2.8.0
+   */
+  @Deprecated
+  @JsonIgnore
+  public String[] getSupportedSubmitMethods() {
+    return supportedSubmitMethods;
+  }
+
+  /**
+   * @deprecated @since 2.8.0
+   */
+  @Deprecated
+  @JsonIgnore
+  public boolean isJsonEditor() {
+    return jsonEditor;
+  }
+
+  /**
+   * @deprecated @since 2.8.0
+   */
+  @Deprecated
+  @JsonIgnore
+  public boolean isShowRequestHeaders() {
+    return showRequestHeaders;
+  }
+
+  /**
+   * @deprecated @since 2.8.0
+   */
+  @Deprecated
+  @JsonIgnore
+  public Long getRequestTimeout() {
+    return requestTimeout;
+  }
+
   @JsonProperty("deepLinking")
   public Boolean getDeepLinking() {
     return deepLinking;
@@ -175,5 +370,21 @@ public class UiConfiguration {
   @JsonProperty("validatorUrl")
   public String getValidatorUrl() {
     return validatorUrl;
+  }
+
+  /**
+   * @deprecated @since 2.8.0
+   */
+  @Deprecated
+  public static class Constants {
+    /**
+     * @deprecated @since 2.8.0
+     */
+    public static final String[] DEFAULT_SUBMIT_METHODS = new String[] { "get", "post", "put", "delete", "patch" };
+
+    /**
+     * @deprecated @since 2.8.0
+     */
+    public static final String[] NO_SUBMIT_METHODS = new String[] {};
   }
 }

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/UiConfiguration.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/UiConfiguration.java
@@ -23,155 +23,157 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class UiConfiguration {
-  static final UiConfiguration DEFAULT = new UiConfiguration(null);
+
+  /*--------------------------------------------*\
+   * Display
+  \*--------------------------------------------*/
+  private final Boolean deepLinking;
+  private final Boolean displayOperationId;
+  private final Integer defaultModelsExpandDepth;
+  private final Integer defaultModelExpandDepth;
+  private final ModelRendering defaultModelRendering;
+  private final Boolean displayRequestDuration;
+  private final DocExpansion docExpansion;
+  private final Object filter; // Boolean=false OR String
+  private final Integer maxDisplayedTags;
+  private final OperationsSorter operationsSorter;
+  private final Boolean showExtensions;
+  private final TagsSorter tagsSorter;
+
+  /*--------------------------------------------*\
+   * Network
+  \*--------------------------------------------*/
   private final String validatorUrl;
-  private final String docExpansion;
-  private final String apisSorter;
-  private final String defaultModelRendering;
-  private final Long requestTimeout;
-
-  private final String[] supportedSubmitMethods;
-
-  private final boolean jsonEditor;
-  private final boolean showRequestHeaders;
-
-  public UiConfiguration(String validatorUrl) {
-    this(validatorUrl, "none", "alpha", "schema", Constants.DEFAULT_SUBMIT_METHODS, false, true, null);
-  }
-
-  public UiConfiguration(String validatorUrl, String[] supportedSubmitMethods) {
-    this(validatorUrl, "none", "alpha", "schema", supportedSubmitMethods, false, true, null);
-  }
-
-  /** * Use the default constructor instead (with requestTimeout)
-   * {@link UiConfiguration#UiConfiguration(String, String, String, String, String[], boolean, boolean, Long)} )}
-   *
-   * @param validatorUrl           By default, Swagger-UI attempts to validate specs against swagger.io's online
-   *                               validator. You can use this parameter to set a different validator URL, for example
-   *                               for locally deployed validators (Validator Badge). Setting it to null will disable
-   *                               validation. This parameter is relevant for Swagger 2.0 specs only.
-   * @param docExpansion           Controls how the API listing is displayed. It can be set to 'none' (default),
-   *                               'list' (shows operations for each resource), or 'full' (fully expanded: shows
-   *                               operations and their details).
-   * @param apisSorter             Apply a sort to the API/tags list. It can be 'alpha' (sort by name) or a function
-   *                               (see Array.prototype.sort() to know how sort function works). Default is the order
-   *                               returned by the server unchanged.
-   * @param defaultModelRendering  Controls how models are shown when the API is first rendered. (The user can
-   *                               always switch the rendering for a given model by clicking the 'Model' and 'Model
-   *                               Schema' links.) It can be set to 'model' or 'schema', and the default is 'schema'.
-   * @param supportedSubmitMethods An array of of the HTTP operations that will have the 'Try it out!' option. An
-   *                               empty array disables all operations. This does not filter the operations from the
-   *                               display.
-   * @param jsonEditor             Enables a graphical view for editing complex bodies. Defaults to false.
-   * @param showRequestHeaders     Whether or not to show the headers that were sent when making a request via the
-   *                               'Try it out!' option. Defaults to false.
-   * @deprecated @since 2.6.1
-   */
-  @Deprecated
-  public UiConfiguration(
-      String validatorUrl,
-      String docExpansion,
-      String apisSorter,
-      String defaultModelRendering,
-      String[] supportedSubmitMethods,
-      boolean jsonEditor,
-      boolean showRequestHeaders) {
-    this(
-        validatorUrl,
-        docExpansion,
-        apisSorter,
-        defaultModelRendering,
-        supportedSubmitMethods,
-        jsonEditor,
-        showRequestHeaders,
-        null);
-  }
 
   /**
    * Default constructor
    *
-   * @param validatorUrl           By default, Swagger-UI attempts to validate specs against swagger.io's online
-   *                               validator. You can use this parameter to set a different validator URL, for example
-   *                               for locally deployed validators (Validator Badge). Setting it to null will disable
-   *                               validation. This parameter is relevant for Swagger 2.0 specs only.
-   * @param docExpansion           Controls how the API listing is displayed. It can be set to 'none' (default),
-   *                               'list' (shows operations for each resource), or 'full' (fully expanded: shows
-   *                               operations and their details).
-   * @param apisSorter             Apply a sort to the API/tags list. It can be 'alpha' (sort by name) or a function
-   *                               (see Array.prototype.sort() to know how sort function works). Default is the order
-   *                               returned by the server unchanged.
-   * @param defaultModelRendering  Controls how models are shown when the API is first rendered. (The user can
-   *                               always switch the rendering for a given model by clicking the 'Model' and 'Model
-   *                               Schema' links.) It can be set to 'model' or 'schema', and the default is 'schema'.
-   * @param supportedSubmitMethods An array of of the HTTP operations that will have the 'Try it out!' option. An
-   *                               empty array disables all operations. This does not filter the operations from the
-   *                               display.
-   * @param jsonEditor             Enables a graphical view for editing complex bodies. Defaults to false.
-   * @param showRequestHeaders     Whether or not to show the headers that were sent when making a request via the
-   *                               'Try it out!' option. Defaults to false.
-   * @param requestTimeout         - XHR timeout
+   * @param deepLinking              If set to true, enables deep linking for tags and operations. See the Deep Linking
+   *                                 documentation for more information.
+   * @param displayOperationId       Controls the display of operationId in operations list. The default is false.
+   * @param defaultModelsExpandDepth The default expansion depth for models (set to -1 completely hide the models).
+   * @param defaultModelExpandDepth  The default expansion depth for the model on the model-example section.
+   * @param defaultModelRendering    Controls how the model is shown when the API is first rendered. (The user can
+   *                                 always switch the rendering for a given model by clicking the 'Model' and 'Example
+   *                                 Value' links.)
+   * @param displayRequestDuration   Controls the display of the request duration (in milliseconds) for Try-It-Out
+   *                                 requests.
+   * @param docExpansion             Controls the default expansion setting for the operations and tags. It can be
+   *                                 'list' (expands only the tags), 'full' (expands the tags and operations) or 'none'
+   *                                 (expands nothing).
+   * @param filter                   If set, enables filtering. The top bar will show an edit box that you can use to
+   *                                 filter the tagged operations that are shown. Can be Boolean to enable or disable,
+   *                                 or a string, in which case filtering will be enabled using that string as the
+   *                                 filter expression. Filtering is case sensitive matching the filter expression
+   *                                 anywhere inside the tag.
+   * @param maxDisplayedTags         If set, limits the number of tagged operations displayed to at most this many. The
+   *                                 default is to show all operations.
+   * @param operationsSorter         Apply a sort to the operation list of each API. It can be 'alpha' (sort by paths
+   *                                 alphanumerically), 'method' (sort by HTTP method) or a function (see
+   *                                 Array.prototype.sort() to know how sort function works). Default is the order
+   *                                 returned by the server unchanged.
+   * @param showExtensions           Controls the display of vendor extension (x-) fields and values for Operations,
+   *                                 Parameters, and Schema.
+   * @param tagsSorter               Apply a sort to the tag list of each API. It can be 'alpha' (sort by paths
+   *                                 alphanumerically) or a function (see Array.prototype.sort() to learn how to write a
+   *                                 sort function). Two tag name strings are passed to the sorter for each pass.
+   *                                 Default is the order determined by Swagger-UI.
+   * @param validatorUrl             By default, Swagger-UI attempts to validate specs against swagger.io's online
+   *                                 validator. You can use this parameter to set a different validator URL, for example
+   *                                 for locally deployed validators (Validator Badge). Setting it to null will disable
+   *                                 validation. This parameter is relevant for Swagger 2.0 specs only.
    */
   public UiConfiguration(
-      String validatorUrl,
-      String docExpansion,
-      String apisSorter,
-      String defaultModelRendering,
-      String[] supportedSubmitMethods,
-      boolean jsonEditor,
-      boolean showRequestHeaders,
-      Long requestTimeout) {
-    this.validatorUrl = validatorUrl;
-    this.docExpansion = docExpansion;
-    this.apisSorter = apisSorter;
+      Boolean deepLinking,
+      Boolean displayOperationId,
+      Integer defaultModelsExpandDepth,
+      Integer defaultModelExpandDepth,
+      ModelRendering defaultModelRendering,
+      Boolean displayRequestDuration,
+      DocExpansion docExpansion,
+      Object filter,
+      Integer maxDisplayedTags,
+      OperationsSorter operationsSorter,
+      Boolean showExtensions,
+      TagsSorter tagsSorter,
+      String validatorUrl) {
+    this.deepLinking = deepLinking;
+    this.displayOperationId = displayOperationId;
+    this.defaultModelsExpandDepth = defaultModelsExpandDepth;
+    this.defaultModelExpandDepth = defaultModelExpandDepth;
     this.defaultModelRendering = defaultModelRendering;
-    this.requestTimeout = requestTimeout;
-    this.jsonEditor = jsonEditor;
-    this.showRequestHeaders = showRequestHeaders;
-    this.supportedSubmitMethods = supportedSubmitMethods;
+    this.displayRequestDuration = displayRequestDuration;
+    this.docExpansion = docExpansion;
+    this.filter = filter;
+    this.maxDisplayedTags = maxDisplayedTags;
+    this.operationsSorter = operationsSorter;
+    this.showExtensions = showExtensions;
+    this.tagsSorter = tagsSorter;
+    this.validatorUrl = validatorUrl;
+  }
+
+  @JsonProperty("deepLinking")
+  public Boolean getDeepLinking() {
+    return deepLinking;
+  }
+
+  @JsonProperty("displayOperationId")
+  public Boolean getDisplayOperationId() {
+    return displayOperationId;
+  }
+
+  @JsonProperty("defaultModelsExpandDepth")
+  public Integer getDefaultModelsExpandDepth() {
+    return defaultModelsExpandDepth;
+  }
+
+  @JsonProperty("defaultModelExpandDepth")
+  public Integer getDefaultModelExpandDepth() {
+    return defaultModelExpandDepth;
+  }
+
+  @JsonProperty("defaultModelRendering")
+  public ModelRendering getDefaultModelRendering() {
+    return defaultModelRendering;
+  }
+
+  @JsonProperty("displayRequestDuration")
+  public Boolean getDisplayRequestDuration() {
+    return displayRequestDuration;
+  }
+
+  @JsonProperty("docExpansion")
+  public DocExpansion getDocExpansion() {
+    return docExpansion;
+  }
+
+  @JsonProperty("filter")
+  public Object getFilter() {
+    return filter;
+  }
+
+  @JsonProperty("maxDisplayedTags")
+  public Integer getMaxDisplayedTags() {
+    return maxDisplayedTags;
+  }
+
+  @JsonProperty("operationsSorter")
+  public OperationsSorter getOperationsSorter() {
+    return operationsSorter;
+  }
+
+  @JsonProperty("showExtensions")
+  public Boolean getShowExtensions() {
+    return showExtensions;
+  }
+
+  @JsonProperty("tagsSorter")
+  public TagsSorter getTagsSorter() {
+    return tagsSorter;
   }
 
   @JsonProperty("validatorUrl")
   public String getValidatorUrl() {
     return validatorUrl;
-  }
-
-  @JsonProperty("docExpansion")
-  public String getDocExpansion() {
-    return docExpansion;
-  }
-
-  @JsonProperty("apisSorter")
-  public String getApisSorter() {
-    return apisSorter;
-  }
-
-  @JsonProperty("defaultModelRendering")
-  public String getDefaultModelRendering() {
-    return defaultModelRendering;
-  }
-
-  @JsonProperty("supportedSubmitMethods")
-  public String[] getSupportedSubmitMethods() {
-    return supportedSubmitMethods;
-  }
-
-  @JsonProperty("jsonEditor")
-  public boolean isJsonEditor() {
-    return jsonEditor;
-  }
-
-  @JsonProperty("showRequestHeaders")
-  public boolean isShowRequestHeaders() {
-    return showRequestHeaders;
-  }
-
-  @JsonProperty("requestTimeout")
-  public Long getRequestTimeout() {
-    return requestTimeout;
-  }
-
-  public static class Constants {
-    public static final String[] DEFAULT_SUBMIT_METHODS = new String[] { "get", "post", "put", "delete", "patch" };
-    public static final String[] NO_SUBMIT_METHODS = new String[] {};
   }
 }

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/UiConfigurationBuilder.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/UiConfigurationBuilder.java
@@ -1,0 +1,191 @@
+/*
+ *
+ *  Copyright 2018 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package springfox.documentation.swagger.web;
+
+import static springfox.documentation.builders.BuilderDefaults.defaultIfAbsent;
+
+public class UiConfigurationBuilder {
+
+  /*--------------------------------------------*\
+   * Display
+  \*--------------------------------------------*/
+  private Boolean deepLinking;
+  private Boolean displayOperationId;
+  private Integer defaultModelsExpandDepth;
+  private Integer defaultModelExpandDepth;
+  private ModelRendering defaultModelRendering;
+  private Boolean displayRequestDuration;
+  private DocExpansion docExpansion;
+  private Object filter; // Boolean=false OR String
+  private Integer maxDisplayedTags;
+  private OperationsSorter operationsSorter;
+  private Boolean showExtensions;
+  private TagsSorter tagsSorter;
+
+  /*--------------------------------------------*\
+   * Network
+  \*--------------------------------------------*/
+  private String validatorUrl;
+
+  private UiConfigurationBuilder() {
+  }
+
+  public static UiConfigurationBuilder builder() {
+    return new UiConfigurationBuilder();
+  }
+
+  public UiConfiguration build() {
+    return new UiConfiguration(
+        defaultIfAbsent(deepLinking, true),
+        defaultIfAbsent(displayOperationId, false),
+        defaultIfAbsent(defaultModelsExpandDepth, 1),
+        defaultIfAbsent(defaultModelExpandDepth, 1),
+        defaultIfAbsent(defaultModelRendering, ModelRendering.EXAMPLE),
+        defaultIfAbsent(displayRequestDuration, false),
+        defaultIfAbsent(docExpansion, DocExpansion.NONE),
+        defaultIfAbsent(filter, false),
+        defaultIfAbsent(maxDisplayedTags, null),
+        defaultIfAbsent(operationsSorter, OperationsSorter.ALPHA),
+        defaultIfAbsent(showExtensions, false),
+        defaultIfAbsent(tagsSorter, TagsSorter.ALPHA),
+        defaultIfAbsent(validatorUrl, null)
+    );
+  }
+
+  /**
+   * @param deepLinking If set to true, enables deep linking for tags and operations. See the Deep Linking documentation
+   *                    for more information.
+   */
+  public UiConfigurationBuilder deepLinking(Boolean deepLinking) {
+    this.deepLinking = deepLinking;
+    return this;
+  }
+
+  /**
+   * @param displayOperationId Controls the display of operationId in operations list. The default is false.
+   */
+  public UiConfigurationBuilder displayOperationId(Boolean displayOperationId) {
+    this.displayOperationId = displayOperationId;
+    return this;
+  }
+
+  /**
+   * @param defaultModelsExpandDepth The default expansion depth for models (set to -1 completely hide the models).
+   */
+  public UiConfigurationBuilder defaultModelsExpandDepth(Integer defaultModelsExpandDepth) {
+    this.defaultModelsExpandDepth = defaultModelsExpandDepth;
+    return this;
+  }
+
+  /**
+   * @param defaultModelExpandDepth The default expansion depth for the model on the model-example section.
+   */
+  public UiConfigurationBuilder defaultModelExpandDepth(Integer defaultModelExpandDepth) {
+    this.defaultModelExpandDepth = defaultModelExpandDepth;
+    return this;
+  }
+
+  /**
+   * @param defaultModelRendering Controls how the model is shown when the API is first rendered. (The user can always
+   *                              switch the rendering for a given model by clicking the 'Model' and 'Example Value'
+   *                              links.)
+   */
+  public UiConfigurationBuilder defaultModelRendering(ModelRendering defaultModelRendering) {
+    this.defaultModelRendering = defaultModelRendering;
+    return this;
+  }
+
+  /**
+   * @param displayRequestDuration Controls the display of the request duration (in milliseconds) for Try-It-Out
+   *                               requests.
+   */
+  public UiConfigurationBuilder displayRequestDuration(Boolean displayRequestDuration) {
+    this.displayRequestDuration = displayRequestDuration;
+    return this;
+  }
+
+  /**
+   * @param docExpansion Controls the default expansion setting for the operations and tags. It can be 'list' (expands
+   *                     only the tags), 'full' (expands the tags and operations) or 'none' (expands nothing).
+   */
+  public UiConfigurationBuilder docExpansion(DocExpansion docExpansion) {
+    this.docExpansion = docExpansion;
+    return this;
+  }
+
+  /**
+   * @param filter If set, enables filtering. The top bar will show an edit box that you can use to filter the tagged
+   *               operations that are shown. Can be Boolean to enable or disable, or a string, in which case filtering
+   *               will be enabled using that string as the filter expression. Filtering is case sensitive matching the
+   *               filter expression anywhere inside the tag.
+   */
+  public UiConfigurationBuilder filter(Object filter) {
+    this.filter = filter;
+    return this;
+  }
+
+  /**
+   * @param maxDisplayedTags If set, limits the number of tagged operations displayed to at most this many. The default
+   *                         is to show all operations.
+   */
+  public UiConfigurationBuilder maxDisplayedTags(Integer maxDisplayedTags) {
+    this.maxDisplayedTags = maxDisplayedTags;
+    return this;
+  }
+
+  /**
+   * @param operationsSorter Apply a sort to the operation list of each API. It can be 'alpha' (sort by paths
+   *                         alphanumerically), 'method' (sort by HTTP method) or a function (see Array.prototype.sort()
+   *                         to know how sort function works). Default is the order returned by the server unchanged.
+   */
+  public UiConfigurationBuilder operationsSorter(OperationsSorter operationsSorter) {
+    this.operationsSorter = operationsSorter;
+    return this;
+  }
+
+  /**
+   * @param showExtensions Controls the display of vendor extension (x-) fields and values for Operations, Parameters,
+   *                       and Schema.
+   */
+  public UiConfigurationBuilder showExtensions(Boolean showExtensions) {
+    this.showExtensions = showExtensions;
+    return this;
+  }
+
+  /**
+   * @param tagsSorter Apply a sort to the tag list of each API. It can be 'alpha' (sort by paths alphanumerically) or a
+   *                   function (see Array.prototype.sort() to learn how to write a sort function). Two tag name strings
+   *                   are passed to the sorter for each pass. Default is the order determined by Swagger-UI.
+   */
+  public UiConfigurationBuilder tagsSorter(TagsSorter tagsSorter) {
+    this.tagsSorter = tagsSorter;
+    return this;
+  }
+
+  /**
+   * @param validatorUrl By default, Swagger-UI attempts to validate specs against swagger.io's online validator. You
+   *                     can use this parameter to set a different validator URL, for example for locally deployed
+   *                     validators (Validator Badge). Setting it to null will disable validation. This parameter is
+   *                     relevant for Swagger 2.0 specs only.
+   */
+  public UiConfigurationBuilder validatorUrl(String validatorUrl) {
+    this.validatorUrl = validatorUrl;
+    return this;
+  }
+}

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/web/ApiResourceControllerSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/web/ApiResourceControllerSpec.groovy
@@ -37,39 +37,38 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class ApiResourceControllerSpec extends Specification {
   def mockMvc
   def security = """{
-    "apiKey": "key",
-    "apiKeyName": "api_key",
-    "apiKeyVehicle": "header",
-    "appName": "test",
     "clientId": "client",
     "clientSecret": "client-secret",
     "realm": "real",
-    "scopeSeparator": ","
+    "appName": "test",
+    "scopeSeparator": ",",
+    "additionalQueryStringParams": {"string":"value","boolean":true,"int":1},
+    "useBasicAuthenticationWithAccessCodeGrant": false
 }"""
   def ui = """{
-    "apisSorter": "alpha",
-    "defaultModelRendering": "schema",
+    "deepLinking": true,
+    "displayOperationId": false,
+    "defaultModelsExpandDepth": 1,
+    "defaultModelExpandDepth": 1,
+    "defaultModelRendering": "example",
+    "displayRequestDuration": false,
     "docExpansion": "none",
-    "jsonEditor": false,
-    "showRequestHeaders": true,
-    "supportedSubmitMethods": [
-        "get",
-        "post",
-        "put",
-        "delete",
-        "patch"
-    ],
+    "filter": false,
+    "maxDisplayedTags": 1000,
+    "operationsSorter": "alpha",
+    "showExtensions": false,
+    "tagsSorter": "alpha",
     "validatorUrl": "/validate"
 }"""
   def resources = """[
         {
             "name": "test",
-            "location": "/v1?group=test",
+            "url": "/v1?group=test",
             "swaggerVersion": "1.2"
         },
         {
             "name": "test",
-            "location": "/v2?group=test",
+            "url": "/v2?group=test",
             "swaggerVersion": "2.0"
         }
     ]"""
@@ -79,16 +78,30 @@ class ApiResourceControllerSpec extends Specification {
   def setup() {
     sut = new ApiResourceController(inMemorySwaggerResources())
     sut.with {
-      securityConfiguration = new SecurityConfiguration(
-          "client",
-          "client-secret",
-          "real",
-          "test",
-          "key",
-          ApiKeyVehicle.HEADER,
-          "api_key",
-          ",")
-      uiConfiguration = new UiConfiguration("/validate", UiConfiguration.Constants.DEFAULT_SUBMIT_METHODS)
+      securityConfiguration = SecurityConfigurationBuilder.builder()
+          .clientId("client")
+          .clientSecret("client-secret")
+          .realm("real")
+          .appName("test")
+          .scopeSeparator(",")
+          .additionalQueryStringParams(['string': 'value', 'boolean': true, 'int': 1])
+          .useBasicAuthenticationWithAccessCodeGrant(false)
+          .build()
+      uiConfiguration = UiConfigurationBuilder.builder()
+          .deepLinking(true)
+          .displayOperationId(false)
+          .defaultModelsExpandDepth(1)
+          .defaultModelExpandDepth(1)
+          .defaultModelRendering(ModelRendering.EXAMPLE)
+          .displayRequestDuration(false)
+          .docExpansion(DocExpansion.NONE)
+          .filter(false)
+          .maxDisplayedTags(1000)
+          .operationsSorter(OperationsSorter.ALPHA)
+          .showExtensions(false)
+          .tagsSorter(TagsSorter.ALPHA)
+          .validatorUrl("/validate")
+          .build()
     }
     mockMvc = MockMvcBuilders.standaloneSetup(sut).build()
   }

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/web/SecurityConfigurationBuilderSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/web/SecurityConfigurationBuilderSpec.groovy
@@ -24,10 +24,9 @@ import org.skyscreamer.jsonassert.JSONAssert
 import org.skyscreamer.jsonassert.JSONCompareMode
 import spock.lang.Specification
 
-class SecurityConfigurationSpec extends Specification {
-  def securityConfig = SecurityConfiguration.DEFAULT
+class SecurityConfigurationBuilderSpec extends Specification {
+  def securityConfig = SecurityConfigurationBuilder.builder().build()
   def expected = "{\n" +
-      "    \"scopeSeparator\": \",\"\n" +
       "}"
 
   def "Renders non-null values using default ObjectMapper"() {

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/web/SecurityConfigurationSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/web/SecurityConfigurationSpec.groovy
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2017-2018 the original author or authors.
+ *  Copyright 2018 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -24,20 +24,10 @@ import org.skyscreamer.jsonassert.JSONAssert
 import org.skyscreamer.jsonassert.JSONCompareMode
 import spock.lang.Specification
 
-class UiConfigurationSpec extends Specification {
-  def uiConfig = UiConfigurationBuilder.builder().build()
+class SecurityConfigurationSpec extends Specification {
+  def securityConfig = SecurityConfigurationBuilder.builder()
+          .build()
   def expected = "{\n" +
-      "    \"deepLinking\": true,\n" +
-      "    \"displayOperationId\": false,\n" +
-      "    \"defaultModelsExpandDepth\": 1,\n" +
-      "    \"defaultModelExpandDepth\": 1,\n" +
-      "    \"defaultModelRendering\": \"example\",\n" +
-      "    \"displayRequestDuration\": false,\n" +
-      "    \"docExpansion\": \"none\",\n" +
-      "    \"filter\": false,\n" +
-      "    \"operationsSorter\": \"alpha\",\n" +
-      "    \"showExtensions\": false,\n" +
-      "    \"tagsSorter\": \"alpha\"\n" +
       "}"
 
   def "Renders non-null values using default ObjectMapper"() {
@@ -45,7 +35,7 @@ class UiConfigurationSpec extends Specification {
     ObjectMapper mapper = new ObjectMapper()
 
     when:
-    def actual = mapper.writer().writeValueAsString(uiConfig)
+    def actual = mapper.writer().writeValueAsString(securityConfig)
 
     then:
     JSONAssert.assertEquals(expected, actual, JSONCompareMode.NON_EXTENSIBLE)
@@ -57,7 +47,7 @@ class UiConfigurationSpec extends Specification {
     mapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY)
 
     when:
-    def actual = mapper.writer().writeValueAsString(uiConfig)
+    def actual = mapper.writer().writeValueAsString(securityConfig)
 
     then:
     JSONAssert.assertEquals(expected, actual, JSONCompareMode.NON_EXTENSIBLE)

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/web/UiConfigurationBuilderSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/web/UiConfigurationBuilderSpec.groovy
@@ -24,10 +24,20 @@ import org.skyscreamer.jsonassert.JSONAssert
 import org.skyscreamer.jsonassert.JSONCompareMode
 import spock.lang.Specification
 
-class SecurityConfigurationSpec extends Specification {
-  def securityConfig = SecurityConfiguration.DEFAULT
+class UiConfigurationBuilderSpec extends Specification {
+  def uiConfig = UiConfigurationBuilder.builder().build()
   def expected = "{\n" +
-      "    \"scopeSeparator\": \",\"\n" +
+      "    \"deepLinking\": true,\n" +
+      "    \"displayOperationId\": false,\n" +
+      "    \"defaultModelsExpandDepth\": 1,\n" +
+      "    \"defaultModelExpandDepth\": 1,\n" +
+      "    \"defaultModelRendering\": \"example\",\n" +
+      "    \"displayRequestDuration\": false,\n" +
+      "    \"docExpansion\": \"none\",\n" +
+      "    \"filter\": false,\n" +
+      "    \"operationsSorter\": \"alpha\",\n" +
+      "    \"showExtensions\": false,\n" +
+      "    \"tagsSorter\": \"alpha\"\n" +
       "}"
 
   def "Renders non-null values using default ObjectMapper"() {
@@ -35,7 +45,7 @@ class SecurityConfigurationSpec extends Specification {
     ObjectMapper mapper = new ObjectMapper()
 
     when:
-    def actual = mapper.writer().writeValueAsString(securityConfig)
+    def actual = mapper.writer().writeValueAsString(uiConfig)
 
     then:
     JSONAssert.assertEquals(expected, actual, JSONCompareMode.NON_EXTENSIBLE)
@@ -47,7 +57,7 @@ class SecurityConfigurationSpec extends Specification {
     mapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY)
 
     when:
-    def actual = mapper.writer().writeValueAsString(securityConfig)
+    def actual = mapper.writer().writeValueAsString(uiConfig)
 
     then:
     JSONAssert.assertEquals(expected, actual, JSONCompareMode.NON_EXTENSIBLE)

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/web/UiConfigurationSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/web/UiConfigurationSpec.groovy
@@ -25,19 +25,19 @@ import org.skyscreamer.jsonassert.JSONCompareMode
 import spock.lang.Specification
 
 class UiConfigurationSpec extends Specification {
-  def uiConfig = UiConfigurationBuilder.builder().build()
+  def uiConfig = new UiConfiguration("validator:urn", UiConfiguration.Constants.NO_SUBMIT_METHODS)
   def expected = "{\n" +
       "    \"deepLinking\": true,\n" +
       "    \"displayOperationId\": false,\n" +
       "    \"defaultModelsExpandDepth\": 1,\n" +
       "    \"defaultModelExpandDepth\": 1,\n" +
-      "    \"defaultModelRendering\": \"example\",\n" +
       "    \"displayRequestDuration\": false,\n" +
       "    \"docExpansion\": \"none\",\n" +
       "    \"filter\": false,\n" +
       "    \"operationsSorter\": \"alpha\",\n" +
       "    \"showExtensions\": false,\n" +
-      "    \"tagsSorter\": \"alpha\"\n" +
+      "    \"tagsSorter\": \"alpha\",\n" +
+      "    \"validatorUrl\": \"validator:urn\"\n" +
       "}"
 
   def "Renders non-null values using default ObjectMapper"() {

--- a/springfox-swagger-ui/build.gradle
+++ b/springfox-swagger-ui/build.gradle
@@ -26,7 +26,7 @@ plugins {
 }
 
 ext {
-  swaggerUiVersion = '3.8.1'
+  swaggerUiVersion = '3.9.0'
   swaggerUiDist = "build/libs/swagger-ui-dist.zip"
   swaggerUiExplodedDir = "swagger-ui-${swaggerUiVersion}/dist/"
   downloadUrl = "https://github.com/swagger-api/swagger-ui/archive/v${swaggerUiVersion}.zip"

--- a/springfox-swagger-ui/build.gradle
+++ b/springfox-swagger-ui/build.gradle
@@ -26,7 +26,7 @@ plugins {
 }
 
 ext {
-  swaggerUiVersion = '3.7.0'
+  swaggerUiVersion = '3.8.1'
   swaggerUiDist = "build/libs/swagger-ui-dist.zip"
   swaggerUiExplodedDir = "swagger-ui-${swaggerUiVersion}/dist/"
   downloadUrl = "https://github.com/swagger-api/swagger-ui/archive/v${swaggerUiVersion}.zip"

--- a/springfox-swagger-ui/src/web/js/springfox.js
+++ b/springfox-swagger-ui/src/web/js/springfox.js
@@ -1,10 +1,5 @@
 window.onload = () => {
 
-  const getBaseURL = () => {
-    const urlMatches = /(.*)\/swagger-ui.html.*/.exec(window.location.href);
-    return urlMatches[1];
-  };
-
   const buildSystemAsync = async (baseUrl) => {
     try {
       const configUIResponse = await fetch(baseUrl + "/swagger-resources/configuration/ui");
@@ -16,7 +11,7 @@ window.onload = () => {
       const resourcesResponse = await fetch(baseUrl + "/swagger-resources");
       const resources = await resourcesResponse.json();
       resources.forEach(resource => {
-        resource.url = baseUrl + resource.location;
+        resource.url = baseUrl + resource.url;
       });
 
       window.ui = getUI(baseUrl, resources, configUI, configSecurity);
@@ -57,18 +52,18 @@ window.onload = () => {
       /*--------------------------------------------*\
        * Display
       \*--------------------------------------------*/
-      deepLinking: true,
-      displayOperationId: false,
-      defaultModelsExpandDepth: 1,
-      defaultModelExpandDepth: 1,
-      defaultModelRendering: resources.defaultModelRendering,
-      displayRequestDuration: false,
-      docExpansion: resources.docExpansion,
-      filter: false,
-      maxDisplayedTags: null,
-      operationsSorter: configUI.apisSorter || "alpha",
-      showExtensions: false,
-      tagSorter: configUI.apisSorter || "alpha",
+      deepLinking: configUI.deepLinking,
+      displayOperationId: configUI.displayOperationId,
+      defaultModelsExpandDepth: configUI.defaultModelsExpandDepth,
+      defaultModelExpandDepth: configUI.defaultModelExpandDepth,
+      defaultModelRendering: configUI.defaultModelRendering,
+      displayRequestDuration: configUI.displayRequestDuration,
+      docExpansion: configUI.docExpansion,
+      filter: configUI.filter,
+      maxDisplayedTags: configUI.maxDisplayedTags,
+      operationsSorter: configUI.operationsSorter,
+      showExtensions: configUI.showExtensions,
+      tagSorter: configUI.tagSorter,
       /*--------------------------------------------*\
        * Network
       \*--------------------------------------------*/
@@ -76,7 +71,7 @@ window.onload = () => {
       requestInterceptor: (a => a),
       responseInterceptor: (a => a),
       showMutatedRequest: true,
-      validatorUrl: null,
+      validatorUrl: configUI.validatorUrl,
       /*--------------------------------------------*\
        * Macros
       \*--------------------------------------------*/
@@ -93,11 +88,16 @@ window.onload = () => {
       realm: configSecurity.realm,
       appName: configSecurity.appName,
       scopeSeparator: configSecurity.scopeSeparator,
-      additionalQueryStringParams: {},
-      useBasicAuthenticationWithAccessCodeGrant: false,
+      additionalQueryStringParams: configSecurity.additionalQueryStringParams,
+      useBasicAuthenticationWithAccessCodeGrant: configSecurity.useBasicAuthenticationWithAccessCodeGrant,
     });
 
     return ui;
+  };
+
+  const getBaseURL = () => {
+    const urlMatches = /(.*)\/swagger-ui.html.*/.exec(window.location.href);
+    return urlMatches[1];
   };
 
   /* Entry Point */

--- a/swagger-contract-tests/src/test/groovy/springfox/test/contract/swaggertests/FunctionContractSpec.groovy
+++ b/swagger-contract-tests/src/test/groovy/springfox/test/contract/swaggertests/FunctionContractSpec.groovy
@@ -108,17 +108,17 @@ class FunctionContractSpec extends Specification implements FileAccess {
     then:
     result.find {
       it.name == 'petstore' &&
-          it.location == '/v2/api-docs?group=petstore' &&
+          it.url == '/v2/api-docs?group=petstore' &&
           it.swaggerVersion == '2.0'
     }
     result.find {
       it.name == 'businessService' &&
-          it.location == '/v2/api-docs?group=businessService' &&
+          it.url == '/v2/api-docs?group=businessService' &&
           it.swaggerVersion == '2.0'
     }
     result.find {
       it.name == 'concrete' &&
-          it.location == '/v2/api-docs?group=concrete' &&
+          it.url == '/v2/api-docs?group=concrete' &&
           it.swaggerVersion == '2.0'
     }
   }
@@ -187,7 +187,7 @@ class FunctionContractSpec extends Specification implements FileAccess {
     then:
     result.find {
       it.name == 'default' &&
-          it.location == '/api-docs' &&
+          it.url == '/api-docs' &&
           it.swaggerVersion == '1.2'
     }
   }


### PR DESCRIPTION
#### What's this PR do/fix?
I improved the configuration API for Swagger UI 3.x. There are some breaking changes, I think it's necessary to write a migration guide on the wiki or something.
#### Are there unit tests? If not how should this be manually tested?
I have done a minimal test...
#### Any background context you want to provide?
#2153
#### What are the relevant issues?
#2166
#### The Migration Guide
##### UI Config
- 2.7.1 
```java
  @Bean
  UiConfiguration uiConfig() {
    return new UiConfiguration(
        "validatorUrl",// url
        "none",       // docExpansion          => none | list
        "alpha",      // apiSorter             => alpha
        "schema",     // defaultModelRendering => schema
        UiConfiguration.Constants.DEFAULT_SUBMIT_METHODS,
        false,        // enableJsonEditor      => true | false
        true,         // showRequestHeaders    => true | false
        60000L);      // requestTimeout => in milliseconds, defaults to null (uses jquery xh timeout)
  }
```
- 2.8.0
```java
  @Bean
  UiConfiguration uiConfig() {
    return UiConfigurationBuilder.builder()
        .deepLinking(true)
        .displayOperationId(false)
        .defaultModelsExpandDepth(1)
        .defaultModelExpandDepth(1)
        .defaultModelRendering(ModelRendering.EXAMPLE)
        .displayRequestDuration(false)
        .docExpansion(DocExpansion.NONE)
        .filter(false)
        .maxDisplayedTags(null)
        .operationsSorter(OperationsSorter.ALPHA)
        .showExtensions(false)
        .tagsSorter(TagsSorter.ALPHA)
        .validatorUrl(null)
        .build();
  }
```

##### Security Config
- 2.7.1
```java
  @Bean
  SecurityConfiguration security() {
    return new SecurityConfiguration(
        "test-app-client-id",
        "test-app-client-secret",
        "test-app-realm",
        "test-app",
        "apiKey",
        ApiKeyVehicle.HEADER,
        "api_key",
        "," /*scope separator*/);
  }
```
- 2.8.0
```java
  @Bean
  SecurityConfiguration security() {
    return SecurityConfigurationBuilder.builder()
        .clientId("test-app-client-id")
        .clientSecret("test-app-client-secret")
        .realm("test-app-realm")
        .appName("test-app")
        .scopeSeparator(",")
        .additionalQueryStringParams(null)
        .useBasicAuthenticationWithAccessCodeGrant(false)
        .build();
  }
```