### PR TITLE
add Bean Property Definition presence check

### DIFF
--- a/springfox-bean-validators/src/test/groovy/springfox/bean/validators/plugins/BeanValidatorsSpec.groovy
+++ b/springfox-bean-validators/src/test/groovy/springfox/bean/validators/plugins/BeanValidatorsSpec.groovy
@@ -15,7 +15,6 @@ import springfox.documentation.spi.schema.contexts.ModelPropertyContext
 
 import javax.validation.constraints.NotNull
 import javax.validation.constraints.Pattern
-import java.lang.annotation.Annotation
 import java.lang.reflect.AnnotatedElement
 
 class BeanValidatorsSpec extends Specification {

--- a/springfox-bean-validators/src/test/groovy/springfox/bean/validators/plugins/BeanValidatorsSpec.groovy
+++ b/springfox-bean-validators/src/test/groovy/springfox/bean/validators/plugins/BeanValidatorsSpec.groovy
@@ -7,12 +7,15 @@ import com.fasterxml.jackson.databind.type.TypeFactory
 import spock.lang.Specification
 import spock.lang.Unroll
 import springfox.bean.validators.plugins.models.BeanValidatorsTestModel
+import springfox.bean.validators.plugins.models.XmlTypeModel
 import springfox.documentation.builders.ModelPropertyBuilder
+import springfox.documentation.schema.property.XmlPropertyPlugin
 import springfox.documentation.spi.DocumentationType
 import springfox.documentation.spi.schema.contexts.ModelPropertyContext
 
 import javax.validation.constraints.NotNull
 import javax.validation.constraints.Pattern
+import java.lang.annotation.Annotation
 import java.lang.reflect.AnnotatedElement
 
 class BeanValidatorsSpec extends Specification {
@@ -45,6 +48,21 @@ class BeanValidatorsSpec extends Specification {
       def annotation = Validators.extractAnnotation(context, NotNull)
     then:
       !annotation.isPresent()
+  }
+
+  def "When XmlPropertyPlugin has absent bean definition"() {
+    when:
+      def plugin = new XmlPropertyPlugin()
+      def property = XmlTypeModel.getDeclaredField("strings")
+      property.getDeclaredAnnotations()
+      def context = new ModelPropertyContext(
+            new ModelPropertyBuilder(),
+            property,
+            new TypeResolver(),
+            DocumentationType.SWAGGER_2)
+      plugin.apply(context)
+    then:
+      noExceptionThrown()
   }
 
   @Unroll

--- a/springfox-bean-validators/src/test/java/springfox/bean/validators/plugins/models/XmlTypeModel.java
+++ b/springfox-bean-validators/src/test/java/springfox/bean/validators/plugins/models/XmlTypeModel.java
@@ -1,0 +1,53 @@
+/*
+ *
+ *  Copyright 2015 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+
+package springfox.bean.validators.plugins.models;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@javax.xml.bind.annotation.XmlType(
+    name = "XML_TYPE_OBJECT",
+    propOrder = {"strings"}
+)
+public class XmlTypeModel implements Serializable {
+  @XmlElement(name = "strings")
+  private List<String> strings;
+
+  public XmlTypeModel() {
+  }
+
+  public List<String> getStrings() {
+    if (this.strings == null) {
+      this.strings = new ArrayList();
+    }
+
+    return this.strings;
+  }
+
+  public void setStrings(List<String> strings) {
+    this.strings = strings;
+  }
+}
+

--- a/springfox-bean-validators/src/test/java/springfox/bean/validators/plugins/models/XmlTypeModel.java
+++ b/springfox-bean-validators/src/test/java/springfox/bean/validators/plugins/models/XmlTypeModel.java
@@ -35,14 +35,10 @@ public class XmlTypeModel implements Serializable {
   @XmlElement(name = "strings")
   private List<String> strings;
 
-  public XmlTypeModel() {
-  }
-
   public List<String> getStrings() {
     if (this.strings == null) {
       this.strings = new ArrayList();
     }
-
     return this.strings;
   }
 

--- a/springfox-schema/src/main/java/springfox/documentation/schema/property/XmlPropertyPlugin.java
+++ b/springfox-schema/src/main/java/springfox/documentation/schema/property/XmlPropertyPlugin.java
@@ -61,7 +61,7 @@ public class XmlPropertyPlugin implements ModelPropertyBuilderPlugin {
           XmlAttribute.class));
     }
 
-    if (elementAnnotation.isPresent()) {
+    if (elementAnnotation.isPresent() && context.getBeanPropertyDefinition().isPresent()) {
       Optional<XmlElementWrapper> wrapper = findPropertyAnnotation(
           context.getBeanPropertyDefinition().get(),
           XmlElementWrapper.class);


### PR DESCRIPTION
**What's this PR do/fix?**
This PR fixes issue [https://github.com/springfox/springfox/issues/2286](https://github.com/springfox/springfox/issues/2286)

**Are there unit tests? If not how should this be manually tested?**
I made a groovy test called "When XmlPropertyPlugin has absent bean definition" in BeanValidatorsSpec test.

