### PR TITLE
Remove output related to fixed issue (#1244) #2428

### DIFF
--- a/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/parameter/MinMaxAnnotationPlugin.java
+++ b/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/parameter/MinMaxAnnotationPlugin.java
@@ -52,11 +52,6 @@ public class MinMaxAnnotationPlugin implements ParameterBuilderPlugin {
       AllowableRangeValues values = allowableRange(min, max);
       LOG.debug("adding allowable Values: " + values.getMin() + " - " + values.getMax());
       context.parameterBuilder().allowableValues(values);
-
-      // TODO Additionally show @Min/@Max in the description until
-      // https://github.com/springfox/springfox/issues/1244 gets fixed
-      context.parameterBuilder()
-          .description(String.format("@Min: %s - @Max: %s (until #1244 gets fixed)", values.getMin(), values.getMax()));
     }
   }
 

--- a/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/parameter/SizeAnnotationPlugin.java
+++ b/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/parameter/SizeAnnotationPlugin.java
@@ -54,14 +54,6 @@ public class SizeAnnotationPlugin implements ParameterBuilderPlugin {
       AllowableRangeValues values = stringLengthRange(size.get());
       LOG.debug("Adding allowable Values @Size: {} - {}", values.getMin(), values.getMax());
       context.parameterBuilder().allowableValues(values);
-
-      // TODO Additionally show @Size in the description until https://github.com/springfox/springfox/issues/1244
-      // gets fixed
-      context.parameterBuilder()
-          .description(
-              String.format("@Size: %s - %s (until #1244 gets fixed)",
-                  values.getMin(),
-                  values.getMax()));
     }
   }
 }


### PR DESCRIPTION
I noticed some descriptions in my documentation like `@Size: Min - Max (until #1244 gets fixed)`. Looks like that was fixed back in 2.5, and  I see the correct "minimum" and "maximum" values for all of them, so I opened #2428 and got rid of the generated message.