### PR TITLE
springfox-data-rest: fix EntitySearchExtractor return type

### DIFF
--- a/springfox-data-rest/src/main/java/springfox/documentation/spring/data/rest/EntitySearchExtractor.java
+++ b/springfox-data-rest/src/main/java/springfox/documentation/spring/data/rest/EntitySearchExtractor.java
@@ -79,7 +79,7 @@ class EntitySearchExtractor implements EntityOperationsExtractor {
       TypeResolver resolver) {
     ResolvedType returnType = methodResolver.methodReturnType(handler);
     if (Collections.isContainerType(returnType)) {
-      return resolver.resolve(Resources.class, returnType);
+      return resolver.resolve(Resources.class, Collections.collectionElementType(returnType));
     } else if (Types.isBaseType(returnType)) {
       return returnType;
     }

--- a/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-spring-data-rest.json
+++ b/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-spring-data-rest.json
@@ -504,7 +504,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/ResourcesOfListOfPerson"
+                            "$ref": "#/definitions/ResourcesOfPerson"
                         }
                     }
                 }
@@ -532,7 +532,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/ResourcesOfListOfPerson"
+                            "$ref": "#/definitions/ResourcesOfPerson"
                         }
                     }
                 }
@@ -1889,33 +1889,6 @@
                 "attribute": false,
                 "wrapped": false
             }
-        },
-        "ResourcesOfListOfPerson": {
-            "type": "object",
-            "properties": {
-                "content": {
-                    "type": "array",
-                    "items": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/definitions/Person"
-                        }
-                    }
-                },
-                "links": {
-                    "type": "array",
-                    "xml": {
-                        "name": "link",
-                        "namespace": "http://www.w3.org/2005/Atom",
-                        "attribute": false,
-                        "wrapped": false
-                    },
-                    "items": {
-                        "$ref": "#/definitions/Link"
-                    }
-                }
-            },
-            "title": "ResourcesOfListOfPerson"
         },
         "ResourcesOfPerson": {
             "type": "object",


### PR DESCRIPTION
#### What's this PR do/fix?

This is a fix for #2311 

#### Are there unit tests? If not how should this be manually tested?
_declaration-spring-data-rest_ contract has been updated to reflect the changed behavior.

#### Any background context you want to provide?

_findAll_ and _search_ methods should return the same type of result.

#### What are the relevant issues?
#2311
