### PR TITLE
Remove the default sort of dockets shown in the home page

### DIFF
--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/InMemorySwaggerResourcesProvider.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/InMemorySwaggerResourcesProvider.java
@@ -27,8 +27,7 @@ import springfox.documentation.service.Documentation;
 import springfox.documentation.spring.web.DocumentationCache;
 import springfox.documentation.spring.web.plugins.Docket;
 
-import java.util.ArrayList;
-import java.util.Collections;
+import java.util.ArrayList; 
 import java.util.List;
 import java.util.Map;
 
@@ -75,7 +74,7 @@ public class InMemorySwaggerResourcesProvider implements SwaggerResourcesProvide
         resources.add(swaggerResource);
       }
     }
-    Collections.sort(resources);
+    //Collections.sort(resources);
     return resources;
   }
 


### PR DESCRIPTION
This is just a modification with just two slashes, but it means a lot. It fits a design principle that "do not modify something behind users". We known it intends to sort automatically for users. However it will confuse the user due to that the final order of dockets are different from the order specified by user. 
For example, the user defines three dockets with following order:
```
@Bean Docket1().....
@Bean Docket2().....
@Bean Docket3().....
```
But maybe the order shown in the home page become something below:
```
Docket3
Docket1
Docket2
```
This is confusing.
The best solution is removing this line of codes. Let the users decide the order by which dockets are shown.

