### PR TITLE
Fix for Parameter Annotations like @ApiParam do not traverse super cl…

### DIFF
--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/operation/HandlerMethodResolver.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/operation/HandlerMethodResolver.java
@@ -38,6 +38,7 @@ import org.springframework.core.MethodParameter;
 import org.springframework.core.ParameterNameDiscoverer;
 import org.springframework.web.method.HandlerMethod;
 import springfox.documentation.service.ResolvedMethodParameter;
+import springfox.documentation.spring.web.readers.operation.util.AnnotationUtils;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
@@ -178,9 +179,10 @@ public class HandlerMethodResolver {
         MethodParameter[] methodParameters = methodToResolve.getMethodParameters();
         for (int i = 0; i < input.getArgumentCount(); i++) {
           parameters.add(new ResolvedMethodParameter(
-              discoveredName(methodParameters[i]).or(String.format("param%s", i)),
-              methodParameters[i],
-              input.getArgumentType(i)));
+                  methodParameters[i].getParameterIndex(),
+                  discoveredName(methodParameters[i]).or(String.format("param%s", i)),
+                  AnnotationUtils.getInheritedAnnotations(methodToResolve, methodParameters[i].getParameterIndex()),
+                  input.getArgumentType(i)));
         }
         return parameters;
       }

--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/operation/util/AnnotationUtils.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/operation/util/AnnotationUtils.java
@@ -1,0 +1,49 @@
+/*
+ *
+ *  Copyright 2016 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+
+package springfox.documentation.spring.web.readers.operation.util;
+
+import org.springframework.util.ConcurrentReferenceHashMap;
+import org.springframework.web.method.HandlerMethod;
+
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+public class AnnotationUtils {
+
+    private static final Map<HandlerMethod, Annotation[][]> ANNOTATION_CACHE =
+            new ConcurrentReferenceHashMap<HandlerMethod, Annotation[][]>(256);
+
+    public static List<Annotation> getInheritedAnnotations(HandlerMethod methodToResolve, int parameterIndex) {
+        Annotation[][] parameterAnnotations = getInheritedParameterAnnotations(methodToResolve);
+        return Arrays.asList(parameterAnnotations[parameterIndex]);
+    }
+
+    private static Annotation[][] getInheritedParameterAnnotations(HandlerMethod methodToResolve) {
+        Annotation[][] annotations = ANNOTATION_CACHE.get(methodToResolve);
+        if (annotations == null) {
+            annotations = ReflectionUtils.getParameterAnnotations(methodToResolve.getMethod());
+            ANNOTATION_CACHE.put(methodToResolve, annotations);
+        }
+        return annotations;
+    }
+
+}

--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/operation/util/ArrayUtils.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/operation/util/ArrayUtils.java
@@ -1,0 +1,93 @@
+/*
+ *
+ *  Copyright 2016 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+
+package springfox.documentation.spring.web.readers.operation.util;
+
+import java.lang.reflect.Array;
+
+/**
+ * Downsized version of org.apache.commons.lang3.ArrayUtils.
+ */
+public class ArrayUtils {
+
+    /**
+     * <p>Copies the given array and adds the given element at the end of the new array.
+     *
+     * <p>The new array contains the same elements of the input
+     * array plus the given element in the last position. The component type of
+     * the new array is the same as that of the input array.
+     *
+     * <p>If the input array is {@code null}, a new one element array is returned
+     *  whose component type is the same as the element, unless the element itself is null,
+     *  in which case the return type is Object[]
+     *
+     * <pre>
+     * ArrayUtils.add(null, null)      = [null]
+     * ArrayUtils.add(null, "a")       = ["a"]
+     * ArrayUtils.add(["a"], null)     = ["a", null]
+     * ArrayUtils.add(["a"], "b")      = ["a", "b"]
+     * ArrayUtils.add(["a", "b"], "c") = ["a", "b", "c"]
+     * </pre>
+     *
+     * @param <T> the component type of the array
+     * @param array  the array to "add" the element to, may be {@code null}
+     * @param element  the object to add, may be {@code null}
+     * @return A new array containing the existing elements plus the new element
+     * The returned array type will be that of the input array (unless null),
+     * in which case it will have the same type as the element.
+     * If both are null, an IllegalArgumentException is thrown
+     * @since 2.1
+     * @throws IllegalArgumentException if both arguments are null
+     */
+    public static <T> T[] add(final T[] array, final T element) {
+        Class<?> type;
+        if (array != null) {
+            type = array.getClass().getComponentType();
+        } else if (element != null) {
+            type = element.getClass();
+        } else {
+            throw new IllegalArgumentException("Arguments cannot both be null");
+        }
+        @SuppressWarnings("unchecked") // type must be T
+        final
+        T[] newArray = (T[]) copyArrayGrow1(array, type);
+        newArray[newArray.length - 1] = element;
+        return newArray;
+    }
+
+    /**
+     * Returns a copy of the given array of size 1 greater than the argument.
+     * The last value of the array is left to the default value.
+     *
+     * @param array The array to copy, must not be {@code null}.
+     * @param newArrayComponentType If {@code array} is {@code null}, create a
+     * size 1 array of this type.
+     * @return A new copy of the array of size 1 greater than the input.
+     */
+    private static Object copyArrayGrow1(final Object array, final Class<?> newArrayComponentType) {
+        if (array != null) {
+            final int arrayLength = Array.getLength(array);
+            final Object newArray = Array.newInstance(array.getClass().getComponentType(), arrayLength + 1);
+            System.arraycopy(array, 0, newArray, 0, arrayLength);
+            return newArray;
+        }
+        return Array.newInstance(newArrayComponentType, 1);
+    }
+
+}

