### PR TITLE
Adds required marker to fields annotated with @NotBlank BeanValidation annotation

### DIFF
--- a/springfox-bean-validators/src/main/java/springfox/bean/validators/configuration/BeanValidatorPluginsConfiguration.java
+++ b/springfox-bean-validators/src/main/java/springfox/bean/validators/configuration/BeanValidatorPluginsConfiguration.java
@@ -20,13 +20,11 @@ package springfox.bean.validators.configuration;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import springfox.bean.validators.plugins.parameter.ExpandedParameterMinMaxAnnotationPlugin;
-import springfox.bean.validators.plugins.parameter.ExpandedParameterNotNullAnnotationPlugin;
-import springfox.bean.validators.plugins.parameter.ExpandedParameterPatternAnnotationPlugin;
-import springfox.bean.validators.plugins.parameter.ExpandedParameterSizeAnnotationPlugin;
+import springfox.bean.validators.plugins.parameter.*;
 import springfox.bean.validators.plugins.schema.DecimalMinMaxAnnotationPlugin;
 import springfox.bean.validators.plugins.schema.MinMaxAnnotationPlugin;
 import springfox.bean.validators.plugins.schema.NotNullAnnotationPlugin;
+import springfox.bean.validators.plugins.schema.NotBlankAnnotationPlugin;
 import springfox.bean.validators.plugins.schema.PatternAnnotationPlugin;
 import springfox.bean.validators.plugins.schema.SizeAnnotationPlugin;
 
