### PR TITLE
allow importing into eclipse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ out/
 *.hprof
 node_modules/
 package-lock.json
+.eclipse/
+bin/

--- a/buildSrc/src/main/groovy/springfox/gradlebuild/BuildInfoFactory.groovy
+++ b/buildSrc/src/main/groovy/springfox/gradlebuild/BuildInfoFactory.groovy
@@ -20,10 +20,10 @@ class BuildInfoFactory {
     def isReleaseBuild = project.gradle.startParameter.taskNames.contains("release")
 
     SemanticVersion buildVersion = versioningStrategy.buildVersion(releaseType, isReleaseBuild)
-    project.logger.lifecycle("[RELEASE] current verison: ${versioningStrategy.current()}, " +
+    project.logger.lifecycle("[RELEASE] current verison: ${versioningStrategy.current(project)}, " +
         "build version: $buildVersion, dryRun: $dryRun, releaseBuild: $isReleaseBuild")
     new BuildInfo(
-        versioningStrategy.current(),
+        versioningStrategy.current(project),
         buildVersion,
         releaseType,
         isReleaseBuild,

--- a/buildSrc/src/main/groovy/springfox/gradlebuild/version/FileVersionStrategy.groovy
+++ b/buildSrc/src/main/groovy/springfox/gradlebuild/version/FileVersionStrategy.groovy
@@ -29,8 +29,8 @@ class FileVersionStrategy implements VersioningStrategy, GitTaggingSupport, GitV
   }
 
   @Override
-  SemanticVersion current() {
-    parseTransform(lastAnnotatedTag(), "")
+  SemanticVersion current(Project project) {
+    parseTransform(lastAnnotatedTag(project), "")
   }
 
   @Override

--- a/buildSrc/src/main/groovy/springfox/gradlebuild/version/GitDescribeVersioningStrategy.groovy
+++ b/buildSrc/src/main/groovy/springfox/gradlebuild/version/GitDescribeVersioningStrategy.groovy
@@ -17,8 +17,8 @@ class GitDescribeVersioningStrategy implements VersioningStrategy, GitVersionPar
   }
 
   @Override
-  SemanticVersion current() {
-    parseTransform(lastAnnotatedTag(), buildNumberFormat)
+  SemanticVersion current(Project project) {
+    parseTransform(lastAnnotatedTag(project), buildNumberFormat)
   }
 
   @Override

--- a/buildSrc/src/main/groovy/springfox/gradlebuild/version/GitTaggingSupport.groovy
+++ b/buildSrc/src/main/groovy/springfox/gradlebuild/version/GitTaggingSupport.groovy
@@ -5,13 +5,13 @@ import springfox.gradlebuild.BuildInfo
 
 trait GitTaggingSupport {
 
-  String lastAnnotatedTag() {
-    def proc = "git describe --exact-match".execute();
+  String lastAnnotatedTag(Project project) {
+    def proc = "git -C ${project.getRootDir().toString()} describe --exact-match".execute();
     proc.waitFor();
     if (proc.exitValue() == 0) {
       return proc.text.trim()
     }
-    proc = "git describe".execute()
+    proc = "git -C ${project.getRootDir().toString()} describe".execute()
     proc.waitFor()
     if (proc.exitValue() == 0) {
       return proc.text.trim()

--- a/buildSrc/src/main/groovy/springfox/gradlebuild/version/VersioningStrategy.groovy
+++ b/buildSrc/src/main/groovy/springfox/gradlebuild/version/VersioningStrategy.groovy
@@ -6,7 +6,7 @@ import springfox.gradlebuild.BuildInfo
 interface VersioningStrategy {
   SemanticVersion buildVersion(ReleaseType releaseType, boolean isReleaseBuild)
   SemanticVersion nextVersion(SemanticVersion buildVersion, ReleaseType releaseType, boolean isReleaseBuild)
-  SemanticVersion current()
+  SemanticVersion current(Project project)
   void persist(Project project, BuildInfo buildInfo)
 
 }


### PR DESCRIPTION
This PR fixes the issue with not being able to import the project into eclipse using buildship (gradle integration).  This is detailed in #1359.

Eclipse is able to have multiple projects unlike intellij which can only have one(i assume intellij sets the working directory to the root of this folder), eclipse sets it working directory to its workspace which is a different directory to its project directory.  When it tries to find the last annotated tag via git its looking in the workspace directory which is not a git repo.

The fix simply adds the `-C <project root directory>` from the project so it can find the correct git repository.

I have imported the project into intellij and eclipse, all existing tests pass when run from a terminal.