--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/operation/util/ReflectionUtils.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/operation/util/ReflectionUtils.java
@@ -1,0 +1,124 @@
+/*
+ *
+ *  Copyright 2016 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+
+package springfox.documentation.spring.web.readers.operation.util;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Downsized version of io.swagger.util.ReflectionUtils
+ */
+public class ReflectionUtils {
+
+    /**
+     * Returns overridden method from superclass if it exists. If method was not found returns null.
+     *
+     * @param method is method to find
+     * @return overridden method from superclass
+     */
+    public static Method getOverriddenMethod(Method method) {
+        Class<?> declaringClass = method.getDeclaringClass();
+        Class<?> superClass = declaringClass.getSuperclass();
+        Method result = null;
+        if (superClass != null && !(superClass.equals(Object.class))) {
+            result = findMethod(method, superClass);
+        }
+        if (result == null) {
+            for (Class<?> anInterface : declaringClass.getInterfaces()) {
+                result = findMethod(method, anInterface);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Searches the method methodToFind in given class cls. If the method is found returns it, else return null.
+     *
+     * @param methodToFind is the method to search
+     * @param cls          is the class or interface where to search
+     * @return method if it is found
+     */
+    public static Method findMethod(Method methodToFind, Class<?> cls) {
+        if (cls == null) {
+            return null;
+        }
+        String methodToSearch = methodToFind.getName();
+        Class<?>[] soughtForParameterType = methodToFind.getParameterTypes();
+        Type[] soughtForGenericParameterType = methodToFind.getGenericParameterTypes();
+        for (Method method : cls.getMethods()) {
+            if (method.getName().equals(methodToSearch) && method.getReturnType().isAssignableFrom(methodToFind.getReturnType())) {
+                Class<?>[] srcParameterTypes = method.getParameterTypes();
+                Type[] srcGenericParameterTypes = method.getGenericParameterTypes();
+                if (soughtForParameterType.length == srcParameterTypes.length &&
+                        soughtForGenericParameterType.length == srcGenericParameterTypes.length) {
+                    if (hasIdenticalParameters(srcParameterTypes, soughtForParameterType, srcGenericParameterTypes, soughtForGenericParameterType)) {
+                        return method;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private static boolean hasIdenticalParameters(Class<?>[] srcParameterTypes, Class<?>[] soughtForParameterType,
+                                                  Type[] srcGenericParameterTypes, Type[] soughtForGenericParameterType) {
+        for (int j = 0; j < soughtForParameterType.length; j++) {
+            Class<?> parameterType = soughtForParameterType[j];
+            if (!(srcParameterTypes[j].equals(parameterType) || (!srcGenericParameterTypes[j].equals(soughtForGenericParameterType[j]) &&
+                    srcParameterTypes[j].isAssignableFrom(parameterType)))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static Annotation[][] getParameterAnnotations(Method method) {
+        Annotation[][] methodAnnotations = method.getParameterAnnotations();
+        Method overriddenmethod = getOverriddenMethod(method);
+
+        if (overriddenmethod != null) {
+            Annotation[][] overriddenAnnotations = overriddenmethod
+                    .getParameterAnnotations();
+
+            for (int i = 0; i < methodAnnotations.length; i++) {
+                List<Type> types = new ArrayList<Type>();
+                for (int j = 0; j < methodAnnotations[i].length; j++) {
+                    types.add(methodAnnotations[i][j].annotationType());
+                }
+                for (int j = 0; j < overriddenAnnotations[i].length; j++) {
+                    if (!types.contains(overriddenAnnotations[i][j]
+                            .annotationType())) {
+                        methodAnnotations[i] = ArrayUtils.add(
+                                methodAnnotations[i],
+                                overriddenAnnotations[i][j]);
+                    }
+                }
+
+            }
+        }
+        return methodAnnotations;
+    }
+}


### PR DESCRIPTION
…asses for resolution #1575.

#### What's this PR do/fix?
Annotations of method parameters are now resolved by traversing super classes and interfaces.
Annotations are cached per handler method to avoid repeated lookups.
The code to find the inherited annotations is taken from swagger-core's ReflectionUtils class.

The first commit of this PR should be considered a draft. Feedback welcome.

#### Are there unit tests? If not how should this be manually tested?
No unit tests yet. 
I'm happy to provide some tests but need some help doing so.

