### PR TITLE
Add support for showCommonExtensions configuration options for swagger-ui

### DIFF
--- a/springfox-spring-config/src/main/java/springfox/springconfig/Swagger2SpringBoot.java
+++ b/springfox-spring-config/src/main/java/springfox/springconfig/Swagger2SpringBoot.java
@@ -158,6 +158,7 @@ public class Swagger2SpringBoot {
         .maxDisplayedTags(null)
         .operationsSorter(OperationsSorter.ALPHA)
         .showExtensions(false)
+        .showCommonExtensions(false)
         .tagsSorter(TagsSorter.ALPHA)
         .supportedSubmitMethods(UiConfiguration.Constants.DEFAULT_SUBMIT_METHODS)
         .validatorUrl(null)

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/UiConfiguration.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/UiConfiguration.java
@@ -46,6 +46,7 @@ public class UiConfiguration {
   private final Integer maxDisplayedTags;
   private final OperationsSorter operationsSorter;
   private final Boolean showExtensions;
+  private final Boolean showCommonExtensions;
   private final TagsSorter tagsSorter;
   private final String validatorUrl;
   /**
@@ -190,6 +191,7 @@ public class UiConfiguration {
     this.maxDisplayedTags = null;
     this.operationsSorter = OperationsSorter.of(apisSorter);
     this.showExtensions = false;
+    this.showCommonExtensions = false;
     this.tagsSorter = TagsSorter.of(apisSorter);
   }
 
@@ -222,6 +224,8 @@ public class UiConfiguration {
    *                                 returned by the server unchanged.
    * @param showExtensions           Controls the display of vendor extension (x-) fields and values for Operations,
    *                                 Parameters, and Schema.
+   * @param showCommonExtensions     Controls the display of extensions (pattern, maxLength, minLength, maximum,
+   *                                 minimum) fields and values for Parameters.
    * @param tagsSorter               Apply a sort to the tag list of each API. It can be 'alpha' (sort by paths
    *                                 alphanumerically) or a function (see Array.prototype.sort() to learn how to write a
    *                                 sort function). Two tag name strings are passed to the sorter for each pass.
@@ -243,6 +247,7 @@ public class UiConfiguration {
       Integer maxDisplayedTags,
       OperationsSorter operationsSorter,
       Boolean showExtensions,
+      Boolean showCommonExtensions,
       TagsSorter tagsSorter,
       String validatorUrl) {
     this(
@@ -257,6 +262,7 @@ public class UiConfiguration {
         maxDisplayedTags,
         operationsSorter,
         showExtensions,
+        showCommonExtensions,
         tagsSorter,
         Constants.DEFAULT_SUBMIT_METHODS,
         validatorUrl);
@@ -291,6 +297,8 @@ public class UiConfiguration {
    *                                 returned by the server unchanged.
    * @param showExtensions           Controls the display of vendor extension (x-) fields and values for Operations,
    *                                 Parameters, and Schema.
+   * @param showCommonExtensions     Controls the display of extensions (pattern, maxLength, minLength, maximum,
+   *                                 minimum) fields and values for Parameters.
    * @param tagsSorter               Apply a sort to the tag list of each API. It can be 'alpha' (sort by paths
    *                                 alphanumerically) or a function (see Array.prototype.sort() to learn how to write a
    *                                 sort function). Two tag name strings are passed to the sorter for each pass.
@@ -316,6 +324,7 @@ public class UiConfiguration {
       Integer maxDisplayedTags,
       OperationsSorter operationsSorter,
       Boolean showExtensions,
+      Boolean showCommonExtensions,
       TagsSorter tagsSorter,
       String[] supportedSubmitMethods,
       String validatorUrl) {
@@ -331,6 +340,7 @@ public class UiConfiguration {
     this.maxDisplayedTags = maxDisplayedTags;
     this.operationsSorter = operationsSorter;
     this.showExtensions = showExtensions;
+    this.showCommonExtensions = showCommonExtensions;
     this.tagsSorter = tagsSorter;
     this.supportedSubmitMethods = supportedSubmitMethods;
     this.validatorUrl = validatorUrl;
@@ -429,6 +439,11 @@ public class UiConfiguration {
   @JsonProperty("showExtensions")
   public Boolean getShowExtensions() {
     return showExtensions;
+  }
+
+  @JsonProperty("showCommonExtensions")
+  public Boolean getShowCommonExtensions() {
+    return showCommonExtensions;
   }
 
   @JsonProperty("tagsSorter")

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/UiConfigurationBuilder.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/UiConfigurationBuilder.java
@@ -36,6 +36,7 @@ public class UiConfigurationBuilder {
   private Integer maxDisplayedTags;
   private OperationsSorter operationsSorter;
   private Boolean showExtensions;
+  private Boolean showCommonExtensions;
   private TagsSorter tagsSorter;
 
   /*--------------------------------------------*\
@@ -64,6 +65,7 @@ public class UiConfigurationBuilder {
         defaultIfAbsent(maxDisplayedTags, null),
         defaultIfAbsent(operationsSorter, OperationsSorter.ALPHA),
         defaultIfAbsent(showExtensions, false),
+        defaultIfAbsent(showCommonExtensions, false),
         defaultIfAbsent(tagsSorter, TagsSorter.ALPHA),
         defaultIfAbsent(supportedSubmitMethods, UiConfiguration.Constants.DEFAULT_SUBMIT_METHODS),
         defaultIfAbsent(validatorUrl, null)
@@ -178,6 +180,16 @@ public class UiConfigurationBuilder {
    */
   public UiConfigurationBuilder showExtensions(Boolean showExtensions) {
     this.showExtensions = showExtensions;
+    return this;
+  }
+
+  /**
+   * @param showCommonExtensions Controls the display of extensions (pattern, maxLength, minLength, maximum, minimum)
+   *                             fields and values for Parameters.
+   * @return this
+   */
+  public UiConfigurationBuilder showCommonExtensions(Boolean showCommonExtensions) {
+    this.showCommonExtensions = showCommonExtensions;
     return this;
   }
 

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/web/ApiResourceControllerSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/web/ApiResourceControllerSpec.groovy
@@ -60,6 +60,7 @@ class ApiResourceControllerSpec extends Specification {
     "maxDisplayedTags": 1000,
     "operationsSorter": "alpha",
     "showExtensions": false,
+    "showCommonExtensions": false,
     "tagsSorter": "alpha",
     "supportedSubmitMethods":["get","put","post","delete","options","head","patch","trace"],
     "validatorUrl": "/validate"
@@ -105,6 +106,7 @@ class ApiResourceControllerSpec extends Specification {
           .maxDisplayedTags(1000)
           .operationsSorter(OperationsSorter.ALPHA)
           .showExtensions(false)
+          .showCommonExtensions(false)
           .tagsSorter(TagsSorter.ALPHA)
           .supportedSubmitMethods(UiConfiguration.Constants.DEFAULT_SUBMIT_METHODS)
           .validatorUrl("/validate")

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/web/UiConfigurationBuilderSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/web/UiConfigurationBuilderSpec.groovy
@@ -40,6 +40,7 @@ class UiConfigurationBuilderSpec extends Specification {
       "    \"filter\": false,\n" +
       "    \"operationsSorter\": \"alpha\",\n" +
       "    \"showExtensions\": false,\n" +
+      "    \"showCommonExtensions\": false,\n" +
       "    \"tagsSorter\": \"alpha\",\n" +
       "    \"supportedSubmitMethods\": [\"get\",\"put\",\"post\",\"delete\",\"options\",\"head\",\"patch\"," +
       "\"trace\"],\n" +

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/web/UiConfigurationSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/web/UiConfigurationSpec.groovy
@@ -40,6 +40,7 @@ class UiConfigurationSpec extends Specification {
       "    \"filter\": false,\n" +
       "    \"operationsSorter\": \"alpha\",\n" +
       "    \"showExtensions\": false,\n" +
+      "    \"showCommonExtensions\": false,\n" +
       "    \"tagsSorter\": \"alpha\",\n" +
       "    \"validatorUrl\": \"validator:urn\"\n" +
       "}"
@@ -59,6 +60,7 @@ class UiConfigurationSpec extends Specification {
       "    \"filter\": false,\n" +
       "    \"operationsSorter\": \"alpha\",\n" +
       "    \"showExtensions\": false,\n" +
+      "    \"showCommonExtensions\": false,\n" +
       "    \"tagsSorter\": \"alpha\",\n" +
       "    \"validatorUrl\": \"\"\n" +
       "}"


### PR DESCRIPTION
#### What's this PR do/fix?

Add support for`showCommonExtensions` configuration options for swagger-ui

#### Are there unit tests? If not how should this be manually tested?

Yes. Update existing unit tests.

#### Any background context you want to provide?

None

#### What are the relevant issues?

https://github.com/springfox/springfox/issues/2402