@@ -41,6 +39,11 @@ public class BeanValidatorPluginsConfiguration {
   @Bean
   public ExpandedParameterNotNullAnnotationPlugin expanderNotNull() {
     return new ExpandedParameterNotNullAnnotationPlugin();
+  }
+
+  @Bean
+  public ExpandedParameterNotBlankAnnotationPlugin expanderNotBlank() {
+    return new ExpandedParameterNotBlankAnnotationPlugin();
   }
 
   @Bean
@@ -61,6 +64,11 @@ public class BeanValidatorPluginsConfiguration {
   @Bean
   public springfox.bean.validators.plugins.parameter.NotNullAnnotationPlugin parameterNotNull() {
     return new springfox.bean.validators.plugins.parameter.NotNullAnnotationPlugin();
+  }
+
+  @Bean
+  public springfox.bean.validators.plugins.parameter.NotBlankAnnotationPlugin parameterNotBlank() {
+    return new springfox.bean.validators.plugins.parameter.NotBlankAnnotationPlugin();
   }
 
   @Bean
@@ -91,6 +99,11 @@ public class BeanValidatorPluginsConfiguration {
   @Bean
   public NotNullAnnotationPlugin notNullPlugin() {
     return new NotNullAnnotationPlugin();
+  }
+
+  @Bean
+  public NotBlankAnnotationPlugin notBlankPlugin() {
+    return new NotBlankAnnotationPlugin();
   }
 
   @Bean

--- a/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/parameter/ExpandedParameterNotBlankAnnotationPlugin.java
+++ b/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/parameter/ExpandedParameterNotBlankAnnotationPlugin.java
@@ -1,0 +1,55 @@
+/*
+ *
+ *  Copyright 2015-2017 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package springfox.bean.validators.plugins.parameter;
+
+import javax.validation.constraints.NotBlank;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import springfox.bean.validators.plugins.Validators;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.service.ExpandedParameterBuilderPlugin;
+import springfox.documentation.spi.service.contexts.ParameterExpansionContext;
+
+@Component
+@Order(Validators.BEAN_VALIDATOR_PLUGIN_ORDER)
+public class ExpandedParameterNotBlankAnnotationPlugin implements ExpandedParameterBuilderPlugin {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ExpandedParameterNotBlankAnnotationPlugin.class);
+
+  @Override
+  public boolean supports(DocumentationType delimiter) {
+    // we simply support all documentationTypes!
+    return true;
+  }
+
+  @Override
+  public void apply(ParameterExpansionContext context) {
+
+    Optional<NotBlank> notBlank = context.findAnnotation(NotBlank.class);
+
+    if (notBlank.isPresent()) {
+      LOG.debug("Setting parameter to required because of @NotBlank attribute");
+      context.getParameterBuilder().required(true);
+    }
+  }
+}

--- a/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/parameter/NotBlankAnnotationPlugin.java
+++ b/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/parameter/NotBlankAnnotationPlugin.java
@@ -1,0 +1,56 @@
+/*
+ *
+ *  Copyright 2015-2017 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package springfox.bean.validators.plugins.parameter;
+
+import javax.validation.constraints.NotBlank;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import springfox.bean.validators.plugins.Validators;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.service.ParameterBuilderPlugin;
+import springfox.documentation.spi.service.contexts.ParameterContext;
+
+import static springfox.bean.validators.plugins.Validators.annotationFromParameter;
+
+@Component
+@Order(Validators.BEAN_VALIDATOR_PLUGIN_ORDER)
+public class NotBlankAnnotationPlugin implements ParameterBuilderPlugin {
+
+  private static final Logger LOG = LoggerFactory.getLogger(NotBlankAnnotationPlugin.class);
+
+  @Override
+  public boolean supports(DocumentationType delimiter) {
+    // we simply support all documentationTypes!
+    return true;
+  }
+
+  @Override
+  public void apply(ParameterContext context) {
+    Optional<NotBlank> notBlank = annotationFromParameter(context, NotBlank.class);
+
+    if (notBlank.isPresent()) {
+      LOG.debug("@NotBlank present: setting parameter as required");
+      context.parameterBuilder().required(true);
+    }
+  }
+}

--- a/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/schema/NotBlankAnnotationPlugin.java
+++ b/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/schema/NotBlankAnnotationPlugin.java
@@ -1,0 +1,61 @@
+/*
+ *
+ *  Copyright 2016-2017 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package springfox.bean.validators.plugins.schema;
+
+import javax.validation.constraints.NotBlank;
+import java.util.Optional;
+
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import springfox.bean.validators.plugins.Validators;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.schema.ModelPropertyBuilderPlugin;
+import springfox.documentation.spi.schema.contexts.ModelPropertyContext;
+
+import static springfox.bean.validators.plugins.Validators.annotationFromBean;
+import static springfox.bean.validators.plugins.Validators.annotationFromField;
+
+@Component
+@Order(Validators.BEAN_VALIDATOR_PLUGIN_ORDER)
+public class NotBlankAnnotationPlugin implements ModelPropertyBuilderPlugin {
+
+  /**
+   * support all documentationTypes
+   */
+  @Override
+  public boolean supports(DocumentationType delimiter) {
+    // we simply support all documentationTypes!
+    return true;
+  }
+
+  /**
+   * read NotNull annotation
+   */
+  @Override
+  public void apply(ModelPropertyContext context) {
+    Optional<NotBlank> notBlank = extractAnnotation(context);
+    if (notBlank.isPresent()) {
+      context.getBuilder().required(notBlank.isPresent());
+    }
+  }
+
+  private Optional<NotBlank> extractAnnotation(ModelPropertyContext context) {
+    return annotationFromBean(context, NotBlank.class).map(Optional::of).orElse(annotationFromField(context, NotBlank.class));
+  }
+}

--- a/springfox-bean-validators/src/test/groovy/springfox/bean/validators/configuration/BeanValidatorPluginsConfigurationSpec.groovy
+++ b/springfox-bean-validators/src/test/groovy/springfox/bean/validators/configuration/BeanValidatorPluginsConfigurationSpec.groovy
@@ -21,11 +21,13 @@ package springfox.bean.validators.configuration
 import spock.lang.Specification
 import springfox.bean.validators.plugins.parameter.ExpandedParameterMinMaxAnnotationPlugin
 import springfox.bean.validators.plugins.parameter.ExpandedParameterNotNullAnnotationPlugin
+import springfox.bean.validators.plugins.parameter.ExpandedParameterNotBlankAnnotationPlugin
 import springfox.bean.validators.plugins.parameter.ExpandedParameterPatternAnnotationPlugin
 import springfox.bean.validators.plugins.parameter.ExpandedParameterSizeAnnotationPlugin
 import springfox.bean.validators.plugins.schema.DecimalMinMaxAnnotationPlugin
 import springfox.bean.validators.plugins.schema.MinMaxAnnotationPlugin
 import springfox.bean.validators.plugins.schema.NotNullAnnotationPlugin
+import springfox.bean.validators.plugins.schema.NotBlankAnnotationPlugin
 import springfox.bean.validators.plugins.schema.PatternAnnotationPlugin
 import springfox.bean.validators.plugins.schema.SizeAnnotationPlugin
 
@@ -37,37 +39,41 @@ class BeanValidatorPluginsConfigurationSpec extends Specification {
         when:
         def minMaxPlugin = config.minMaxPlugin()
         def notNullPlugin = config.notNullPlugin()
+        def notBlankPlugin = config.notBlankPlugin()
         def patternPlugin = config.patternPlugin()
         def sizePlugin = config.sizePlugin()
         def decimalPlugin = config.decimalMinMaxPlugin()
 
         def parameterMinMax = config.parameterMinMax()
         def parameterNotNull = config.parameterNotNull()
+        def parameterNotBlank = config.parameterNotBlank()
         def parameterPattern = config.parameterPattern()
         def parameterSize = config.parameterSize()
 
         def expanderMinMax = config.expanderMinMax()
         def expanderNotNull = config.expanderNotNull()
+        def expanderNotBlank = config.expanderNotBlank()
         def expanderPattern = config.expanderPattern()
         def expanderSize = config.expanderSize()
 
         then:
         minMaxPlugin instanceof  MinMaxAnnotationPlugin
         notNullPlugin instanceof  NotNullAnnotationPlugin
+        notBlankPlugin instanceof  NotBlankAnnotationPlugin
         patternPlugin instanceof PatternAnnotationPlugin
         sizePlugin instanceof  SizeAnnotationPlugin
         decimalPlugin instanceof DecimalMinMaxAnnotationPlugin
 
         parameterMinMax instanceof springfox.bean.validators.plugins.parameter.MinMaxAnnotationPlugin
         parameterNotNull instanceof springfox.bean.validators.plugins.parameter.NotNullAnnotationPlugin
+        parameterNotBlank instanceof springfox.bean.validators.plugins.parameter.NotBlankAnnotationPlugin
         parameterPattern instanceof springfox.bean.validators.plugins.parameter.PatternAnnotationPlugin
         parameterSize instanceof springfox.bean.validators.plugins.parameter.SizeAnnotationPlugin
 
         expanderMinMax instanceof ExpandedParameterMinMaxAnnotationPlugin
         expanderNotNull instanceof ExpandedParameterNotNullAnnotationPlugin
+        expanderNotBlank instanceof ExpandedParameterNotBlankAnnotationPlugin
         expanderPattern instanceof ExpandedParameterPatternAnnotationPlugin
         expanderSize instanceof ExpandedParameterSizeAnnotationPlugin
-
-
     }
 }


### PR DESCRIPTION
Adds `required` marker to fields annotated with `@NotBlank` BeanValidation annotation

#### What's this PR do/fix?
* Adds required marker to fields annotated with `@NotBlank` BeanValidation annotation
#### Are there unit tests? If not how should this be manually tested?
* Unit Tests extended. No manual testing is required
#### Any background context you want to provide?
* No
#### What are the relevant issues?
* No issue
