### PR TITLE
#1570 Add examples support

### DIFF
--- a/springfox-core/src/main/java/springfox/documentation/builders/ResponseMessageBuilder.java
+++ b/springfox-core/src/main/java/springfox/documentation/builders/ResponseMessageBuilder.java
@@ -19,6 +19,7 @@
 
 package springfox.documentation.builders;
 
+import springfox.documentation.schema.Example;
 import springfox.documentation.schema.ModelReference;
 import springfox.documentation.service.Header;
 import springfox.documentation.service.ResponseMessage;
@@ -35,6 +36,7 @@ public class ResponseMessageBuilder {
   private int code;
   private String message;
   private ModelReference responseModel;
+  private List<Example> examples = newArrayList();
   private Map<String, Header> headers = newTreeMap();
   private List<VendorExtension> vendorExtensions = newArrayList();
 
@@ -68,6 +70,18 @@ public class ResponseMessageBuilder {
    */
   public ResponseMessageBuilder responseModel(ModelReference responseModel) {
     this.responseModel = defaultIfAbsent(responseModel, this.responseModel);
+    return this;
+  }
+
+  /**
+   * Updates the response examples
+   *
+   * @param examples response examples
+   * @return this
+   * @since 2.9.4
+   */
+  public ResponseMessageBuilder examples(List<Example> examples) {
+    this.examples.addAll(nullToEmptyList(examples));
     return this;
   }
 
@@ -120,6 +134,6 @@ public class ResponseMessageBuilder {
   }
 
   public ResponseMessage build() {
-    return new ResponseMessage(code, message, responseModel, headers, vendorExtensions);
+    return new ResponseMessage(code, message, responseModel, examples, headers, vendorExtensions);
   }
 }

--- a/springfox-core/src/main/java/springfox/documentation/service/ResponseMessage.java
+++ b/springfox-core/src/main/java/springfox/documentation/service/ResponseMessage.java
@@ -19,6 +19,7 @@
 
 package springfox.documentation.service;
 
+import springfox.documentation.schema.Example;
 import springfox.documentation.schema.ModelReference;
 
 import java.util.List;
@@ -28,6 +29,7 @@ public class ResponseMessage {
   private final int code;
   private final String message;
   private final ModelReference responseModel;
+  private final List<Example> examples;
   private final Map<String, Header> headers;
   private final List<VendorExtension> vendorExtensions;
 
@@ -35,11 +37,13 @@ public class ResponseMessage {
       int code,
       String message,
       ModelReference responseModel,
+      List<Example> examples,
       Map<String, Header> headers,
       List<VendorExtension> vendorExtensions) {
     this.code = code;
     this.message = message;
     this.responseModel = responseModel;
+    this.examples = examples;
     this.headers = headers;
     this.vendorExtensions = vendorExtensions;
   }
@@ -54,6 +58,10 @@ public class ResponseMessage {
 
   public ModelReference getResponseModel() {
     return responseModel;
+  }
+
+  public List<Example> getExamples() {
+    return examples;
   }
 
   public Map<String, Header> getHeaders() {

--- a/springfox-core/src/test/groovy/springfox/documentation/builders/ResponseMessageBuilderSpec.groovy
+++ b/springfox-core/src/test/groovy/springfox/documentation/builders/ResponseMessageBuilderSpec.groovy
@@ -20,9 +20,11 @@
 package springfox.documentation.builders
 
 import spock.lang.Specification
+import springfox.documentation.schema.Example
 import springfox.documentation.schema.ModelRef
 import springfox.documentation.service.Header
 
+import static com.google.common.collect.Lists.newArrayList
 import static com.google.common.collect.Maps.*
 
 class ResponseMessageBuilderSpec extends Specification {
@@ -37,10 +39,11 @@ class ResponseMessageBuilderSpec extends Specification {
       built."$property" == value
 
     where:
-      builderMethod     | value                  | property
-      'code'            | 200                    | 'code'
-      'message'         | 'OK'                   | 'message'
-      'responseModel'   | new ModelRef('String') | 'responseModel'
+      builderMethod   | value                                               | property
+      'code'          | 200                                                 | 'code'
+      'message'       | 'OK'                                                | 'message'
+      'responseModel' | new ModelRef('String')                              | 'responseModel'
+      'examples'      | newArrayList(new Example("mediaType", "value"))     | 'examples'
   }
 
   def "Setting builder properties to null values preserves existing values"() {
@@ -55,9 +58,10 @@ class ResponseMessageBuilderSpec extends Specification {
       built."$property" == value
 
     where:
-      builderMethod     | value                  | property
-      'message'         | 'OK'                   | 'message'
-      'responseModel'   | new ModelRef('String') | 'responseModel'
+      builderMethod     | value                  							| property
+      'message'         | 'OK'                   							| 'message'
+      'responseModel'   | new ModelRef('String') 							| 'responseModel'
+      'examples'      	| newArrayList(new Example("mediaType", "value"))   | 'examples'
   }
 
 

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/plugins/DocketSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/plugins/DocketSpec.groovy
@@ -77,6 +77,7 @@ class DocketSpec extends DocumentationContextSpec {
         OK.value(),
         "blah",
         null,
+        [],
         [] as Map,
         [])])
         .useDefaultResponseMessages(true)
@@ -113,6 +114,7 @@ class DocketSpec extends DocumentationContextSpec {
         OK.value(),
         "blah",
         null,
+        [],
         [] as Map,
         [])])
         .useDefaultResponseMessages(false)

--- a/springfox-spring-web/src/test/java/springfox/documentation/spring/web/dummy/ResponseExampleTestController.java
+++ b/springfox-spring-web/src/test/java/springfox/documentation/spring/web/dummy/ResponseExampleTestController.java
@@ -1,0 +1,67 @@
+/*
+ *
+ *  Copyright 2015 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package springfox.documentation.spring.web.dummy;
+
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Example;
+import io.swagger.annotations.ExampleProperty;
+
+public class ResponseExampleTestController {
+
+    @ApiOperation(value = "operationWithOneExample")
+    @ApiResponses(value = {@ApiResponse(code = 200, message = "")})
+    public void operationWithNoExamples() {
+    }
+
+    @ApiOperation(value = "operationWithOneExample")
+    @ApiResponses(value =
+            {
+                    @ApiResponse(code = 200, message = "", examples = @Example(
+                            value = @ExampleProperty(
+                                    value = "value", mediaType = "mediaType")))})
+    public void operationWithOneExample() {
+    }
+
+    @ApiOperation(value = "operationWithTwoExamples")
+    @ApiResponses(value =
+            {
+                    @ApiResponse(code = 200, message = "", examples = @Example(
+                            value = {
+                                    @ExampleProperty(
+                                            value = "value1", mediaType = "mediaType1"),
+                                    @ExampleProperty(
+                                            value = "value2", mediaType = "mediaType2")}))})
+    public void operationWithTwoExamples() {
+    }
+
+    @ApiOperation(value = "operationWithEmptyExample")
+    @ApiResponses(value =
+            {
+                    @ApiResponse(code = 200, message = "", examples = @Example(
+                            value = {
+                                    @ExampleProperty(
+                                            value = "value1", mediaType = "mediaType1"),
+                                    @ExampleProperty(
+                                            value = "", mediaType = "mediaType2")}))})
+    public void operationWithEmptyExample() {
+    }
+
+}

--- a/springfox-spring-web/src/test/java/springfox/documentation/spring/web/dummy/controllers/FeatureDemonstrationService.java
+++ b/springfox-spring-web/src/test/java/springfox/documentation/spring/web/dummy/controllers/FeatureDemonstrationService.java
@@ -24,6 +24,8 @@ import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.ExampleProperty;
 import io.swagger.annotations.Extension;
 import io.swagger.annotations.ExtensionProperty;
@@ -284,4 +286,21 @@ public class FeatureDemonstrationService {
     }
   }
   // end::question-27[]
+
+  @RequestMapping(value = "/1570", method = RequestMethod.POST)
+  @ApiOperation(value = "Demo using examples")
+  @ApiResponses(value = {@ApiResponse(code = 404, message = "User not found"),
+                  @ApiResponse(
+                    code = 405,
+                    message = "Validation exception",
+                    examples = @io.swagger.annotations.Example(
+                      value =  {
+                        @io.swagger.annotations.ExampleProperty(
+                          mediaType = "Example json",
+                          value = "{\"invalidField\": \"address\"}"),
+                        @io.swagger.annotations.ExampleProperty(
+                          mediaType = "Example string",
+                          value = "The first name was invalid")}))})
+  public void saveUser() {
+  }
 }

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/operation/SwaggerResponseMessageReader.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/operation/SwaggerResponseMessageReader.java
@@ -24,12 +24,14 @@ import com.google.common.base.Optional;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.ExampleProperty;
 import io.swagger.annotations.ResponseHeader;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import springfox.documentation.builders.ResponseMessageBuilder;
+import springfox.documentation.schema.Example;
 import springfox.documentation.schema.ModelReference;
 import springfox.documentation.schema.TypeNameExtractor;
 import springfox.documentation.service.Header;
@@ -45,6 +47,9 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.google.common.base.Optional.*;
+import static com.google.common.base.Strings.emptyToNull;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Maps.*;
 import static com.google.common.collect.Sets.*;
 import static springfox.documentation.schema.ResolvedTypes.*;
@@ -115,6 +120,12 @@ public class SwaggerResponseMessageReader implements OperationBuilderPlugin {
                 modelRefFactory(modelContext, typeNameExtractor)
                     .apply(context.alternateFor(type.get())));
           }
+          List<Example> examples = newArrayList();
+          for (ExampleProperty exampleProperty : apiResponse.examples().value()) {
+            if (!isNullOrEmpty(exampleProperty.value())) {
+              examples.add(new Example(emptyToNull(exampleProperty.mediaType()), exampleProperty.value()));
+            }
+          }
           Map<String, Header> headers = newHashMap(defaultHeaders);
           headers.putAll(headers(apiResponse.responseHeaders()));
 
@@ -122,6 +133,7 @@ public class SwaggerResponseMessageReader implements OperationBuilderPlugin {
               .code(apiResponse.code())
               .message(apiResponse.message())
               .responseModel(responseModel.orNull())
+              .examples(examples)
               .headersWithDescription(headers)
               .build());
         }

--- a/springfox-swagger1/src/test/groovy/springfox/documentation/swagger1/integration/DocketSpec.groovy
+++ b/springfox-swagger1/src/test/groovy/springfox/documentation/swagger1/integration/DocketSpec.groovy
@@ -74,6 +74,7 @@ class DocketSpec extends DocumentationContextSpec {
           OK.value(),
           "blah",
           null,
+          [],
           [] as Map,
           [])])
               .useDefaultResponseMessages(true)
@@ -98,6 +99,7 @@ class DocketSpec extends DocumentationContextSpec {
           OK.value(),
           "blah",
           null,
+          [],
           [] as Map,
           [])])
               .useDefaultResponseMessages(false)

--- a/springfox-swagger2/src/main/java/springfox/documentation/swagger2/mappers/ExamplesMapper.java
+++ b/springfox-swagger2/src/main/java/springfox/documentation/swagger2/mappers/ExamplesMapper.java
@@ -1,0 +1,39 @@
+/*
+ *
+ *  Copyright 2015-2018 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package springfox.documentation.swagger2.mappers;
+
+import static com.google.common.collect.Maps.newTreeMap;
+
+import java.util.List;
+import java.util.Map;
+
+import org.mapstruct.Mapper;
+import springfox.documentation.schema.Example;
+
+@Mapper
+public class ExamplesMapper {
+
+  public Map<String, Object> mapExamples(List<Example> from) {
+    Map<String, Object> examples = newTreeMap();
+    for (Example each : from) {
+      examples.put(each.getMediaType().or(""), each.getValue());
+    }
+    return examples;
+  }
+}

--- a/springfox-swagger2/src/main/java/springfox/documentation/swagger2/mappers/ServiceModelToSwagger2Mapper.java
+++ b/springfox-swagger2/src/main/java/springfox/documentation/swagger2/mappers/ServiceModelToSwagger2Mapper.java
@@ -21,7 +21,6 @@ package springfox.documentation.swagger2.mappers;
 
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import io.swagger.models.Contact;
 import io.swagger.models.Info;
@@ -132,7 +131,9 @@ public abstract class ServiceModelToSwagger2Mapper {
       Response response = new Response()
           .description(responseMessage.getMessage())
           .schema(responseProperty);
-      response.setExamples(Maps.<String, Object>newHashMap());
+      Map<String, Object> examples = new ExamplesMapper()
+              .mapExamples(responseMessage.getExamples());
+      response.setExamples(examples);
       response.setHeaders(transformEntries(responseMessage.getHeaders(), toPropertyEntry()));
       Map<String, Object> extensions = new VendorExtensionsMapper()
           .mapExtensions(responseMessage.getVendorExtensions());

--- a/springfox-swagger2/src/test/groovy/springfox/documentation/swagger2/mappers/ExamplesMapperSpec.groovy
+++ b/springfox-swagger2/src/test/groovy/springfox/documentation/swagger2/mappers/ExamplesMapperSpec.groovy
@@ -1,0 +1,47 @@
+package springfox.documentation.swagger2.mappers
+
+
+import com.google.common.collect.Lists
+import spock.lang.Specification
+import springfox.documentation.schema.Example
+
+class ExamplesMapperSpec extends Specification {
+  def "examples are mapped correctly" () {
+    given:
+      def mediaType = "mediaType"
+      def value = "value"
+      def examples = Lists.newArrayList(new Example(mediaType, value))
+    when:
+      def sut = new ExamplesMapper()
+    then:
+      def mapped = sut.mapExamples(examples)
+    and:
+      mapped.size() == 1
+      mapped.get(mediaType) == value
+  }
+
+  def "null mediaType is converted to empty string" () {
+    given:
+    def mediaType = null
+    def value = "value"
+    def examples = Lists.newArrayList(new Example(mediaType, value))
+    when:
+    def sut = new ExamplesMapper()
+    then:
+    def mapped = sut.mapExamples(examples)
+    and:
+    mapped.size() == 1
+    mapped.get("") == value
+  }
+
+  def "empty example list maps to empty map" () {
+    given:
+    def examples = Lists.newArrayList()
+    when:
+    def sut = new ExamplesMapper()
+    then:
+    def mapped = sut.mapExamples(examples)
+    and:
+    mapped.size() == 0
+  }
+}

--- a/springfox-swagger2/src/test/groovy/springfox/documentation/swagger2/mappers/ServiceModelToSwagger2MapperSpec.groovy
+++ b/springfox-swagger2/src/test/groovy/springfox/documentation/swagger2/mappers/ServiceModelToSwagger2MapperSpec.groovy
@@ -8,6 +8,7 @@ import com.google.common.collect.LinkedListMultimap
 import org.springframework.http.HttpMethod
 import spock.lang.Specification
 import springfox.documentation.builders.*
+import springfox.documentation.schema.Example
 import springfox.documentation.schema.ModelRef
 import springfox.documentation.service.*
 import springfox.documentation.spi.service.contexts.Defaults
@@ -44,6 +45,7 @@ class ServiceModelToSwagger2MapperSpec extends Specification implements MapperSu
       mappedOperation.responses.size() == builtOperation.responseMessages.size()
       mappedOperation.responses.get("200").description == builtOperation.responseMessages.first().message
       mappedOperation.responses.get("200").schema.type == "string"
+      mappedOperation.responses.get("200").examples.get("mediaType") == "value"
       mappedOperation.vendorExtensions.size() == builtOperation.vendorExtensions.size()
       mappedOperation.vendorExtensions.containsKey("x-test1")
       mappedOperation.vendorExtensions.containsKey("x-test2")
@@ -158,10 +160,12 @@ class ServiceModelToSwagger2MapperSpec extends Specification implements MapperSu
         .scope("test")
         .description("test scope")
         .build()
+    def example = new Example("mediaType", "value")
     def response = new ResponseMessageBuilder()
         .code(200)
         .message("Success")
         .responseModel(new ModelRef("string"))
+        .examples([example])
         .build()
 
     def first = new ObjectVendorExtension("")

--- a/swagger-contract-tests/src/test/resources/contract/swagger/declaration-feature-demonstration-service.json
+++ b/swagger-contract-tests/src/test/resources/contract/swagger/declaration-feature-demonstration-service.json
@@ -602,6 +602,52 @@
             "path": "/features/1490/{itemId}"
         },
         {
+            "description": "saveUser",
+            "operations": [
+                {
+                    "consumes": [
+                        "application/json"
+                    ],
+                    "deprecated": "false",
+                    "method": "POST",
+                    "nickname": "saveUserUsingPOST",
+                    "parameters": [],
+                    "produces": [
+                        "*/*"
+                    ],
+                    "responseMessages": [
+                        {
+                            "code": 200,
+                            "message": "OK"
+                        },
+                        {
+                            "code": 201,
+                            "message": "Created"
+                        },
+                        {
+                            "code": 401,
+                            "message": "Unauthorized"
+                        },
+                        {
+                            "code": 403,
+                            "message": "Forbidden"
+                        },
+                        {
+                            "code": 404,
+                            "message": "User not found"
+                        },
+                        {
+                            "code": 405,
+                            "message": "Validation exception"
+                        }
+                    ],
+                    "summary": "Demo using examples",
+                    "type": "void"
+                }
+            ],
+            "path": "/features/1570"
+        },
+        {
             "description": "addFiles",
             "operations": [
                 {

--- a/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-feature-demonstration-service-codeGen.json
+++ b/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-feature-demonstration-service-codeGen.json
@@ -203,6 +203,34 @@
                 "deprecated": false
             }
         },
+        "/features/1570": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "deprecated": false,
+                "operationId": "saveUserUsingPOST_2",
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "404": {
+                        "description": "User not found"
+                    },
+                    "405": {
+                        "description": "Validation exception",
+                        "examples": {
+                            "Example json": "{\"invalidField\": \"address\"}",
+                            "Example string": "The first name was invalid"
+                        }
+                    }
+                },
+                "summary": "Demo using examples",
+                "tags": [
+                    "feature-demonstration-service"
+                ]
+            }
+        },
         "/features/2031": {
             "post": {
                 "tags": [

--- a/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-feature-demonstration-service.json
+++ b/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-feature-demonstration-service.json
@@ -6,7 +6,7 @@
         "title": "Api Documentation",
         "termsOfService": "urn:tos",
         "contact": {
-            
+
         },
         "license": {
             "name": "Apache 2.0",
@@ -201,6 +201,34 @@
                     }
                 },
                 "deprecated": false
+            }
+        },
+        "/features/1570": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "deprecated": false,
+                "operationId": "saveUserUsingPOST_1",
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "404": {
+                        "description": "User not found"
+                    },
+                    "405": {
+                        "description": "Validation exception",
+                        "examples": {
+                            "Example json": "{\"invalidField\": \"address\"}",
+                            "Example string": "The first name was invalid"
+                        }
+                    }
+                },
+                "summary": "Demo using examples",
+                "tags": [
+                    "feature-demonstration-service"
+                ]
             }
         },
         "/features/2031": {


### PR DESCRIPTION
Support ApiResponse examples.

**Summary**
Transforms @Example.value() (i.e. @ExampleProperty[]) into a List\<Example\> that then will be transformed into a Map<String, Object> that then will be used to populate the examples map in io.swagger.models.Response

**Details**
1) Added a List\<Example\> to ResponseMessage
2) Added a small block of code in SwaggerResponseMessageReader (where an ApiResponse is transformed into a ResponseMessage) that will transform an ExampleProperty into an Example and then add it to the ResponseMessage using the field above.
3) Transform the List\<Example\> to a Map<String, Object> in ServiceModelToSwagger2Mapper, and populate the Response.examples with it.

**Test**
1) Added additional UT to ResponseMessageSpec, ResponseMessageBuilderSpec and ServiceModelToSwagger2MapperSpec to cover newly added functionality.
2) Added a ResponseExampleTestController that will be used by SwaggerResponseMessageReaderSpec to test examples support.
3) Added UT for new ExamplesMapper class.
4) Added a new endpoint in FeatureDemonstrationService (not sure if this is the right place), to test the contract using the contract tests.