### PR TITLE
Upgrading swagger-ui to 3.11.0

### DIFF
--- a/springfox-spring-config/src/main/java/springfox/springconfig/Swagger2SpringBoot.java
+++ b/springfox-spring-config/src/main/java/springfox/springconfig/Swagger2SpringBoot.java
@@ -160,6 +160,7 @@ public class Swagger2SpringBoot {
         .operationsSorter(OperationsSorter.ALPHA)
         .showExtensions(false)
         .tagsSorter(TagsSorter.ALPHA)
+        .supportedSubmitMethods(UiConfiguration.Constants.DEFAULT_SUBMIT_METHODS)
         .validatorUrl(null)
         .build();
   }

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/UiConfiguration.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/UiConfiguration.java
@@ -46,12 +46,6 @@ public class UiConfiguration {
    * @deprecated @since 2.8.0. This field is unused
    */
   @Deprecated
-  private String[] supportedSubmitMethods;
-
-  /**
-   * @deprecated @since 2.8.0. This field is unused
-   */
-  @Deprecated
   private boolean jsonEditor;
 
   /**
@@ -79,6 +73,7 @@ public class UiConfiguration {
   /*--------------------------------------------*\
    * Network
   \*--------------------------------------------*/
+  private String[] supportedSubmitMethods;
   private final String validatorUrl;
 
   /**
@@ -111,8 +106,8 @@ public class UiConfiguration {
    * @param defaultModelRendering  Controls how models are shown when the API is first rendered. (The user can
    *                               always switch the rendering for a given model by clicking the 'Model' and 'Model
    *                               Schema' links.) It can be set to 'model' or 'schema', and the default is 'schema'.
-   * @param supportedSubmitMethods An array of of the HTTP operations that will have the 'Try it out!' option. An
-   *                               empty array disables all operations. This does not filter the operations from the
+   * @param supportedSubmitMethods List of HTTP methods that have the Try it out feature enabled. An empty array
+   *                               disables Try it out for all operations. This does not filter the operations from the
    *                               display.
    * @param jsonEditor             Enables a graphical view for editing complex bodies. Defaults to false.
    * @param showRequestHeaders     Whether or not to show the headers that were sent when making a request via the
@@ -155,8 +150,8 @@ public class UiConfiguration {
    * @param defaultModelRendering  Controls how models are shown when the API is first rendered. (The user can
    *                               always switch the rendering for a given model by clicking the 'Model' and 'Model
    *                               Schema' links.) It can be set to 'model' or 'schema', and the default is 'schema'.
-   * @param supportedSubmitMethods An array of of the HTTP operations that will have the 'Try it out!' option. An
-   *                               empty array disables all operations. This does not filter the operations from the
+   * @param supportedSubmitMethods List of HTTP methods that have the Try it out feature enabled. An empty array
+   *                               disables Try it out for all operations. This does not filter the operations from the
    *                               display.
    * @param jsonEditor             Enables a graphical view for editing complex bodies. Defaults to false.
    * @param showRequestHeaders     Whether or not to show the headers that were sent when making a request via the
@@ -247,6 +242,79 @@ public class UiConfiguration {
       Boolean showExtensions,
       TagsSorter tagsSorter,
       String validatorUrl) {
+    this(
+        deepLinking,
+        displayOperationId,
+        defaultModelsExpandDepth,
+        defaultModelExpandDepth,
+        defaultModelRendering,
+        displayRequestDuration,
+        docExpansion,
+        filter,
+        maxDisplayedTags,
+        operationsSorter,
+        showExtensions,
+        tagsSorter,
+            Constants.DEFAULT_SUBMIT_METHODS,
+        validatorUrl);
+  }
+
+  /**
+   * Default constructor
+   *
+   * @param deepLinking              If set to true, enables deep linking for tags and operations. See the Deep Linking
+   *                                 documentation for more information.
+   * @param displayOperationId       Controls the display of operationId in operations list. The default is false.
+   * @param defaultModelsExpandDepth The default expansion depth for models (set to -1 completely hide the models).
+   * @param defaultModelExpandDepth  The default expansion depth for the model on the model-example section.
+   * @param defaultModelRendering    Controls how the model is shown when the API is first rendered. (The user can
+   *                                 always switch the rendering for a given model by clicking the 'Model' and 'Example
+   *                                 Value' links.)
+   * @param displayRequestDuration   Controls the display of the request duration (in milliseconds) for Try-It-Out
+   *                                 requests.
+   * @param docExpansion             Controls the default expansion setting for the operations and tags. It can be
+   *                                 'list' (expands only the tags), 'full' (expands the tags and operations) or 'none'
+   *                                 (expands nothing).
+   * @param filter                   If set, enables filtering. The top bar will show an edit box that you can use to
+   *                                 filter the tagged operations that are shown. Can be Boolean to enable or disable,
+   *                                 or a string, in which case filtering will be enabled using that string as the
+   *                                 filter expression. Filtering is case sensitive matching the filter expression
+   *                                 anywhere inside the tag.
+   * @param maxDisplayedTags         If set, limits the number of tagged operations displayed to at most this many. The
+   *                                 default is to show all operations.
+   * @param operationsSorter         Apply a sort to the operation list of each API. It can be 'alpha' (sort by paths
+   *                                 alphanumerically), 'method' (sort by HTTP method) or a function (see
+   *                                 Array.prototype.sort() to know how sort function works). Default is the order
+   *                                 returned by the server unchanged.
+   * @param showExtensions           Controls the display of vendor extension (x-) fields and values for Operations,
+   *                                 Parameters, and Schema.
+   * @param tagsSorter               Apply a sort to the tag list of each API. It can be 'alpha' (sort by paths
+   *                                 alphanumerically) or a function (see Array.prototype.sort() to learn how to write a
+   *                                 sort function). Two tag name strings are passed to the sorter for each pass.
+   *                                 Default is the order determined by Swagger-UI.
+   * @param supportedSubmitMethods   List of HTTP methods that have the Try it out feature enabled. An empty array
+   *                                 disables Try it out for all operations. This does not filter the operations from the
+   *                                 display.
+   * @param validatorUrl             By default, Swagger-UI attempts to validate specs against swagger.io's online
+   *                                 validator. You can use this parameter to set a different validator URL, for example
+   *                                 for locally deployed validators (Validator Badge). Setting it to null will disable
+   *                                 validation. This parameter is relevant for Swagger 2.0 specs only.
+   */
+  public UiConfiguration(
+      Boolean deepLinking,
+      Boolean displayOperationId,
+      Integer defaultModelsExpandDepth,
+      Integer defaultModelExpandDepth,
+      ModelRendering defaultModelRendering,
+      Boolean displayRequestDuration,
+      DocExpansion docExpansion,
+      Object filter,
+      Integer maxDisplayedTags,
+      OperationsSorter operationsSorter,
+      Boolean showExtensions,
+      TagsSorter tagsSorter,
+      String[] supportedSubmitMethods,
+      String validatorUrl) {
     this.apisSorter = "alpha";
     this.deepLinking = deepLinking;
     this.displayOperationId = displayOperationId;
@@ -260,6 +328,7 @@ public class UiConfiguration {
     this.operationsSorter = operationsSorter;
     this.showExtensions = showExtensions;
     this.tagsSorter = tagsSorter;
+    this.supportedSubmitMethods = supportedSubmitMethods;
     this.validatorUrl = validatorUrl;
   }
 
@@ -270,15 +339,6 @@ public class UiConfiguration {
   @JsonProperty("apisSorter")
   public String getApisSorter() {
     return apisSorter;
-  }
-
-  /**
-   * @deprecated @since 2.8.0
-   */
-  @Deprecated
-  @JsonProperty("supportedSubmitMethods")
-  public String[] getSupportedSubmitMethods() {
-    return supportedSubmitMethods;
   }
 
   /**
@@ -368,24 +428,18 @@ public class UiConfiguration {
     return tagsSorter;
   }
 
+  @JsonProperty("supportedSubmitMethods")
+  public String[] getSupportedSubmitMethods() {
+    return supportedSubmitMethods;
+  }
+
   @JsonProperty("validatorUrl")
   public String getValidatorUrl() {
     return validatorUrl;
   }
 
-  /**
-   * @deprecated @since 2.8.0
-   */
-  @Deprecated
   public static class Constants {
-    /**
-     * @deprecated @since 2.8.0
-     */
-    public static final String[] DEFAULT_SUBMIT_METHODS = new String[] { "get", "post", "put", "delete", "patch" };
-
-    /**
-     * @deprecated @since 2.8.0
-     */
+    public static final String[] DEFAULT_SUBMIT_METHODS = new String[] { "get", "put", "post", "delete", "options", "head", "patch", "trace" };
     public static final String[] NO_SUBMIT_METHODS = new String[] {};
   }
 }

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/UiConfigurationBuilder.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/UiConfigurationBuilder.java
@@ -41,6 +41,7 @@ public class UiConfigurationBuilder {
   /*--------------------------------------------*\
    * Network
   \*--------------------------------------------*/
+  private String[] supportedSubmitMethods;
   private String validatorUrl;
 
   private UiConfigurationBuilder() {
@@ -64,6 +65,7 @@ public class UiConfigurationBuilder {
         defaultIfAbsent(operationsSorter, OperationsSorter.ALPHA),
         defaultIfAbsent(showExtensions, false),
         defaultIfAbsent(tagsSorter, TagsSorter.ALPHA),
+        defaultIfAbsent(supportedSubmitMethods, UiConfiguration.Constants.DEFAULT_SUBMIT_METHODS),
         defaultIfAbsent(validatorUrl, null)
     );
   }
@@ -175,6 +177,16 @@ public class UiConfigurationBuilder {
    */
   public UiConfigurationBuilder tagsSorter(TagsSorter tagsSorter) {
     this.tagsSorter = tagsSorter;
+    return this;
+  }
+
+  /**
+   * @param supportedSubmitMethods List of HTTP methods that have the Try it out feature enabled. An empty array
+   *                               disables Try it out for all operations. This does not filter the operations from the
+   *                               display.
+   */
+  public UiConfigurationBuilder supportedSubmitMethods(String[] supportedSubmitMethods) {
+    this.supportedSubmitMethods = supportedSubmitMethods;
     return this;
   }
 

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/web/ApiResourceControllerSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/web/ApiResourceControllerSpec.groovy
@@ -61,6 +61,7 @@ class ApiResourceControllerSpec extends Specification {
     "operationsSorter": "alpha",
     "showExtensions": false,
     "tagsSorter": "alpha",
+    "supportedSubmitMethods":["get","put","post","delete","options","head","patch","trace"],
     "validatorUrl": "/validate"
 }"""
   def resources = """[
@@ -105,6 +106,7 @@ class ApiResourceControllerSpec extends Specification {
           .operationsSorter(OperationsSorter.ALPHA)
           .showExtensions(false)
           .tagsSorter(TagsSorter.ALPHA)
+          .supportedSubmitMethods(UiConfiguration.Constants.DEFAULT_SUBMIT_METHODS)
           .validatorUrl("/validate")
           .build()
     }

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/web/UiConfigurationBuilderSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/web/UiConfigurationBuilderSpec.groovy
@@ -40,7 +40,8 @@ class UiConfigurationBuilderSpec extends Specification {
       "    \"filter\": false,\n" +
       "    \"operationsSorter\": \"alpha\",\n" +
       "    \"showExtensions\": false,\n" +
-      "    \"tagsSorter\": \"alpha\"\n" +
+      "    \"tagsSorter\": \"alpha\",\n" +
+      "    \"supportedSubmitMethods\": [\"get\",\"put\",\"post\",\"delete\",\"options\",\"head\",\"patch\",\"trace\"]\n" +
       "}"
 
   def "Renders non-null values using default ObjectMapper"() {

--- a/springfox-swagger-ui/build.gradle
+++ b/springfox-swagger-ui/build.gradle
@@ -29,7 +29,7 @@ plugins {
 }
 
 ext {
-  swaggerUiVersion = '3.9.1'
+  swaggerUiVersion = '3.11.0'
   swaggerUiDist = "build/libs/swagger-ui-dist.zip"
   swaggerUiExplodedDir = "swagger-ui-${swaggerUiVersion}/dist/"
   downloadUrl = "https://github.com/swagger-api/swagger-ui/archive/v${swaggerUiVersion}.zip"
@@ -44,8 +44,8 @@ dependencies {
 }
 
 node {
-  version = '9.5.0'
-  npmVersion = '5.6.0'
+  version = '9.6.1'
+  npmVersion = '5.7.1'
   distBaseUrl = 'https://nodejs.org/dist'
   download = true
   workDir = file("${project.buildDir}/nodejs")

--- a/springfox-swagger-ui/src/web/js/springfox.js
+++ b/springfox-swagger-ui/src/web/js/springfox.js
@@ -71,6 +71,7 @@ window.onload = () => {
       requestInterceptor: (a => a),
       responseInterceptor: (a => a),
       showMutatedRequest: true,
+      supportedSubmitMethods: configUI.supportedSubmitMethods,
       validatorUrl: configUI.validatorUrl,
       /*--------------------------------------------*\
        * Macros

--- a/springfox-swagger-ui/src/web/package-lock.json
+++ b/springfox-swagger-ui/src/web/package-lock.json
@@ -28,21 +28,20 @@
       }
     },
     "ajv": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.1.1.tgz",
+      "integrity": "sha1-l41Zf7wrfQ5aXD3esUmmgvKr+g4=",
       "dev": true,
       "requires": {
-        "co": "4.6.0",
         "fast-deep-equal": "1.0.0",
         "fast-json-stable-stringify": "2.0.0",
         "json-schema-traverse": "0.3.1"
       }
     },
     "ajv-keywords": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
-      "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.1.0.tgz",
+      "integrity": "sha1-rCsnk5xUPpXSwG5/f1wnvkqlQ74=",
       "dev": true
     },
     "align-text": {
@@ -94,9 +93,9 @@
       "dev": true
     },
     "asn1.js": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.2.tgz",
-      "integrity": "sha512-b/OsSjvWEo8Pi8H0zsDd2P6Uqo2TK2pH8gNLSJtNLM2Db0v2QaAZ0pBQJXVjAn4gBuugeVDr7s63ZogpUIwWDg==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "dev": true,
       "requires": {
         "bn.js": "4.11.8",
@@ -891,9 +890,9 @@
       "dev": true
     },
     "base64-js": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
-      "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.3.tgz",
+      "integrity": "sha512-MsAhsUW1GxCdgYSO6tAfZrNapmUKk7mWx/k5mFY/A1gBtkaCaNapTg+FExCw1r9yeaZhqx/xPg43xgTFH6KL5w==",
       "dev": true
     },
     "big.js": {
@@ -1027,7 +1026,7 @@
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
-        "base64-js": "1.2.1",
+        "base64-js": "1.2.3",
         "ieee754": "1.1.8",
         "isarray": "1.0.0"
       }
@@ -1109,12 +1108,6 @@
         "right-align": "0.1.3",
         "wordwrap": "0.0.2"
       }
-    },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
     },
     "code-point-at": {
       "version": "1.1.0",
@@ -1230,7 +1223,7 @@
         "pbkdf2": "3.0.14",
         "public-encrypt": "4.0.0",
         "randombytes": "2.0.6",
-        "randomfill": "1.0.3"
+        "randomfill": "1.0.4"
       }
     },
     "d": {
@@ -1239,7 +1232,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.38"
+        "es5-ext": "0.10.39"
       }
     },
     "date-now": {
@@ -1339,9 +1332,9 @@
       }
     },
     "errno": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.6.tgz",
-      "integrity": "sha512-IsORQDpaaSwcDP4ZZnHxgE85werpo34VYn1Ud3mq+eUsF593faR8oCZNXrROVkpFu2TsbrNhHin0aUrTsQ9vNw==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+      "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
       "dev": true,
       "requires": {
         "prr": "1.0.1"
@@ -1357,9 +1350,9 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.38",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.38.tgz",
-      "integrity": "sha512-jCMyePo7AXbUESwbl8Qi01VSH2piY9s/a3rSU/5w/MlTIx8HPL1xn2InGN8ejt/xulcJgnTO7vqNtOAxzYd2Kg==",
+      "version": "0.10.39",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.39.tgz",
+      "integrity": "sha512-AlaXZhPHl0po/uxMx1tyrlt1O86M6D5iVaDH8UgLfgek4kXTX6vzsRfJQWC2Ku+aG8pkw1XWzh9eTkwfVrsD5g==",
       "dev": true,
       "requires": {
         "es6-iterator": "2.0.3",
@@ -1373,7 +1366,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.38",
+        "es5-ext": "0.10.39",
         "es6-symbol": "3.1.1"
       }
     },
@@ -1384,7 +1377,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.38",
+        "es5-ext": "0.10.39",
         "es6-iterator": "2.0.3",
         "es6-set": "0.1.5",
         "es6-symbol": "3.1.1",
@@ -1398,7 +1391,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.38",
+        "es5-ext": "0.10.39",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
@@ -1411,7 +1404,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.38"
+        "es5-ext": "0.10.39"
       }
     },
     "es6-weak-map": {
@@ -1421,7 +1414,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.38",
+        "es5-ext": "0.10.39",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1"
       }
@@ -1473,7 +1466,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.38"
+        "es5-ext": "0.10.39"
       }
     },
     "events": {
@@ -1607,7 +1600,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "2.8.0",
+        "nan": "2.9.2",
         "node-pre-gyp": "0.6.39"
       },
       "dependencies": {
@@ -2957,8 +2950,8 @@
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
       "dev": true,
       "requires": {
-        "errno": "0.1.6",
-        "readable-stream": "2.3.3"
+        "errno": "0.1.7",
+        "readable-stream": "2.3.4"
       }
     },
     "micromatch": {
@@ -3041,9 +3034,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
-      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz",
+      "integrity": "sha512-ltW65co7f3PQWBDbqVvaU1WtFJUsNW7sWWm4HINhbMQIyVyzIeyZ8toX5TC5eeooE6piZoaEh4cZkueSKG3KYw==",
       "dev": true,
       "optional": true
     },
@@ -3067,7 +3060,7 @@
         "process": "0.11.10",
         "punycode": "1.4.1",
         "querystring-es3": "0.2.1",
-        "readable-stream": "2.3.3",
+        "readable-stream": "2.3.4",
         "stream-browserify": "2.0.1",
         "stream-http": "2.8.0",
         "string_decoder": "1.0.3",
@@ -3201,7 +3194,7 @@
       "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
       "dev": true,
       "requires": {
-        "asn1.js": "4.9.2",
+        "asn1.js": "4.10.1",
         "browserify-aes": "1.1.1",
         "create-hash": "1.1.3",
         "evp_bytestokey": "1.0.3",
@@ -3317,9 +3310,9 @@
       "dev": true
     },
     "process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
       "dev": true
     },
     "prr": {
@@ -3416,9 +3409,9 @@
       }
     },
     "randomfill": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.3.tgz",
-      "integrity": "sha512-YL6GrhrWoic0Eq8rXVbMptH7dAxCs0J+mh5Y0euNekPPYaxEmdVGim6GdoxoRzKW2yJoU8tueifS7mYxvcFDEQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "dev": true,
       "requires": {
         "randombytes": "2.0.6",
@@ -3447,15 +3440,15 @@
       }
     },
     "readable-stream": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
+      "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
       "dev": true,
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
         "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
+        "process-nextick-args": "2.0.0",
         "safe-buffer": "5.1.1",
         "string_decoder": "1.0.3",
         "util-deprecate": "1.0.2"
@@ -3469,7 +3462,7 @@
       "requires": {
         "graceful-fs": "4.1.11",
         "minimatch": "3.0.4",
-        "readable-stream": "2.3.3",
+        "readable-stream": "2.3.4",
         "set-immediate-shim": "1.0.1"
       }
     },
@@ -3668,7 +3661,7 @@
       "dev": true,
       "requires": {
         "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
+        "readable-stream": "2.3.4"
       }
     },
     "stream-http": {
@@ -3679,7 +3672,7 @@
       "requires": {
         "builtin-status-codes": "3.0.0",
         "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
+        "readable-stream": "2.3.4",
         "to-arraybuffer": "1.0.1",
         "xtend": "4.0.1"
       }
@@ -3904,15 +3897,15 @@
       }
     },
     "webpack": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.10.0.tgz",
-      "integrity": "sha512-fxxKXoicjdXNUMY7LIdY89tkJJJ0m1Oo8PQutZ5rLgWbV5QVKI15Cn7+/IHnRTd3vfKfiwBx6SBqlorAuNA8LA==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.11.0.tgz",
+      "integrity": "sha512-3kOFejWqj5ISpJk4Qj/V7w98h9Vl52wak3CLiw/cDOfbVTq7FeoZ0SdoHHY9PYlHr50ZS42OfvzE2vB4nncKQg==",
       "dev": true,
       "requires": {
         "acorn": "5.4.1",
         "acorn-dynamic-import": "2.0.2",
-        "ajv": "5.5.2",
-        "ajv-keywords": "2.1.1",
+        "ajv": "6.1.1",
+        "ajv-keywords": "3.1.0",
         "async": "2.6.0",
         "enhanced-resolve": "3.4.1",
         "escope": "3.6.0",

--- a/springfox-swagger-ui/src/web/package.json
+++ b/springfox-swagger-ui/src/web/package.json
@@ -18,6 +18,6 @@
     "babel-loader": "^7.1.2",
     "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.6.1",
-    "webpack": "^3.10.0"
+    "webpack": "^3.11.0"
   }
 }


### PR DESCRIPTION
#### What's this PR do/fix?
- [x] Upgrade Swagger-UI version from 3.9.1 to [3.11.0](https://github.com/swagger-api/swagger-ui/releases/tag/v3.11.0)
- [x] Add `supportedSubmitMethods` in [3.10.0](https://github.com/swagger-api/swagger-ui/releases/tag/v3.10.0)
#### Are there unit tests? If not how should this be manually tested?
Yes
#### Any background context you want to provide?
Restored the `supportedSubmitMethods` config option from Swagger UI 2.x in 3.10.0.
#### What are the relevant issues?
none