### PR TITLE
Should use credentials on same origin when fetching springfox resources

### DIFF
--- a/springfox-swagger-ui/src/web/js/springfox.js
+++ b/springfox-swagger-ui/src/web/js/springfox.js
@@ -2,13 +2,13 @@ window.onload = () => {
 
   const buildSystemAsync = async (baseUrl) => {
     try {
-      const configUIResponse = await fetch(baseUrl + "/swagger-resources/configuration/ui");
+      const configUIResponse = await fetch(baseUrl + "/swagger-resources/configuration/ui", {credentials: 'same-origin'});
       const configUI = await configUIResponse.json();
 
-      const configSecurityResponse = await fetch(baseUrl + "/swagger-resources/configuration/security");
+      const configSecurityResponse = await fetch(baseUrl + "/swagger-resources/configuration/security", {credentials: 'same-origin'});
       const configSecurity = await configSecurityResponse.json();
 
-      const resourcesResponse = await fetch(baseUrl + "/swagger-resources");
+      const resourcesResponse = await fetch(baseUrl + "/swagger-resources", {credentials: 'same-origin'});
       const resources = await resourcesResponse.json();
       resources.forEach(resource => {
         resource.url = baseUrl + resource.url;


### PR DESCRIPTION
If swagger-ressources is not publicly accessible Swagger UI loading will fail, even though the current user is already authenticated.

This is caused during the SpringFox initialization by missing request credentials (for instance a session cookie) while trying to load `/swagger-resources/configuration/ui`, `/swagger-resources/configuration/security` and `/swagger-resources`. Swagger UI itself does properly reuse existing credentials afterwards.

This is a regression in 2.8.0 as this worked fine with springfox-swagger-ui 2.7.0.