### PR TITLE
Using media type to determine correct param type when expanding param…

### DIFF
--- a/springfox-bean-validators/src/test/groovy/springfox/bean/validators/plugins/parameter/ExpandedParameterMinMaxAnnotationPluginSpec.groovy
+++ b/springfox-bean-validators/src/test/groovy/springfox/bean/validators/plugins/parameter/ExpandedParameterMinMaxAnnotationPluginSpec.groovy
@@ -36,6 +36,7 @@ class ExpandedParameterMinMaxAnnotationPluginSpec
     ParameterExpansionContext context = new ParameterExpansionContext(
         "Test",
         "",
+        "",
         new ModelAttributeParameterMetadataAccessor(
             [named(Subject, fieldName).rawMember],
             resolver.resolve(Subject),

--- a/springfox-bean-validators/src/test/groovy/springfox/bean/validators/plugins/parameter/ExpandedParameterNotNullAnnotationPluginSpec.groovy
+++ b/springfox-bean-validators/src/test/groovy/springfox/bean/validators/plugins/parameter/ExpandedParameterNotNullAnnotationPluginSpec.groovy
@@ -34,6 +34,7 @@ class ExpandedParameterNotNullAnnotationPluginSpec
     ParameterExpansionContext context = new ParameterExpansionContext(
         "Test",
         "",
+        "",
         new ModelAttributeParameterMetadataAccessor(
             [named(Subject, fieldName).rawMember],
             resolver.resolve(Subject),

--- a/springfox-bean-validators/src/test/groovy/springfox/bean/validators/plugins/parameter/ExpandedParameterPatternAnnotationPluginSpec.groovy
+++ b/springfox-bean-validators/src/test/groovy/springfox/bean/validators/plugins/parameter/ExpandedParameterPatternAnnotationPluginSpec.groovy
@@ -52,6 +52,7 @@ class ExpandedParameterPatternAnnotationPluginSpec
     ParameterExpansionContext context = new ParameterExpansionContext(
         "Test",
         "",
+        "",
         new ModelAttributeParameterMetadataAccessor(
             [named(Subject, fieldName).rawMember],
             resolver.resolve(Subject),

--- a/springfox-bean-validators/src/test/groovy/springfox/bean/validators/plugins/parameter/ExpandedParameterSizeAnnotationPluginSpec.groovy
+++ b/springfox-bean-validators/src/test/groovy/springfox/bean/validators/plugins/parameter/ExpandedParameterSizeAnnotationPluginSpec.groovy
@@ -38,6 +38,7 @@ class ExpandedParameterSizeAnnotationPluginSpec
     ParameterExpansionContext context = new ParameterExpansionContext(
         "Test",
         "",
+        "",
         new ModelAttributeParameterMetadataAccessor(
             [named(Subject, fieldName).rawMember],
             resolver.resolve(Subject),

--- a/springfox-spi/src/main/java/springfox/documentation/spi/service/contexts/ParameterExpansionContext.java
+++ b/springfox-spi/src/main/java/springfox/documentation/spi/service/contexts/ParameterExpansionContext.java
@@ -33,6 +33,7 @@ public class ParameterExpansionContext {
 
   private final String dataTypeName;
   private final String parentName;
+  private final String parameterType;
   private final ParameterMetadataAccessor metadataAccessor;
   private final DocumentationType documentationType;
   private final ParameterBuilder parameterBuilder;
@@ -40,12 +41,14 @@ public class ParameterExpansionContext {
   public ParameterExpansionContext(
       String dataTypeName,
       String parentName,
+      String parameterType,
       ParameterMetadataAccessor metadataAccessor,
       DocumentationType documentationType,
       ParameterBuilder parameterBuilder) {
 
     this.dataTypeName = dataTypeName;
     this.parentName = parentName;
+    this.parameterType = parameterType;
     this.metadataAccessor = metadataAccessor;
     this.documentationType = documentationType;
     this.parameterBuilder = parameterBuilder;
@@ -57,6 +60,10 @@ public class ParameterExpansionContext {
 
   public String getParentName() {
     return parentName;
+  }
+
+  public String getParameterType() {
+    return parameterType;
   }
 
   /**

--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/operation/OperationParameterReader.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/operation/OperationParameterReader.java
@@ -98,7 +98,7 @@ public class OperationParameterReader implements OperationBuilderPlugin {
         if (shouldExpand(methodParameter, alternate)) {
           parameters.addAll(
               expander.expand(
-                  new ExpansionContext("", alternate, context.getDocumentationContext())));
+                  new ExpansionContext("", alternate, context)));
         } else {
           parameters.add(pluginsManager.parameter(parameterContext));
         }

--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/parameter/ExpandedParameterBuilder.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/parameter/ExpandedParameterBuilder.java
@@ -94,7 +94,7 @@ public class ExpandedParameterBuilder implements ExpandedParameterBuilderPlugin 
         .type(resolved)
         .modelRef(new ModelRef(typeName, itemModel))
         .allowableValues(allowable)
-        .parameterType("query")
+        .parameterType(context.getParameterType())
         .order(DEFAULT_PRECEDENCE)
         .parameterAccess(null);
   }

--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/parameter/ExpansionContext.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/parameter/ExpansionContext.java
@@ -22,33 +22,34 @@ package springfox.documentation.spring.web.readers.parameter;
 import com.fasterxml.classmate.ResolvedType;
 import com.google.common.collect.Sets;
 import springfox.documentation.spi.service.contexts.DocumentationContext;
+import springfox.documentation.spi.service.contexts.OperationContext;
 
 import java.util.Set;
 
-import static com.google.common.base.Objects.*;
-import static com.google.common.collect.Sets.*;
+import static com.google.common.base.Objects.equal;
+import static com.google.common.collect.Sets.newHashSet;
 
 public class ExpansionContext {
     private final String parentName;
     private final ResolvedType paramType;
-    private final DocumentationContext documentationContext;
+    private final OperationContext operationContext;
     private final Set<ResolvedType> seenTypes;
 
     public ExpansionContext(
             String parentName,
             ResolvedType paramType,
-            DocumentationContext documentationContext) {
-        this(parentName, paramType, documentationContext, Sets.<ResolvedType>newHashSet());
+            OperationContext operationContext) {
+        this(parentName, paramType, operationContext, Sets.<ResolvedType>newHashSet());
     }
 
     private ExpansionContext(
             String parentName,
             ResolvedType paramType,
-            DocumentationContext documentationContext,
+            OperationContext operationContext,
             Set<ResolvedType> seenTypes) {
         this.parentName = parentName;
         this.paramType = paramType;
-        this.documentationContext = documentationContext;
+        this.operationContext = operationContext;
         this.seenTypes = newHashSet(seenTypes);
     }
 
@@ -60,8 +61,12 @@ public class ExpansionContext {
         return paramType;
     }
 
+    public OperationContext getOperationContext() {
+        return operationContext;
+    }
+
     public DocumentationContext getDocumentationContext() {
-        return documentationContext;
+        return operationContext.getDocumentationContext();
     }
 
     public boolean hasSeenType(ResolvedType type) {
@@ -72,9 +77,9 @@ public class ExpansionContext {
     public ExpansionContext childContext(
             String parentName,
             ResolvedType childType,
-            DocumentationContext documentationContext) {
+            OperationContext operationContext) {
         Set<ResolvedType> childSeenTypes = newHashSet(seenTypes);
         childSeenTypes.add(childType);
-        return new ExpansionContext(parentName, childType, documentationContext, childSeenTypes);
+        return new ExpansionContext(parentName, childType, operationContext, childSeenTypes);
     }
 }

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/paths/OperationPathDecoratorSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/paths/OperationPathDecoratorSpec.groovy
@@ -11,7 +11,7 @@ class OperationPathDecoratorSpec extends DocumentationContextSpec {
       def requestMappingContext = Mock(RequestMappingContext)
       PathContext ctx = new PathContext(requestMappingContext, Optional.absent())
     and:
-      requestMappingContext.getDocumentationContext() >> context()
+      requestMappingContext.getDocumentationContext() >> documentationContext()
     and:
       def sut = new OperationPathDecorator()
     when:

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/paths/PathMappingDecoratorSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/paths/PathMappingDecoratorSpec.groovy
@@ -11,7 +11,7 @@ class PathMappingDecoratorSpec extends DocumentationContextSpec {
       PathContext ctx = new PathContext(requestMappingContext, Optional.absent())
     and:
       plugin.pathMapping(pathMapping)
-      requestMappingContext.getDocumentationContext() >> context()
+      requestMappingContext.getDocumentationContext() >> documentationContext()
     and:
       def sut = new PathMappingDecorator()
     when:

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/paths/PathSanitizerSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/paths/PathSanitizerSpec.groovy
@@ -10,7 +10,7 @@ class PathSanitizerSpec extends DocumentationContextSpec {
       def requestMappingContext = Mock(RequestMappingContext)
       PathContext ctx = new PathContext(requestMappingContext, Optional.absent())
     and:
-      requestMappingContext.getDocumentationContext() >> context()
+      requestMappingContext.getDocumentationContext() >> documentationContext()
     and:
       def sut = new PathSanitizer()
     when:

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/paths/QueryStringUriTemplateDecoratorSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/paths/QueryStringUriTemplateDecoratorSpec.groovy
@@ -23,7 +23,7 @@ class QueryStringUriTemplateDecoratorSpec extends DocumentationContextSpec {
       def requestMappingContext = Mock(RequestMappingContext)
       PathContext ctx = new PathContext(requestMappingContext, operation(params, allowedValues))
     and:
-      requestMappingContext.getDocumentationContext() >> context()
+      requestMappingContext.getDocumentationContext() >> documentationContext()
     and:
       def sut = new QueryStringUriTemplateDecorator()
     when:

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/plugins/DocketSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/plugins/DocketSpec.groovy
@@ -153,7 +153,7 @@ class DocketSpec extends DocumentationContextSpec {
         .configure(contextBuilder)
 
     expect:
-    context().alternateTypeProvider.rules.contains(rule)
+    documentationContext().alternateTypeProvider.rules.contains(rule)
   }
 
   def "Model substitution registers new rules"() {
@@ -165,7 +165,7 @@ class DocketSpec extends DocumentationContextSpec {
         .configure(contextBuilder)
 
     then:
-    context().alternateTypeProvider.rules.size() == expectedSize + jdk8RuleCount
+    documentationContext().alternateTypeProvider.rules.size() == expectedSize + jdk8RuleCount
 
     where:
     method                    | args                               | expectedSize
@@ -179,7 +179,7 @@ class DocketSpec extends DocumentationContextSpec {
     plugin."$builderMethod"(object)
 
     then:
-    context()."$property" == object || (context()."$property" == [object] as Set)
+    documentationContext()."$property" == object || (documentationContext()."$property" == [object] as Set)
 
     where:
     builderMethod               | object                                         | property
@@ -210,7 +210,7 @@ class DocketSpec extends DocumentationContextSpec {
     plugin."$builderMethod"(object)
 
     then:
-    context().genericsNamingStrategy.getClass() == strategy
+    documentationContext().genericsNamingStrategy.getClass() == strategy
 
     where:
     builderMethod       | object | strategy
@@ -223,7 +223,7 @@ class DocketSpec extends DocumentationContextSpec {
     plugin."$builderMethod"(object)
 
     then:
-    context().pathMapping == path
+    documentationContext().pathMapping == path
 
     where:
     builderMethod | object  | path

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/plugins/DocumentationContextSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/plugins/DocumentationContextSpec.groovy
@@ -24,12 +24,13 @@ import com.google.common.collect.Ordering
 import spock.lang.Specification
 import springfox.documentation.spi.DocumentationType
 import springfox.documentation.spi.service.contexts.Defaults
-import springfox.documentation.spring.web.readers.operation.ApiOperationReader
 import springfox.documentation.spi.service.contexts.DocumentationContextBuilder
+import springfox.documentation.spi.service.contexts.OperationContext
+import springfox.documentation.spring.web.readers.operation.ApiOperationReader
 
 import javax.servlet.ServletContext
 
-import static springfox.documentation.spi.service.contexts.Orderings.*
+import static springfox.documentation.spi.service.contexts.Orderings.nickNameComparator
 
 class DocumentationContextSpec extends Specification {
   DocumentationContextBuilder contextBuilder
@@ -47,7 +48,14 @@ class DocumentationContextSpec extends Specification {
     operationReader = Mock(ApiOperationReader)
   }
 
-  def context() {
+  def documentationContext() {
     plugin.configure(contextBuilder)
+  }
+
+  def context() {
+    OperationContext context = Mock()
+    context.documentationContext >> documentationContext()
+    context.consumes() >> []
+    return context
   }
 }

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/ApiModelReaderSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/ApiModelReaderSpec.groovy
@@ -88,7 +88,7 @@ class ApiModelReaderSpec extends DocumentationContextSpec {
 
   def requestMappingContext(HandlerMethod handlerMethod) {
     return new RequestMappingContext(
-        context(),
+        documentationContext(),
         new WebMvcRequestHandler(methodResolver, requestMappingInfo('/somePath'),
             handlerMethod))
   }

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/ApiOperationReaderSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/ApiOperationReaderSpec.groovy
@@ -66,7 +66,7 @@ class ApiOperationReaderSpec extends DocumentationContextSpec {
 
       HandlerMethod handlerMethod = dummyHandlerMethod()
 
-      RequestMappingContext context = new RequestMappingContext(context(),
+      RequestMappingContext context = new RequestMappingContext(documentationContext(),
               new WebMvcRequestHandler(methodResolver,
                   requestMappingInfo,
                   handlerMethod))

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/MediaTypeReaderSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/MediaTypeReaderSpec.groovy
@@ -52,7 +52,7 @@ class MediaTypeReaderSpec extends DocumentationContextSpec {
             ]
         )
     OperationContext operationContext =
-        operationContext(context(), handlerMethod, 0, requestMappingInfo, httpMethod)
+        operationContext(documentationContext(), handlerMethod, 0, requestMappingInfo, httpMethod)
     operationContext.operationBuilder().method(HttpMethod.valueOf(httpMethod.toString()))
 
     when:
@@ -88,7 +88,7 @@ class MediaTypeReaderSpec extends DocumentationContextSpec {
         )
     OperationContext operationContext =
         operationContext(
-            context(),
+            documentationContext(),
             dummyHandlerMethod(),
             0,
             requestMappingInfo,
@@ -123,7 +123,7 @@ class MediaTypeReaderSpec extends DocumentationContextSpec {
             ]
         )
     OperationContext operationContext =
-        operationContext(context(), dummyHandlerMethod(), 0, requestMappingInfo)
+        operationContext(documentationContext(), dummyHandlerMethod(), 0, requestMappingInfo)
 
     when:
     sut.apply(operationContext)

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/operation/DefaultResponseMessageReaderSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/operation/DefaultResponseMessageReaderSpec.groovy
@@ -53,7 +53,7 @@ class DefaultResponseMessageReaderSpec extends DocumentationContextSpec {
   def "Should add default response messages"() {
     given:
       OperationContext operationContext =
-          operationContext(context(),
+          operationContext(documentationContext(),
               handlerMethod,
               0,
               requestMappingInfo("/somePath"),
@@ -78,7 +78,7 @@ class DefaultResponseMessageReaderSpec extends DocumentationContextSpec {
   def "swagger annotation should override when using default reader"() {
     given:
       OperationContext operationContext =
-          operationContext(context(), dummyHandlerMethod('methodWithApiResponses'))
+          operationContext(documentationContext(), dummyHandlerMethod('methodWithApiResponses'))
 
     when:
       sut.apply(operationContext)
@@ -95,7 +95,7 @@ class DefaultResponseMessageReaderSpec extends DocumentationContextSpec {
 
   def "Methods with return type containing a model should override the success response code"() {
     given:
-      OperationContext operationContext = operationContext(context(), dummyHandlerMethod('methodWithConcreteResponseBody'))
+      OperationContext operationContext = operationContext(documentationContext(), dummyHandlerMethod('methodWithConcreteResponseBody'))
 
     when:
       sut.apply(operationContext)
@@ -111,7 +111,7 @@ class DefaultResponseMessageReaderSpec extends DocumentationContextSpec {
   def "Methods with return type containing a container model should override the success response code"() {
     given:
       OperationContext operationContext =
-          operationContext(context(), dummyHandlerMethod('methodWithListOfBusinesses'))
+          operationContext(documentationContext(), dummyHandlerMethod('methodWithListOfBusinesses'))
 
     when:
       sut.apply(operationContext)
@@ -128,7 +128,7 @@ class DefaultResponseMessageReaderSpec extends DocumentationContextSpec {
   def "Methods with return type containing ResponseStatus annotation"() {
     given:
       OperationContext operationContext =
-          operationContext(context(), dummyHandlerMethod('methodWithResponseStatusAnnotation'))
+          operationContext(documentationContext(), dummyHandlerMethod('methodWithResponseStatusAnnotation'))
 
     when:
       sut.apply(operationContext)
@@ -144,7 +144,7 @@ class DefaultResponseMessageReaderSpec extends DocumentationContextSpec {
   def "Methods with return type containing ResponseStatus annotation and empty reason message"() {
     given:
       OperationContext operationContext =
-          operationContext(context(), dummyHandlerMethod('methodWithResponseStatusAnnotationAndEmptyReason'))
+          operationContext(documentationContext(), dummyHandlerMethod('methodWithResponseStatusAnnotationAndEmptyReason'))
 
     when:
       sut.apply(operationContext)

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/operation/OperationCommandReaderSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/operation/OperationCommandReaderSpec.groovy
@@ -33,7 +33,7 @@ class OperationCommandReaderSpec extends DocumentationContextSpec {
   def "should set various properties based on method name or swagger annotation"() {
     given:
       OperationContext operationContext =
-        operationContext(context(), handlerMethod, CURRENT_COUNT)
+        operationContext(documentationContext(), handlerMethod, CURRENT_COUNT)
 
     when:
       command.apply(operationContext)

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/operation/OperationMethodReaderSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/operation/OperationMethodReaderSpec.groovy
@@ -33,7 +33,7 @@ class OperationMethodReaderSpec extends DocumentationContextSpec {
     given:
       OperationContext operationContext =
         operationContext(
-            context(),
+            documentationContext(),
             dummyHandlerMethod('methodWithListOfBusinesses'),
             0,
             requestMappingInfo("/somePath"),

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/operation/OperationParameterHeadersConditionReaderSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/operation/OperationParameterHeadersConditionReaderSpec.groovy
@@ -39,7 +39,7 @@ class OperationParameterHeadersConditionReaderSpec extends DocumentationContextS
       HeadersRequestCondition headersCondition = new HeadersRequestCondition("test=testValue")
       RequestMappingInfo requestMappingInfo = requestMappingInfo('/parameter-conditions',
               ["headersCondition": headersCondition])
-      OperationContext operationContext = operationContext(context(), handlerMethod, 0, requestMappingInfo)
+      OperationContext operationContext = operationContext(documentationContext(), handlerMethod, 0, requestMappingInfo)
     when:
       sut.apply(operationContext)
       def operation = operationContext.operationBuilder().build()
@@ -69,7 +69,7 @@ class OperationParameterHeadersConditionReaderSpec extends DocumentationContextS
       HeadersRequestCondition headersCondition = new HeadersRequestCondition("!test")
       RequestMappingInfo requestMappingInfo = requestMappingInfo('/parameter-conditions',
               ["headersCondition": headersCondition])
-      OperationContext operationContext = operationContext(context(), handlerMethod, 0, requestMappingInfo)
+      OperationContext operationContext = operationContext(documentationContext(), handlerMethod, 0, requestMappingInfo)
 
     when:
       sut.apply(operationContext)
@@ -84,7 +84,7 @@ class OperationParameterHeadersConditionReaderSpec extends DocumentationContextS
     given:
       HandlerMethod handlerMethod = dummyHandlerMethod('methodWithParameterRequestCondition')
       HeadersRequestCondition paramCondition = new HeadersRequestCondition("test=testValue", "test=3")
-      OperationContext operationContext = operationContext(context(),
+      OperationContext operationContext = operationContext(documentationContext(),
         handlerMethod,
         0,
         requestMappingInfo('/parameter-conditions', ["headersCondition": paramCondition]))

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/operation/OperationParameterRequestConditionReaderSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/operation/OperationParameterRequestConditionReaderSpec.groovy
@@ -40,7 +40,7 @@ class OperationParameterRequestConditionReaderSpec extends DocumentationContextS
       RequestMappingInfo requestMappingInfo = requestMappingInfo('/parameter-conditions',
               ["paramsCondition": paramCondition])
       OperationContext operationContext =
-          operationContext(context(), handlerMethod, 0, requestMappingInfo)
+          operationContext(documentationContext(), handlerMethod, 0, requestMappingInfo)
     when:
       sut.apply(operationContext)
       def operation = operationContext.operationBuilder().build()
@@ -71,7 +71,7 @@ class OperationParameterRequestConditionReaderSpec extends DocumentationContextS
       RequestMappingInfo requestMappingInfo = requestMappingInfo('/parameter-conditions',
               ["paramsCondition": paramCondition])
       OperationContext operationContext =
-          operationContext(context(), handlerMethod, 0, requestMappingInfo)
+          operationContext(documentationContext(), handlerMethod, 0, requestMappingInfo)
 
     when:
       sut.apply(operationContext)
@@ -88,7 +88,7 @@ class OperationParameterRequestConditionReaderSpec extends DocumentationContextS
       ParamsRequestCondition paramCondition = new ParamsRequestCondition("test=testValue", "test=3")
       def requestMappingInfo = requestMappingInfo('/parameter-conditions', ["paramsCondition": paramCondition])
       OperationContext operationContext =
-        operationContext(context(), handlerMethod, 0, requestMappingInfo)
+        operationContext(documentationContext(), handlerMethod, 0, requestMappingInfo)
     when:
       sut.apply(operationContext)
 

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/operation/OperationPositionReaderSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/operation/OperationPositionReaderSpec.groovy
@@ -29,7 +29,7 @@ class OperationPositionReaderSpec extends DocumentationContextSpec {
    def "should have correct api position using default reader"() {
     given:
       OperationContext operationContext =
-        operationContext(context(), handlerMethod, contextCount)
+        operationContext(documentationContext(), handlerMethod, contextCount)
 
       def operationPositionReader = new DefaultOperationReader();
     when:

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/operation/OperationResponseClassReaderSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/operation/OperationResponseClassReaderSpec.groovy
@@ -59,7 +59,7 @@ class OperationResponseClassReaderSpec extends DocumentationContextSpec {
 
   def "should have correct response class"() {
     given:
-      OperationContext operationContext = operationContext(context(), handlerMethod)
+      OperationContext operationContext = operationContext(documentationContext(), handlerMethod)
     when:
       sut.apply(operationContext)
       def operation = operationContext.operationBuilder().build()

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/operation/OperationTagsReaderSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/operation/OperationTagsReaderSpec.groovy
@@ -29,7 +29,7 @@ class OperationTagsReaderSpec extends DocumentationContextSpec {
   def "should have correct tags"() {
     given:
       OperationContext operationContext =
-        operationContext(context(), handlerMethod)
+        operationContext(documentationContext(), handlerMethod)
 
     and:
       OperationTagsReader sut = new OperationTagsReader(new DefaultTagsProvider())

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/parameter/ExpandedParameterBuilderSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/parameter/ExpandedParameterBuilderSpec.groovy
@@ -20,6 +20,7 @@ class ExpandedParameterBuilderSpec extends Specification {
     ParameterExpansionContext context = new ParameterExpansionContext(
         "Test",
         "",
+        "",
         new ModelAttributeParameterMetadataAccessor(
             [named("enums").rawMember],
             named("enums").type,
@@ -50,6 +51,7 @@ class ExpandedParameterBuilderSpec extends Specification {
     and:
     ParameterExpansionContext context = new ParameterExpansionContext(
         "Test",
+        "",
         "",
         new ModelAttributeParameterMetadataAccessor(
             [named(field).rawMember],

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/parameter/ParameterDataTypeReaderSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/parameter/ParameterDataTypeReaderSpec.groovy
@@ -72,7 +72,7 @@ class ParameterDataTypeReaderSpec extends DocumentationContextSpec {
           new ResolvedMethodParameter(0, "", annotations, new TypeResolver().resolve(paramType))
       def namingStrategy = new DefaultGenericTypeNamingStrategy()
       ParameterContext parameterContext =
-              new ParameterContext(resolvedMethodParameter, new ParameterBuilder(), context(), namingStrategy,
+              new ParameterContext(resolvedMethodParameter, new ParameterBuilder(), documentationContext(), namingStrategy,
                   Mock(OperationContext))
 
     when:
@@ -129,7 +129,7 @@ class ParameterDataTypeReaderSpec extends DocumentationContextSpec {
           new ResolvedMethodParameter(0, "", [Mock(RequestParam)], new TypeResolver().resolve(Map, String, String))
       def namingStrategy = new DefaultGenericTypeNamingStrategy()
       ParameterContext parameterContext =
-          new ParameterContext(resolvedMethodParameter, new ParameterBuilder(), context(), namingStrategy,
+          new ParameterContext(resolvedMethodParameter, new ParameterBuilder(), documentationContext(), namingStrategy,
               Mock(OperationContext))
 
     when:
@@ -148,7 +148,7 @@ class ParameterDataTypeReaderSpec extends DocumentationContextSpec {
           new ResolvedMethodParameter(0, "", [], new TypeResolver().resolve(List, String))
       def namingStrategy = new DefaultGenericTypeNamingStrategy()
       ParameterContext parameterContext =
-              new ParameterContext(resolvedMethodParameter, new ParameterBuilder(), context(), namingStrategy,
+              new ParameterContext(resolvedMethodParameter, new ParameterBuilder(), documentationContext(), namingStrategy,
                   Mock(OperationContext))
 
     when:

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/parameter/ParameterMultiplesReaderSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/parameter/ParameterMultiplesReaderSpec.groovy
@@ -55,7 +55,7 @@ class ParameterMultiplesReaderSpec extends DocumentationContextSpec {
       ParameterContext parameterContext = new ParameterContext(
           resolvedMethodParameter,
           new ParameterBuilder(),
-          context(),
+          documentationContext(),
           Mock(GenericTypeNamingStrategy),
           Mock(OperationContext))
 

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/parameter/ParameterReaderSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/parameter/ParameterReaderSpec.groovy
@@ -52,7 +52,7 @@ class ParameterReaderSpec extends DocumentationContextSpec {
       def resolvedMethodParameter =
           new ResolvedMethodParameter(0, "", [apiParamAnnotation, reqParamAnnot], Mock(ResolvedType))
       ParameterContext parameterContext = new ParameterContext(resolvedMethodParameter, new ParameterBuilder(),
-          context(), Mock(GenericTypeNamingStrategy), Mock(OperationContext))
+          documentationContext(), Mock(GenericTypeNamingStrategy), Mock(OperationContext))
     when:
       parameterPlugin.apply(parameterContext)
 
@@ -74,7 +74,7 @@ class ParameterReaderSpec extends DocumentationContextSpec {
       def resolvedMethodParameter  = new ResolvedMethodParameter("someName", method.getMethodParameters().first(),
           resolvedBeanType)
       ParameterContext parameterContext = new ParameterContext(resolvedMethodParameter, new ParameterBuilder(),
-        context(), Mock(GenericTypeNamingStrategy), Mock(OperationContext))
+        documentationContext(), Mock(GenericTypeNamingStrategy), Mock(OperationContext))
     when:
       parameterPlugin.apply(parameterContext)
 

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/parameter/ParameterRequiredReaderSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/parameter/ParameterRequiredReaderSpec.groovy
@@ -67,7 +67,7 @@ class ParameterRequiredReaderSpec extends DocumentationContextSpec implements Pa
         new ParameterContext(
             resolvedMethodParameter,
             new ParameterBuilder(),
-            context(),
+            documentationContext(),
             Mock(GenericTypeNamingStrategy),
             operation)
 
@@ -126,7 +126,7 @@ class ParameterRequiredReaderSpec extends DocumentationContextSpec implements Pa
     ParameterContext parameterContext = new ParameterContext(
         resolvedMethodParameter,
         new ParameterBuilder(),
-        context(),
+        documentationContext(),
         Mock(GenericTypeNamingStrategy),
         Mock(OperationContext))
 

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/parameter/ParameterTypeReaderSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/readers/parameter/ParameterTypeReaderSpec.groovy
@@ -56,7 +56,7 @@ class ParameterTypeReaderSpec extends DocumentationContextSpec {
     operationContext.consumes() >> consumes
     operationContext.httpMethod() >> httpMethod
     ParameterContext parameterContext = new ParameterContext(resolvedMethodParameter, new ParameterBuilder(),
-        context(), Mock(GenericTypeNamingStrategy), operationContext)
+        documentationContext(), Mock(GenericTypeNamingStrategy), operationContext)
 
     when:
     def operationCommand = new ParameterTypeReader()

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/scanners/ApiDescriptionReaderSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/scanners/ApiDescriptionReaderSpec.groovy
@@ -51,7 +51,7 @@ class ApiDescriptionReaderSpec extends DocumentationContextSpec {
         [patternsRequestCondition: patternsRequestCondition('/somePath/{businessId}', '/somePath/{businessId:\\d+}')]
     )
     RequestMappingContext mappingContext = new RequestMappingContext(
-        context(),
+        documentationContext(),
         new WebMvcRequestHandler(
             new HandlerMethodResolver(new TypeResolver()),
             requestMappingInfo,
@@ -94,7 +94,7 @@ class ApiDescriptionReaderSpec extends DocumentationContextSpec {
         "/doesNotMatterForThisTest",
         [patternsRequestCondition: patternsRequestCondition('/somePath/{businessId}')])
     RequestMappingContext mappingContext = new RequestMappingContext(
-        context(),
+        documentationContext(),
         new WebMvcRequestHandler(
             new HandlerMethodResolver(new TypeResolver()),
             requestMappingInfo,

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/scanners/ApiListingReferenceScannerSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/scanners/ApiListingReferenceScannerSpec.groovy
@@ -67,7 +67,7 @@ class ApiListingReferenceScannerSpec extends DocumentationContextSpec {
               .configure(contextBuilder)
 
     then:
-      context().groupName == "default"
+      documentationContext().groupName == "default"
     where:
       handlerMappings              | resourceGroupingStrategy     | groupName | message
       [requestMappingInfo("path")] | null                         | null      | "resourceGroupingStrategy is required"
@@ -95,7 +95,7 @@ class ApiListingReferenceScannerSpec extends DocumentationContextSpec {
       contextBuilder.withResourceGroupingStrategy(new SpringGroupingStrategy())
       plugin.configure(contextBuilder)
     and:
-      ApiListingReferenceScanResult result = sut.scan(context())
+      ApiListingReferenceScanResult result = sut.scan(documentationContext())
 
     then:
       result.resourceGroupRequestMappings.size() == 2
@@ -119,7 +119,7 @@ class ApiListingReferenceScannerSpec extends DocumentationContextSpec {
       contextBuilder.requestHandlers(requestHandlers)
       plugin.configure(contextBuilder)
     and:
-      ApiListingReferenceScanResult result = sut.scan(context())
+      ApiListingReferenceScanResult result = sut.scan(documentationContext())
 
     then:
       result.resourceGroupRequestMappings.size() == 2

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/scanners/ApiListingScannerSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/scanners/ApiListingScannerSpec.groovy
@@ -82,7 +82,7 @@ class ApiListingScannerSpec extends DocumentationContextSpec {
 
   def "Should create an api listing for a single resource grouping "() {
     given:
-    def context = context()
+    def context = documentationContext()
     RequestMappingContext requestMappingContext = requestMapping(context)
     listingContext = listingContext(requestMappingContext, context)
 
@@ -102,7 +102,7 @@ class ApiListingScannerSpec extends DocumentationContextSpec {
 
   def "should assign global authorizations"() {
     given:
-    def context = context()
+    def context = documentationContext()
     def requestMappingContext = requestMapping(context)
     listingContext = listingContext(requestMappingContext, context)
 
@@ -117,7 +117,7 @@ class ApiListingScannerSpec extends DocumentationContextSpec {
   def "Should create an api listing for an api description with no backing controller"() {
     given:
     plugin.groupName("different-group")
-    def context = context()
+    def context = documentationContext()
     Map<ResourceGroup, List<RequestMappingContext>> resourceGroupRequestMappings = newHashMap()
     listingContext = new ApiListingScanningContext(context, resourceGroupRequestMappings)
 
@@ -149,7 +149,7 @@ class ApiListingScannerSpec extends DocumentationContextSpec {
   def "Should not mix existing apis with apis with no backing controller"() {
     given:
     plugin.groupName("different-group")
-    def context = context()
+    def context = documentationContext()
     def sut = new ApiListingScanner(
         apiDescriptionReader,
         apiModelReader,
@@ -187,7 +187,7 @@ class ApiListingScannerSpec extends DocumentationContextSpec {
 
   def "should assign resource form @RequestMapping annotation"() {
     given:
-    def context = context()
+    def context = documentationContext()
     def requestMappingContext = requestMapping(context, "dummyMethod")
     def resourceGroupRequestMappings = newHashMap()
     resourceGroupRequestMappings.put(

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/scanners/CachingOperationReaderSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/scanners/CachingOperationReaderSpec.groovy
@@ -36,7 +36,7 @@ class CachingOperationReaderSpec extends DocumentationContextSpec {
     RequestMappingInfo requestMappingInfo = requestMappingInfo('/anyPath')
     def methodResolver = new HandlerMethodResolver(new TypeResolver())
 
-    def context = context()
+    def context = documentationContext()
     def requestMappingContext = new RequestMappingContext(
         context,
         new WebMvcRequestHandler(methodResolver,

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/scanners/SwaggerApiDocumentationScannerSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/scanners/SwaggerApiDocumentationScannerSpec.groovy
@@ -49,7 +49,7 @@ class SwaggerApiDocumentationScannerSpec extends DocumentationContextSpec {
     listingScanner.scan(_) >> LinkedListMultimap.create()
 
     and:
-    Documentation scanned = swaggerApiResourceListing.scan(context())
+    Documentation scanned = swaggerApiResourceListing.scan(documentationContext())
 
     then: "I should should have the correct defaults"
     ResourceListing resourceListing = scanned.resourceListing
@@ -80,7 +80,7 @@ class SwaggerApiDocumentationScannerSpec extends DocumentationContextSpec {
     listingScanner.scan(_) >> LinkedListMultimap.create()
 
     and:
-    Documentation scanned = swaggerApiResourceListing.scan(context())
+    Documentation scanned = swaggerApiResourceListing.scan(documentationContext())
 
     then:
     ApiInfo actual = scanned.getResourceListing().getInfo()
@@ -109,7 +109,7 @@ class SwaggerApiDocumentationScannerSpec extends DocumentationContextSpec {
     listingScanner.scan(_) >> LinkedListMultimap.create()
 
     and:
-    Documentation scanned = swaggerApiResourceListing.scan(context())
+    Documentation scanned = swaggerApiResourceListing.scan(documentationContext())
 
     then:
     ResourceListing resourceListing = scanned.resourceListing
@@ -132,7 +132,7 @@ class SwaggerApiDocumentationScannerSpec extends DocumentationContextSpec {
         .pathProvider(pathProvider)
         .configure(contextBuilder)
 
-    RequestMappingContext requestMappingContext = new RequestMappingContext(context(),
+    RequestMappingContext requestMappingContext = new RequestMappingContext(documentationContext(),
         new WebMvcRequestHandler(
             new HandlerMethodResolver(new TypeResolver()),
             requestMappingInfo("somePath/"),
@@ -148,7 +148,7 @@ class SwaggerApiDocumentationScannerSpec extends DocumentationContextSpec {
     listingScanner.scan(_) >> LinkedListMultimap.create()
 
     and:
-    Documentation scanned = swaggerApiResourceListing.scan(context())
+    Documentation scanned = swaggerApiResourceListing.scan(documentationContext())
     scanned.resourceListing != null
 
     then:
@@ -181,7 +181,7 @@ class SwaggerApiDocumentationScannerSpec extends DocumentationContextSpec {
     listingScanner.scan(_) >> listingsMap
 
     when:
-    Documentation scanned = swaggerApiResourceListing.scan(context())
+    Documentation scanned = swaggerApiResourceListing.scan(documentationContext())
 
     then:
       scanned.resourceListing.apis.size() == 1

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/operation/OperationAuthReaderSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/operation/OperationAuthReaderSpec.groovy
@@ -38,7 +38,7 @@ class OperationAuthReaderSpec extends DocumentationContextSpec {
   def "should read from annotations"() {
     given:
     OperationContext operationContext =
-        operationContext(context(), dummyHandlerMethod('methodWithAuth'))
+        operationContext(documentationContext(), dummyHandlerMethod('methodWithAuth'))
 
     when:
       sut.apply(operationContext)
@@ -63,7 +63,7 @@ class OperationAuthReaderSpec extends DocumentationContextSpec {
               .build()
       plugin.securityContexts(newArrayList(securityContext))
       OperationContext operationContext =
-        operationContext(context(), dummyHandlerMethod())
+        operationContext(documentationContext(), dummyHandlerMethod())
 
     when:
       sut.apply(operationContext)
@@ -84,7 +84,7 @@ class OperationAuthReaderSpec extends DocumentationContextSpec {
               .build()
       plugin.securityContexts(newArrayList(securityContext))
       OperationContext operationContext =
-        operationContext(context(), dummyHandlerMethod('methodWithHttpGETMethod'))
+        operationContext(documentationContext(), dummyHandlerMethod('methodWithHttpGETMethod'))
 
     when:
       sut.apply(operationContext)

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/operation/OperationCommandReaderSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/operation/OperationCommandReaderSpec.groovy
@@ -38,7 +38,7 @@ class OperationCommandReaderSpec extends DocumentationContextSpec {
   def "should set various properties based on method name or swagger annotation"() {
     given:
       OperationContext operationContext =
-          operationContext(context(), handlerMethod, CURRENT_COUNT)
+          operationContext(documentationContext(), handlerMethod, CURRENT_COUNT)
 
     when:
       sut.apply(operationContext)

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/operation/OperationHttpMethodReaderSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/operation/OperationHttpMethodReaderSpec.groovy
@@ -32,7 +32,7 @@ class OperationHttpMethodReaderSpec extends DocumentationContextSpec {
 
     given:
       OperationContext operationContext =
-        operationContext(context(), handlerMethod)
+        operationContext(documentationContext(), handlerMethod)
 
       OperationHttpMethodReader sut = new OperationHttpMethodReader();
     when:

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/operation/OperationImplicitParamsReaderSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/operation/OperationImplicitParamsReaderSpec.groovy
@@ -38,7 +38,7 @@ class OperationImplicitParamsReaderSpec extends DocumentationContextSpec {
 
   def "Should add implicit parameters"() {
     given:
-    OperationContext operationContext = operationContext(context(), handlerMethod, 0)
+    OperationContext operationContext = operationContext(documentationContext(), handlerMethod, 0)
     def resolver = new TypeResolver()
     def enumTypeDeterminer = new JacksonEnumTypeDeterminer()
     def plugins = defaultWebPlugins()

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/operation/OperationNicknameIntoUniqueIdReaderSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/operation/OperationNicknameIntoUniqueIdReaderSpec.groovy
@@ -28,7 +28,7 @@ class OperationNicknameIntoUniqueIdReaderSpec extends DocumentationContextSpec {
   def "should set various unique operation id based on swagger annotation"() {
     given:
       OperationContext operationContext =
-        operationContext(context(), handlerMethod)
+        operationContext(documentationContext(), handlerMethod)
     and:
       def sut = new OperationNicknameIntoUniqueIdReader()
     when:

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/operation/OperationPositionReaderSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/operation/OperationPositionReaderSpec.groovy
@@ -29,7 +29,7 @@ class OperationPositionReaderSpec extends DocumentationContextSpec {
   def "should have correct api position using swagger reader"() {
     given:
       OperationContext operationContext =
-        operationContext(context(), handlerMethod, contextCount)
+        operationContext(documentationContext(), handlerMethod, contextCount)
       OperationPositionReader operationPositionReader = new OperationPositionReader();
 
     when:

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/operation/SwaggerMediaTypeReaderSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/operation/SwaggerMediaTypeReaderSpec.groovy
@@ -41,7 +41,7 @@ class SwaggerMediaTypeReaderSpec extends DocumentationContextSpec {
             ]
         )
     OperationContext operationContext =
-        operationContext(context(), handlerMethod, 0, requestMappingInfo, RequestMethod.POST)
+        operationContext(documentationContext(), handlerMethod, 0, requestMappingInfo, RequestMethod.POST)
     operationContext.operationBuilder().method(HttpMethod.POST)
 
     when:

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/operation/SwaggerOperationModelsProviderSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/operation/SwaggerOperationModelsProviderSpec.groovy
@@ -35,7 +35,7 @@ class SwaggerOperationModelsProviderSpec extends DocumentationContextSpec {
           [patternsRequestCondition: patternsRequestCondition('/somePath/{businessId}', '/somePath/{businessId:\\d+}')]
       )
       RequestMappingContext requestContext = new RequestMappingContext(
-          context(),
+          documentationContext(),
           new WebMvcRequestHandler(methodResolver,
               requestMappingInfo,
               dummyHandlerMethod(operationName)))

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/operation/SwaggerOperationResponseClassReaderSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/operation/SwaggerOperationResponseClassReaderSpec.groovy
@@ -45,7 +45,7 @@ class SwaggerOperationResponseClassReaderSpec extends DocumentationContextSpec {
         modelNameRegistry,
         new JacksonEnumTypeDeterminer())
     OperationContext operationContext =
-        operationContext(context(), handlerMethod)
+        operationContext(documentationContext(), handlerMethod)
 
     SwaggerOperationResponseClassReader sut =
         new SwaggerOperationResponseClassReader(new TypeResolver(), typeNameExtractor)

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/operation/SwaggerOperationTagsReaderSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/operation/SwaggerOperationTagsReaderSpec.groovy
@@ -29,7 +29,7 @@ class SwaggerOperationTagsReaderSpec extends DocumentationContextSpec {
   def "should have correct tags"() {
     given:
       OperationContext operationContext =
-        operationContext(context(), handlerMethod)
+        operationContext(documentationContext(), handlerMethod)
     and:
       SwaggerOperationTagsReader sut = new SwaggerOperationTagsReader(new DefaultTagsProvider())
 

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/operation/SwaggerResponseMessageReaderSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/operation/SwaggerResponseMessageReaderSpec.groovy
@@ -39,7 +39,7 @@ class SwaggerResponseMessageReaderSpec extends DocumentationContextSpec {
   def "ApiResponse annotation should override when using swagger reader"() {
     given:
     OperationContext operationContext =
-        operationContext(context(), dummyHandlerMethod('methodWithApiResponses'))
+        operationContext(documentationContext(), dummyHandlerMethod('methodWithApiResponses'))
 
     PluginRegistry<TypeNameProviderPlugin, DocumentationType> modelNameRegistry =
         OrderAwarePluginRegistry.create([new DefaultTypeNameProvider()])
@@ -70,7 +70,7 @@ class SwaggerResponseMessageReaderSpec extends DocumentationContextSpec {
   def "ApiOperation annotation should provide response"() {
     given:
     OperationContext operationContext =
-        operationContext(context(), dummyHandlerMethod('methodApiResponseClass'))
+        operationContext(documentationContext(), dummyHandlerMethod('methodApiResponseClass'))
 
     PluginRegistry<TypeNameProviderPlugin, DocumentationType> modelNameRegistry =
         OrderAwarePluginRegistry.create([new DefaultTypeNameProvider()])
@@ -102,7 +102,7 @@ class SwaggerResponseMessageReaderSpec extends DocumentationContextSpec {
   def "ApiOperation#responseHeaders and ApiResponse#responseHeader are merged for method #methodName"() {
     given:
     OperationContext operationContext =
-        operationContext(context(), handlerMethodIn(ResponseHeaderTestController, methodName))
+        operationContext(documentationContext(), handlerMethodIn(ResponseHeaderTestController, methodName))
 
     PluginRegistry<TypeNameProviderPlugin, DocumentationType> modelNameRegistry =
         OrderAwarePluginRegistry.create([new DefaultTypeNameProvider()])

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/operation/VendorExtensionsReaderSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/operation/VendorExtensionsReaderSpec.groovy
@@ -30,7 +30,7 @@ class VendorExtensionsReaderSpec extends DocumentationContextSpec {
   def "should read from annotations"() {
     given:
     OperationContext operationContext =
-        operationContext(context(), dummyHandlerMethod('methodWithExtensions'))
+        operationContext(documentationContext(), dummyHandlerMethod('methodWithExtensions'))
       VendorExtensionsReader sut = new VendorExtensionsReader()
     when:
       sut.apply(operationContext)

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/parameter/ApiParamParameterBuilderSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/parameter/ApiParamParameterBuilderSpec.groovy
@@ -53,7 +53,7 @@ class ApiParamParameterBuilderSpec extends DocumentationContextSpec implements A
     ParameterContext parameterContext = new ParameterContext(
         resolvedMethodParameter,
         new ParameterBuilder(),
-        context(),
+        documentationContext(),
         genericNamingStrategy,
         Mock(OperationContext))
 
@@ -86,7 +86,7 @@ class ApiParamParameterBuilderSpec extends DocumentationContextSpec implements A
         new ParameterContext(
             resolvedMethodParameter,
             new ParameterBuilder(),
-            context(),
+            documentationContext(),
             genericNamingStrategy,
             Mock(OperationContext))
 
@@ -115,7 +115,7 @@ class ApiParamParameterBuilderSpec extends DocumentationContextSpec implements A
     ParameterContext parameterContext = new ParameterContext(
         resolvedMethodParameter,
         new ParameterBuilder(),
-        context(),
+        documentationContext(),
         genericNamingStrategy,
         Mock(OperationContext))
 

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/parameter/ParameterMultiplesReaderSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/parameter/ParameterMultiplesReaderSpec.groovy
@@ -51,7 +51,7 @@ class ParameterMultiplesReaderSpec extends DocumentationContextSpec implements A
     ResolvedMethodParameter resolvedMethodParameter = new ResolvedMethodParameter("", methodParameter, resolvedType)
     def genericNamingStrategy = new DefaultGenericTypeNamingStrategy()
     ParameterContext parameterContext = new ParameterContext(resolvedMethodParameter, new ParameterBuilder(),
-        context(), genericNamingStrategy, Mock(OperationContext))
+        documentationContext(), genericNamingStrategy, Mock(OperationContext))
 
     when:
     def operationCommand = stubbedParamBuilder();

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/parameter/ParameterNameReaderSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/parameter/ParameterNameReaderSpec.groovy
@@ -58,7 +58,7 @@ class ParameterNameReaderSpec extends DocumentationContextSpec implements ApiPar
     ParameterContext parameterContext = new ParameterContext(
         resolvedMethodParameter,
         new ParameterBuilder(),
-        context(),
+        documentationContext(),
         genericNamingStrategy,
         Mock(OperationContext))
     when:

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/parameter/ParameterReaderSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/parameter/ParameterReaderSpec.groovy
@@ -47,7 +47,7 @@ class ParameterReaderSpec extends DocumentationContextSpec implements ApiParamAn
         new ResolvedMethodParameter(0, "default", nonNullAnnotations, new TypeResolver().resolve(Object.class))
     def genericNamingStrategy = new DefaultGenericTypeNamingStrategy()
     ParameterContext parameterContext = new ParameterContext(resolvedMethodParameter, new ParameterBuilder(),
-        context(), genericNamingStrategy, Mock(OperationContext))
+        documentationContext(), genericNamingStrategy, Mock(OperationContext))
     def sut = stubbedParamBuilder()
 
     when:

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/parameter/ParameterRequiredReaderSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/parameter/ParameterRequiredReaderSpec.groovy
@@ -82,7 +82,7 @@ class ParameterRequiredReaderSpec extends DocumentationContextSpec implements Ap
     new ParameterContext(
         resolvedMethodParameter,
         new ParameterBuilder(),
-        context(),
+        documentationContext(),
         genericNamingStrategy,
         Mock(OperationContext))
   }

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/parameter/SwaggerExpandedParameterBuilderSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/parameter/SwaggerExpandedParameterBuilderSpec.groovy
@@ -52,6 +52,7 @@ class SwaggerExpandedParameterBuilderSpec extends Specification {
     ParameterExpansionContext context = new ParameterExpansionContext(
         "Test",
         "",
+        "",
         new ModelAttributeParameterMetadataAccessor(
             [field.rawMember],
             field.type,

--- a/springfox-swagger1/src/test/groovy/springfox/documentation/spring/web/scanners/ApiDocumentationScannerSpec.groovy
+++ b/springfox-swagger1/src/test/groovy/springfox/documentation/spring/web/scanners/ApiDocumentationScannerSpec.groovy
@@ -45,7 +45,7 @@ class ApiDocumentationScannerSpec extends DocumentationContextSpec {
     listingReferenceScanner.scan(_) >> new ApiListingReferenceScanResult(newHashMap())
     listingScanner.scan(_) >> LinkedListMultimap.create()
     and:
-    Documentation scanned = docScanner.scan(context())
+    Documentation scanned = docScanner.scan(documentationContext())
 
     then: "I should should have the correct defaults"
     ResourceListing resourceListing = scanned.resourceListing
@@ -74,7 +74,7 @@ class ApiDocumentationScannerSpec extends DocumentationContextSpec {
     listingReferenceScanner.scan(_) >> new ApiListingReferenceScanResult(newHashMap())
     listingScanner.scan(_) >> LinkedListMultimap.create()
     and:
-    Documentation scanned = docScanner.scan(context())
+    Documentation scanned = docScanner.scan(documentationContext())
     then:
     ApiInfo actual = scanned.getResourceListing().getInfo()
     actual.getTitle() == expected.getTitle()
@@ -100,7 +100,7 @@ class ApiDocumentationScannerSpec extends DocumentationContextSpec {
     listingReferenceScanner.scan(_) >> new ApiListingReferenceScanResult(newHashMap())
     listingScanner.scan(_) >> LinkedListMultimap.create()
     and:
-    Documentation scanned = docScanner.scan(context())
+    Documentation scanned = docScanner.scan(documentationContext())
     then:
     ResourceListing resourceListing = scanned.resourceListing
     def authorizationTypes = resourceListing.getSecuritySchemes()
@@ -137,7 +137,7 @@ class ApiDocumentationScannerSpec extends DocumentationContextSpec {
 
 
     when:
-    Documentation scanned = docScanner.scan(context())
+    Documentation scanned = docScanner.scan(documentationContext())
 
     then:
     def firstResouceListingApi = scanned.resourceListing.apis.get(0)

--- a/springfox-swagger1/src/test/groovy/springfox/documentation/spring/web/scanners/SwaggerApiListingReferenceScannerSpec.groovy
+++ b/springfox-swagger1/src/test/groovy/springfox/documentation/spring/web/scanners/SwaggerApiListingReferenceScannerSpec.groovy
@@ -70,7 +70,7 @@ class SwaggerApiListingReferenceScannerSpec extends DocumentationContextSpec {
               .configure(contextBuilder)
 
     then:
-      context().groupName == "default"
+      documentationContext().groupName == "default"
     where:
       handlerMappings              | resourceGroupingStrategy                   | groupName | message
       [requestMappingInfo("path")] | null                                       | null      | "resourceGroupingStrategy is required"
@@ -91,7 +91,7 @@ class SwaggerApiListingReferenceScannerSpec extends DocumentationContextSpec {
       contextBuilder.requestHandlers(requestHandlers)
       plugin.groupName('groupName').configure(contextBuilder)
 
-      ApiListingReferenceScanResult result = sut.scan(context())
+      ApiListingReferenceScanResult result = sut.scan(documentationContext())
 
     then:
       result.resourceGroupRequestMappings.keySet().size() == 1
@@ -119,7 +119,7 @@ class SwaggerApiListingReferenceScannerSpec extends DocumentationContextSpec {
       contextBuilder.withResourceGroupingStrategy(new SpringGroupingStrategy())
       plugin.configure(contextBuilder)
     and:
-      ApiListingReferenceScanResult result= sut.scan(context())
+      ApiListingReferenceScanResult result= sut.scan(documentationContext())
     then:
       result.resourceGroupRequestMappings.size() == 2
       result.resourceGroupRequestMappings[new ResourceGroup("dummy-controller", DummyController)].size() == 1
@@ -141,7 +141,7 @@ class SwaggerApiListingReferenceScannerSpec extends DocumentationContextSpec {
       contextBuilder.requestHandlers(requestHandlers)
       plugin.configure(contextBuilder)
     and:
-      ApiListingReferenceScanResult result= sut.scan(context())
+      ApiListingReferenceScanResult result= sut.scan(documentationContext())
 
     then:
       result.resourceGroupRequestMappings.size() == 2

--- a/springfox-swagger1/src/test/groovy/springfox/documentation/spring/web/scanners/SwaggerApiModelReaderSpec.groovy
+++ b/springfox-swagger1/src/test/groovy/springfox/documentation/spring/web/scanners/SwaggerApiModelReaderSpec.groovy
@@ -107,7 +107,7 @@ class SwaggerApiModelReaderSpec extends DocumentationContextSpec {
 
   def context(HandlerMethod handlerMethod) {
     return new RequestMappingContext(
-        context(),
+        documentationContext(),
         new WebMvcRequestHandler(methodResolver,
             requestMappingInfo('/somePath'),
             handlerMethod))
@@ -121,7 +121,7 @@ class SwaggerApiModelReaderSpec extends DocumentationContextSpec {
         DummyModels.AnnotatedBusinessModel.class
     )
     RequestMappingContext context = new RequestMappingContext(
-        context(),
+        documentationContext(),
         new WebMvcRequestHandler(methodResolver,
             requestMappingInfo('/somePath'),
             handlerMethod))
@@ -169,7 +169,7 @@ class SwaggerApiModelReaderSpec extends DocumentationContextSpec {
         DummyModels.AnnotatedBusinessModel
     )
     RequestMappingContext context = new RequestMappingContext(
-        context(),
+        documentationContext(),
         new WebMvcRequestHandler(
             methodResolver,
             requestMappingInfo('/somePath'),

--- a/springfox-swagger1/src/test/groovy/springfox/documentation/swagger1/integration/DocketSpec.groovy
+++ b/springfox-swagger1/src/test/groovy/springfox/documentation/swagger1/integration/DocketSpec.groovy
@@ -135,7 +135,7 @@ class DocketSpec extends DocumentationContextSpec {
               .alternateTypeRules(rule)
               .configure(contextBuilder)
     expect:
-      context().alternateTypeProvider.rules.contains(rule)
+      documentationContext().alternateTypeProvider.rules.contains(rule)
   }
 
   def "Model substitution registers new rules"() {
@@ -162,7 +162,7 @@ class DocketSpec extends DocumentationContextSpec {
       plugin."$builderMethod"(object)
 
     then:
-      context()."$property" == object
+      documentationContext()."$property" == object
 
     where:
       builderMethod     | object                                         | property

--- a/springfox-swagger1/src/test/groovy/springfox/documentation/swagger1/readers/parameter/OperationParameterReaderSpec.groovy
+++ b/springfox-swagger1/src/test/groovy/springfox/documentation/swagger1/readers/parameter/OperationParameterReaderSpec.groovy
@@ -89,7 +89,7 @@ class OperationParameterReaderSpec extends DocumentationContextSpec {
   def "Should ignore ignorables"() {
     given:
     OperationContext operationContext =
-        operationContext(context(), handlerMethod)
+        operationContext(documentationContext(), handlerMethod)
 
     when:
     sut.apply(operationContext)
@@ -111,7 +111,7 @@ class OperationParameterReaderSpec extends DocumentationContextSpec {
     HandlerMethod handlerMethod = dummyHandlerMethod('methodWithSinglePathVariable', String.class)
 
     OperationContext operationContext =
-        operationContext(context(), handlerMethod)
+        operationContext(documentationContext(), handlerMethod)
 
 
     when:
@@ -134,7 +134,7 @@ class OperationParameterReaderSpec extends DocumentationContextSpec {
   def "Should expand ModelAttribute request params"() {
     given:
     OperationContext operationContext =
-        operationContext(context(), dummyHandlerMethod('methodWithModelAttribute', Example.class))
+        operationContext(documentationContext(), dummyHandlerMethod('methodWithModelAttribute', Example.class))
 
     when:
     sut.apply(operationContext)
@@ -186,7 +186,7 @@ class OperationParameterReaderSpec extends DocumentationContextSpec {
     OperationContext operationContext = new OperationContext(
         new OperationBuilder(new CachingOperationNameGenerator()),
         RequestMethod.GET,
-        new RequestMappingContext(context(),
+        new RequestMappingContext(documentationContext(),
             new WebMvcRequestHandler(methodResolver,
                 requestMappingInfo("/somePath"),
                 dummyHandlerMethod('methodWithTreeishModelAttribute', Treeish.class))), 0)
@@ -204,7 +204,7 @@ class OperationParameterReaderSpec extends DocumentationContextSpec {
   def "Should not expand unannotated request params"() {
     given:
     OperationContext operationContext =
-        operationContext(context(), handlerMethod)
+        operationContext(documentationContext(), handlerMethod)
 
     when:
     sut.apply(operationContext)

--- a/springfox-swagger1/src/test/groovy/springfox/documentation/swagger1/readers/parameter/ParameterNameReaderSpec.groovy
+++ b/springfox-swagger1/src/test/groovy/springfox/documentation/swagger1/readers/parameter/ParameterNameReaderSpec.groovy
@@ -51,9 +51,9 @@ class ParameterNameReaderSpec extends DocumentationContextSpec {
       def genericNamingStrategy = new DefaultGenericTypeNamingStrategy()
     and: "mocks are setup"
       operationContext.consumes() >> []
-    and: "context is setup"
+    and: "documentationContext is setup"
       ParameterContext parameterContext = new ParameterContext(resolvedMethodParameter, new ParameterBuilder(),
-          context(), genericNamingStrategy, operationContext)
+          documentationContext(), genericNamingStrategy, operationContext)
     when:
       def sut = nameReader(apiParam)
       sut.apply(parameterContext)

--- a/springfox-swagger1/src/test/groovy/springfox/documentation/swagger1/web/Swagger1ControllerSpec.groovy
+++ b/springfox-swagger1/src/test/groovy/springfox/documentation/swagger1/web/Swagger1ControllerSpec.groovy
@@ -73,7 +73,7 @@ class Swagger1ControllerSpec extends DocumentationContextSpec
   def "should return #expectedStatus.value() for #group"() {
     given:
       ApiDocumentationScanner scanner = new ApiDocumentationScanner(listingReferenceScanner, listingScanner)
-      sut.documentationCache.addDocumentation(scanner.scan(context()))
+      sut.documentationCache.addDocumentation(scanner.scan(documentationContext()))
     when:
       def result = sut.getResourceListing(group)
     then:

--- a/springfox-swagger1/src/test/groovy/springfox/documentation/swagger1/web/SwaggerApiDescriptionReaderSpec.groovy
+++ b/springfox-swagger1/src/test/groovy/springfox/documentation/swagger1/web/SwaggerApiDescriptionReaderSpec.groovy
@@ -52,7 +52,7 @@ class SwaggerApiDescriptionReaderSpec extends DocumentationContextSpec {
                 [patternsRequestCondition: patternsRequestCondition('/somePath/{businessId}', '/somePath/{businessId:\\d+}')]
         )
         RequestMappingContext mappingContext = new RequestMappingContext(
-            context(),
+            documentationContext(),
             new WebMvcRequestHandler(
                 new HandlerMethodResolver(new TypeResolver()),
                 requestMappingInfo,

--- a/springfox-swagger2/src/test/groovy/springfox/documentation/swagger2/web/Swagger2ControllerSpec.groovy
+++ b/springfox-swagger2/src/test/groovy/springfox/documentation/swagger2/web/Swagger2ControllerSpec.groovy
@@ -66,7 +66,7 @@ class Swagger2ControllerSpec extends DocumentationContextSpec
     given:
       ApiDocumentationScanner scanner =
           new ApiDocumentationScanner(listingReferenceScanner, listingScanner)
-      controller.documentationCache.addDocumentation(scanner.scan(context()))
+      controller.documentationCache.addDocumentation(scanner.scan(documentationContext()))
     when:
       def result = controller.getDocumentation(group, request)
     then:
@@ -90,7 +90,7 @@ class Swagger2ControllerSpec extends DocumentationContextSpec
 
       ApiDocumentationScanner swaggerApiResourceListing =
           new ApiDocumentationScanner(listingReferenceScanner, listingScanner)
-      controller.documentationCache.addDocumentation(swaggerApiResourceListing.scan(context()))
+      controller.documentationCache.addDocumentation(swaggerApiResourceListing.scan(documentationContext()))
     when:
       def result = jsonBodyResponse(controller.getDocumentation(null, req).getBody().value())
 
@@ -129,7 +129,7 @@ class Swagger2ControllerSpec extends DocumentationContextSpec
 
       ApiDocumentationScanner swaggerApiResourceListing =
           new ApiDocumentationScanner(listingReferenceScanner, listingScanner)
-      controller.documentationCache.addDocumentation(swaggerApiResourceListing.scan(context()))
+      controller.documentationCache.addDocumentation(swaggerApiResourceListing.scan(documentationContext()))
     when:
       def result = jsonBodyResponse(controller.getDocumentation(null, req).getBody().value())
 
@@ -147,7 +147,7 @@ class Swagger2ControllerSpec extends DocumentationContextSpec
     given:
       ApiDocumentationScanner swaggerApiResourceListing =
         new ApiDocumentationScanner(listingReferenceScanner, listingScanner)
-      controller.documentationCache.addDocumentation(swaggerApiResourceListing.scan(context()))
+      controller.documentationCache.addDocumentation(swaggerApiResourceListing.scan(documentationContext()))
     when:
       def result = controller.getDocumentation(null, request)
     and:


### PR DESCRIPTION
**What's this PR do/fix?**
This PR attempts to resolve #2376 by using the media type to determine the parameter type when expanding.

**Are there unit tests? If not how should this be manually tested?**
The intentional change was made to `OperationParameterReaderSpec.groovy`.  I split the "Should expand ModelAttribute request params" test into two.  One for multipart, one for non-multipart.  I aimed to keep any other test changes to a minimum.

**Any background context you want to provide?**
N/a

**What are the relevant issues?**
#2376