### PR TITLE
Fixes for response models, examples and parameter order

### DIFF
--- a/springfox-core/src/main/java/springfox/documentation/builders/OperationBuilder.java
+++ b/springfox-core/src/main/java/springfox/documentation/builders/OperationBuilder.java
@@ -319,6 +319,7 @@ public class OperationBuilder {
             .responseModel(responseWithModel)
             .headersWithDescription(responseMessage.getHeaders())
             .headersWithDescription(each.getHeaders())
+            .examples(each.getExamples())
             .build());
       } else {
         merged.add(each);

--- a/springfox-core/src/main/java/springfox/documentation/service/Operation.java
+++ b/springfox-core/src/main/java/springfox/documentation/service/Operation.java
@@ -80,8 +80,7 @@ public class Operation {
     this.protocol = protocol;
     this.isHidden = isHidden;
     this.securityReferences = toAuthorizationsMap(securityReferences);
-    this.parameters = parameters.stream()
-        .sorted(byParameterName()).collect(toList());
+    this.parameters = parameters;
     this.responseMessages = responseMessages;
     this.deprecated = deprecated;
     this.vendorExtensions = new ArrayList<>(vendorExtensions);

--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/operation/ResponseMessagesReader.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/operation/ResponseMessagesReader.java
@@ -71,7 +71,7 @@ public class ResponseMessagesReader implements OperationBuilderPlugin {
     int httpStatusCode = httpStatusCode(context);
     String message = message(context);
     ModelReference modelRef = null;
-    if (!isVoid(returnType)) {
+    if (!isVoid(returnType) && !isNoContent(httpStatusCode)) {
       ModelContext modelContext = ModelContext.returnValue(
           context.getGroupName(),
           returnType,
@@ -111,4 +111,11 @@ public class ResponseMessagesReader implements OperationBuilderPlugin {
     return reasonPhrase;
   }
 
+  static boolean isNoContent(int code) {
+    try {
+      return HttpStatus.NO_CONTENT.value() == code;
+    } catch (Exception ignored) {
+      return false;
+    }
+  }
 }

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/operation/SwaggerResponseMessageReader.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/operation/SwaggerResponseMessageReader.java
@@ -50,12 +50,14 @@ import java.util.Optional;
 import java.util.Set;
 
 import static java.util.Optional.*;
-import static org.springframework.util.StringUtils.*;
-import static springfox.documentation.schema.ResolvedTypes.*;
-import static springfox.documentation.spi.schema.contexts.ModelContext.*;
-import static springfox.documentation.spring.web.readers.operation.ResponseMessagesReader.*;
-import static springfox.documentation.swagger.annotations.Annotations.*;
-import static springfox.documentation.swagger.readers.operation.ResponseHeaders.*;
+import static org.springframework.util.StringUtils.isEmpty;
+import static springfox.documentation.schema.ResolvedTypes.modelRefFactory;
+import static springfox.documentation.spi.schema.contexts.ModelContext.returnValue;
+import static springfox.documentation.spring.web.readers.operation.ResponseMessagesReader.httpStatusCode;
+import static springfox.documentation.spring.web.readers.operation.ResponseMessagesReader.message;
+import static springfox.documentation.swagger.annotations.Annotations.resolvedTypeFromOperation;
+import static springfox.documentation.swagger.annotations.Annotations.resolvedTypeFromResponse;
+import static springfox.documentation.swagger.readers.operation.ResponseHeaders.headers;
 
 @Component
 @Order(SwaggerPluginSupport.SWAGGER_PLUGIN_ORDER)
@@ -109,7 +111,7 @@ public class SwaggerResponseMessageReader implements OperationBuilderPlugin {
               context.getIgnorableParameterTypes());
           Optional<ModelReference> responseModel = empty();
           Optional<ResolvedType> type = resolvedType(null, apiResponse);
-          if (isSuccessful(apiResponse.code())) {
+          if (isSuccessful(apiResponse.code()) && !isNoContent(apiResponse.code())) {
             type = type.map(Optional::of).orElse(operationResponse);
           }
           if (type.isPresent()) {
@@ -165,6 +167,14 @@ public class SwaggerResponseMessageReader implements OperationBuilderPlugin {
   static boolean isSuccessful(int code) {
     try {
       return HttpStatus.Series.SUCCESSFUL.equals(HttpStatus.Series.valueOf(code));
+    } catch (Exception ignored) {
+      return false;
+    }
+  }
+
+  static boolean isNoContent(int code) {
+    try {
+      return HttpStatus.NO_CONTENT.value() == code;
     } catch (Exception ignored) {
       return false;
     }


### PR DESCRIPTION
- remove model on 204 responses
- remove sorting of operation parameters
- fix merging of default responses with those from @ApiResponse (merge lost examples)

#### What's this PR do/fix?
Fixes the above issues
