### PR TITLE
Remove replaceAll with trim

### DIFF
--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/schema/ApiModelProperties.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/schema/ApiModelProperties.java
@@ -64,7 +64,7 @@ public final class ApiModelProperties {
 
   public static AllowableValues allowableValueFromString(String allowableValueString) {
     AllowableValues allowableValues = new AllowableListValues(Lists.<String>newArrayList(), "LIST");
-    String trimmed = allowableValueString.trim().replaceAll(" ", "");
+    String trimmed = allowableValueString.trim();
     Matcher matcher = RANGE_PATTERN.matcher(trimmed);
     if (matcher.matches()) {
       if (matcher.groupCount() != 4) {


### PR DESCRIPTION
#### What's this PR do/fix?
Adds support for spaces in allowable Fields for 2.8.0 

Specifically Adds changes from 2.6.0 to 2.8.0 https://github.com/springfox/springfox/commit/fcf4a036fcfed4fea9e7859985af4bb5bfdf3682

We don't need both changes from #1211 since line 80 does the following `Iterable<String> split = Splitter.on(',').trimResults().omitEmptyStrings().split(trimmed);`

#### Are there unit tests? If not how should this be manually tested?
There were none prior

#### Any background context you want to provide?
See #2446 
#### What are the relevant issues?
#2446 
