### PR TITLE
WIP: try to fix #2259 - include test reports from correct folder

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -32,7 +32,7 @@ test:
       timeout: 900
   - bash <(curl -s https://codecov.io/bash)
   - mkdir -p $CIRCLE_TEST_REPORTS/junit/
-  - find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;
+  - find . -type f -regex ".*/build/test-results/test/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;
 
 
 deployment:

--- a/swagger-contract-tests/src/test/groovy/springfox/test/contract/swaggertests/FunctionContractSpec.groovy
+++ b/swagger-contract-tests/src/test/groovy/springfox/test/contract/swaggertests/FunctionContractSpec.groovy
@@ -192,6 +192,17 @@ class FunctionContractSpec extends Specification implements FileAccess {
     }
   }
 
+  def "dummy test that should fail"() {
+    given:
+    def number = 3
+
+    when:
+    def twice = number * 2
+
+    then:
+    twice == 5
+  }
+
   @Configuration
   @ComponentScan([
       "springfox.documentation.spring.web.dummy.controllers",


### PR DESCRIPTION
#### What's this PR do/fix?
Fixes CI conf that didn't include test results
#### Are there unit tests? If not how should this be manually tested?
No production or test code changed, but formerly failing tests should appear as failures also in this PR CI report
#### What are the relevant issues?
#2259 