### PR TITLE
handle any extension type

### DIFF
--- a/springfox-swagger2/src/main/java/springfox/documentation/swagger2/mappers/VendorExtensionsMapper.java
+++ b/springfox-swagger2/src/main/java/springfox/documentation/swagger2/mappers/VendorExtensionsMapper.java
@@ -20,7 +20,6 @@ package springfox.documentation.swagger2.mappers;
 
 
 import org.mapstruct.Mapper;
-import springfox.documentation.service.ListVendorExtension;
 import springfox.documentation.service.ObjectVendorExtension;
 import springfox.documentation.service.StringVendorExtension;
 import springfox.documentation.service.VendorExtension;
@@ -39,20 +38,16 @@ public class VendorExtensionsMapper {
 
   public Map<String, Object> mapExtensions(List<VendorExtension> from) {
     Map<String, Object> extensions = new TreeMap<>();
-    Iterable<ListVendorExtension> listExtensions = from.stream()
-        .filter(ListVendorExtension.class::isInstance).map(each -> (ListVendorExtension)each).collect(toList());
-    for (ListVendorExtension each : listExtensions) {
-      extensions.put(each.getName(), each.getValue());
-    }
     Iterable<Map<String, Object>> objectExtensions = from.stream()
         .filter(ObjectVendorExtension.class::isInstance).map(each -> (ObjectVendorExtension)each)
         .map(toExtensionMap()).collect(toList());
     for (Map<String, Object> each : objectExtensions) {
       extensions.putAll(each);
     }
-    Iterable<StringVendorExtension> propertyExtensions = from.stream()
-        .filter(StringVendorExtension.class::isInstance).map(each -> (StringVendorExtension)each).collect(toList());
-    for (StringVendorExtension each : propertyExtensions) {
+    Iterable<VendorExtension> propertyExtensions = from.stream()
+        .filter(each -> !ObjectVendorExtension.class.isInstance(each))
+        .map(each -> (VendorExtension)each).collect(toList());
+    for (VendorExtension each : propertyExtensions) {
       extensions.put(each.getName(), each.getValue());
     }
     return extensions;

--- a/springfox-swagger2/src/test/groovy/springfox/documentation/swagger2/mappers/VendorExtensionsMapperSpec.groovy
+++ b/springfox-swagger2/src/test/groovy/springfox/documentation/swagger2/mappers/VendorExtensionsMapperSpec.groovy
@@ -19,12 +19,16 @@
 package springfox.documentation.swagger2.mappers
 
 import spock.lang.Specification
+import springfox.documentation.service.VendorExtension
 import springfox.documentation.service.ListVendorExtension
 import springfox.documentation.service.ObjectVendorExtension
 import springfox.documentation.service.StringVendorExtension
 
 class VendorExtensionsMapperSpec extends Specification {
-
+  class Person {
+    String name;
+    int age;
+  }
   def second() {
     def second = new ObjectVendorExtension("x-test2")
     second.with {
@@ -45,11 +49,25 @@ class VendorExtensionsMapperSpec extends Specification {
     new ListVendorExtension("x-test3", [1, 3])
   }
 
+  def fourth() {
+    new VendorExtension() {
+      def getValue() {
+        Person person = new Person()
+        person.name = "test"
+        person.age = 1
+        return person
+      }
+      String getName() {
+        "x-test4"
+      }
+    }
+  }
+
   def "mapper works as expected" () {
     given:
       VendorExtensionsMapper sut = new VendorExtensionsMapper()
     when:
-      def mapped = sut.mapExtensions([first(), second(), third()])
+      def mapped = sut.mapExtensions([first(), second(), third(), fourth()])
     then:
       mapped.containsKey("x-test1")
       mapped["x-test1"] == "value1"
@@ -59,5 +77,10 @@ class VendorExtensionsMapperSpec extends Specification {
     and:
       mapped.containsKey("x-test3")
       mapped["x-test3"] == [1, 3]
+    and:
+      mapped.containsKey("x-test4")
+      Person p = mapped["x-test4"]
+      p.name == "test"
+      p.age == 1
   }
 }


### PR DESCRIPTION
This PR allows any object to be added as a vendor extension just like the ListVendorExtension.

Currently you have to override the existing VendorExtensionsMapper in order to add non String type.

Test has been updated to include a check for an pojo type, iv'e also manually checked the correct values are present in the json.