### PR TITLE
Optional ACAHs: X-XSRF-TOKEN

### DIFF
--- a/springfox-spring-config/src/main/java/springfox/springconfig/Swagger2SpringBoot.java
+++ b/springfox-spring-config/src/main/java/springfox/springconfig/Swagger2SpringBoot.java
@@ -161,6 +161,8 @@ public class Swagger2SpringBoot {
         .tagsSorter(TagsSorter.ALPHA)
         .supportedSubmitMethods(UiConfiguration.Constants.DEFAULT_SUBMIT_METHODS)
         .validatorUrl(null)
+        .enableCsrf(true)
+        .csrfExcludedUrls(UiConfiguration.Constants.NO_CSRF_EXCLUDES)
         .build();
   }
 

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/UiConfiguration.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/UiConfiguration.java
@@ -48,6 +48,8 @@ public class UiConfiguration {
   private final Boolean showExtensions;
   private final TagsSorter tagsSorter;
   private final String validatorUrl;
+  private final Boolean enableCsrf;
+  private final String[] csrfExcludedUrls;
   /**
    * @deprecated @since 2.8.0. This field is unused
    */
@@ -191,6 +193,8 @@ public class UiConfiguration {
     this.operationsSorter = OperationsSorter.of(apisSorter);
     this.showExtensions = false;
     this.tagsSorter = TagsSorter.of(apisSorter);
+    this.enableCsrf = true;
+    this.csrfExcludedUrls = Constants.NO_CSRF_EXCLUDES;
   }
 
   /**
@@ -259,7 +263,9 @@ public class UiConfiguration {
         showExtensions,
         tagsSorter,
         Constants.DEFAULT_SUBMIT_METHODS,
-        validatorUrl);
+        validatorUrl,
+        true,
+        Constants.NO_CSRF_EXCLUDES);
   }
 
   /**
@@ -318,7 +324,10 @@ public class UiConfiguration {
       Boolean showExtensions,
       TagsSorter tagsSorter,
       String[] supportedSubmitMethods,
-      String validatorUrl) {
+      String validatorUrl,
+      Boolean enableCsrf,
+      String[] csrfExcludedUrls
+      ) {
     this.apisSorter = "alpha";
     this.deepLinking = deepLinking;
     this.displayOperationId = displayOperationId;
@@ -334,6 +343,8 @@ public class UiConfiguration {
     this.tagsSorter = tagsSorter;
     this.supportedSubmitMethods = supportedSubmitMethods;
     this.validatorUrl = validatorUrl;
+    this.enableCsrf = enableCsrf;
+    this.csrfExcludedUrls = csrfExcludedUrls;
   }
 
   /**
@@ -446,6 +457,16 @@ public class UiConfiguration {
     return ofNullable(validatorUrl).orElse("");
   }
 
+  @JsonProperty("enableCsrf")
+  public Boolean getEnableCsrf() {
+    return enableCsrf;
+  }
+
+  @JsonProperty("csrfExcludedUrls")
+  public String[] getCsrfExcludedUrls() {
+    return csrfExcludedUrls;
+  }
+
   public static class Constants {
     public static final String[] DEFAULT_SUBMIT_METHODS = new String[] {
         "get", "put", "post",
@@ -453,5 +474,7 @@ public class UiConfiguration {
         "patch", "trace" };
 
     public static final String[] NO_SUBMIT_METHODS = new String[] {};
+
+    public static final String[] NO_CSRF_EXCLUDES = new String[] {};
   }
 }

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/UiConfigurationBuilder.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/UiConfigurationBuilder.java
@@ -38,11 +38,14 @@ public class UiConfigurationBuilder {
   private Boolean showExtensions;
   private TagsSorter tagsSorter;
 
+
   /*--------------------------------------------*\
    * Network
   \*--------------------------------------------*/
   private String[] supportedSubmitMethods;
   private String validatorUrl;
+  private Boolean enableCsrf;
+  private String[] csrfExcludedUrls;
 
   private UiConfigurationBuilder() {
   }
@@ -66,7 +69,9 @@ public class UiConfigurationBuilder {
         defaultIfAbsent(showExtensions, false),
         defaultIfAbsent(tagsSorter, TagsSorter.ALPHA),
         defaultIfAbsent(supportedSubmitMethods, UiConfiguration.Constants.DEFAULT_SUBMIT_METHODS),
-        defaultIfAbsent(validatorUrl, null)
+        defaultIfAbsent(validatorUrl, null),
+        defaultIfAbsent(enableCsrf, true),
+        defaultIfAbsent(csrfExcludedUrls, UiConfiguration.Constants.NO_CSRF_EXCLUDES)
     );
   }
 
@@ -212,6 +217,25 @@ public class UiConfigurationBuilder {
    */
   public UiConfigurationBuilder validatorUrl(String validatorUrl) {
     this.validatorUrl = validatorUrl;
+    return this;
+  }
+
+  /**
+   * @param enableCsrf By default CSRF is enabled and the CSRF tokens are added to each request
+   * @return this
+   */
+  public UiConfigurationBuilder enableCsrf(boolean enableCsrf) {
+    this.enableCsrf = enableCsrf;
+    return this;
+  }
+
+  /**
+   * @param csrfExcludedUrls By default when CSRF is enabled the CSRF token is added to each request. Use this parameter to
+   *                         exclude urls starting with values in the array.
+   * @return this
+   */
+  public UiConfigurationBuilder csrfExcludedUrls(String[] csrfExcludedUrls) {
+    this.csrfExcludedUrls = csrfExcludedUrls;
     return this;
   }
 }

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/web/ApiResourceControllerSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/web/ApiResourceControllerSpec.groovy
@@ -62,7 +62,9 @@ class ApiResourceControllerSpec extends Specification {
     "showExtensions": false,
     "tagsSorter": "alpha",
     "supportedSubmitMethods":["get","put","post","delete","options","head","patch","trace"],
-    "validatorUrl": "/validate"
+    "validatorUrl": "/validate",
+    "enableCsrf": true,
+    "csrfExcludedUrls": []
 }"""
   def resources = """[
         {

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/web/UiConfigurationBuilderSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/web/UiConfigurationBuilderSpec.groovy
@@ -43,7 +43,9 @@ class UiConfigurationBuilderSpec extends Specification {
       "    \"tagsSorter\": \"alpha\",\n" +
       "    \"supportedSubmitMethods\": [\"get\",\"put\",\"post\",\"delete\",\"options\",\"head\",\"patch\"," +
       "\"trace\"],\n" +
-      "    \"validatorUrl\": \"\"\n" +
+      "    \"validatorUrl\": \"\",\n" +
+      "    \"enableCsrf\": true,\n" +
+      "    \"csrfExcludedUrls\": []\n" +
       "}"
 
   def "Renders non-null values using default ObjectMapper"() {

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/web/UiConfigurationSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/web/UiConfigurationSpec.groovy
@@ -41,7 +41,9 @@ class UiConfigurationSpec extends Specification {
       "    \"operationsSorter\": \"alpha\",\n" +
       "    \"showExtensions\": false,\n" +
       "    \"tagsSorter\": \"alpha\",\n" +
-      "    \"validatorUrl\": \"validator:urn\"\n" +
+      "    \"validatorUrl\": \"validator:urn\",\n" +
+      "    \"enableCsrf\": true,\n" +
+      "    \"csrfExcludedUrls\": []\n" +
       "}"
 
   def uiConfigWithoutValidatorUrl = new UiConfiguration(null, UiConfiguration.Constants.NO_SUBMIT_METHODS)
@@ -60,8 +62,10 @@ class UiConfigurationSpec extends Specification {
       "    \"operationsSorter\": \"alpha\",\n" +
       "    \"showExtensions\": false,\n" +
       "    \"tagsSorter\": \"alpha\",\n" +
-      "    \"validatorUrl\": \"\"\n" +
-      "}"
+      "    \"validatorUrl\": \"\",\n" +
+      "    \"enableCsrf\": true,\n" +
+      "    \"csrfExcludedUrls\": []\n" +
+          "}"
 
   def "Renders non-null values using default ObjectMapper"() {
     given:

--- a/springfox-swagger-ui/src/web/js/csrf.js
+++ b/springfox-swagger-ui/src/web/js/csrf.js
@@ -3,17 +3,29 @@
  * @param baseUrl
  * @returns {Promise<void>}
  */
-export default async function patchRequestInterceptor(baseUrl) {
+export default async function patchRequestInterceptor(baseUrl, csrfExcludeUrls) {
   try {
     const result = await getCsrf(baseUrl);
 
     if (result) {
+
       window.ui.getConfigs().requestInterceptor = request => {
-        request.headers[result.headerName] = result.token;
+
+        var include = true;
+        // exclude the csrf header for all urls starting with the any of the excludeurls
+        for (var i = 0, len = csrfExcludeUrls.length; i < len; i++) {
+          if(request.url.indexOf(csrfExcludeUrls[i]) === 0){
+            include = false;
+            break;
+          }
+        }
+        if(include) {
+          request.headers[result.headerName] = result.token;
+        }
         // console.debug(request);
         return request;
       };
-      console.debug('Successfully added csrf header for all requests');
+      console.debug('Successfully added csrf header for all requests except ' + excludeUrls );
     } else {
       console.debug('No csrf token can be found');
     }

--- a/springfox-swagger-ui/src/web/js/csrf.test.js
+++ b/springfox-swagger-ui/src/web/js/csrf.test.js
@@ -50,7 +50,7 @@ test('o ? ?', async () => {
 
 test('x o ?', async () => {
   fetchMock.mock(`${baseUrl}/`, `<html><head><title>No Meta</title></head><body></body></html>`);
-  fetchMock.mock(`${baseUrl}/csrf`, { headerName, token });
+  fetchMock.mock(`${baseUrl}/csrf`, { headerName, token })
 
   await expectOk();
 });
@@ -87,5 +87,5 @@ test('x invalid-json ?', async () => {
   expect(error).toBeInstanceOf(FetchError);
 
   // Make sure this function will not throw exception.
-  await patchRequestInterceptor(baseUrl);
+  await patchRequestInterceptor(baseUrl), [];
 });

--- a/springfox-swagger-ui/src/web/js/springfox.js
+++ b/springfox-swagger-ui/src/web/js/springfox.js
@@ -86,7 +86,7 @@ window.onload = () => {
       defaultModelExpandDepth: configUI.defaultModelExpandDepth,
       defaultModelRendering: configUI.defaultModelRendering,
       displayRequestDuration: configUI.displayRequestDuration,
-      docExpansion: configUI.docExpansion,
+      docExpansion: configUI.Do,
       filter: configUI.filter,
       maxDisplayedTags: configUI.maxDisplayedTags,
       operationsSorter: configUI.operationsSorter,
@@ -101,6 +101,9 @@ window.onload = () => {
       showMutatedRequest: true,
       supportedSubmitMethods: configUI.supportedSubmitMethods,
       validatorUrl: configUI.validatorUrl,
+      enableCsrf: configUI.enableCsrf,
+      csrfExcludeUrls: configUI.csrfExcludeUrls,
+
       /*--------------------------------------------*\
        * Macros
       \*--------------------------------------------*/
@@ -132,7 +135,9 @@ window.onload = () => {
   /* Entry Point */
   (async () => {
     await buildSystemAsync(getBaseURL());
-    await csrfSupport(getBaseURL());
+    if (window.ui.getConfigs().enableCsrf) {
+      await csrfSupport(getBaseURL(), window.ui.getConfigs().csrfExcludeUrls);
+    }
   })();
 
 };

--- a/springfox-swagger-ui/src/web/js/springfox.js
+++ b/springfox-swagger-ui/src/web/js/springfox.js
@@ -86,7 +86,7 @@ window.onload = () => {
       defaultModelExpandDepth: configUI.defaultModelExpandDepth,
       defaultModelRendering: configUI.defaultModelRendering,
       displayRequestDuration: configUI.displayRequestDuration,
-      docExpansion: configUI.Do,
+      docExpansion: configUI.docExpansion,
       filter: configUI.filter,
       maxDisplayedTags: configUI.maxDisplayedTags,
       operationsSorter: configUI.operationsSorter,


### PR DESCRIPTION
#### What's this PR do/fix?
[#2578](https://github.com/springfox/springfox/issues/2578). Allow to exclude urls from the CSRF header
#### Are there unit tests? If not how should this be manually tested?
yes. For checking the configuration. No 
#### Any background context you want to provide?
Like #2578 I ran into issues using KeyCloak with SpringFox. It is now possible to enable/disable CSRF support and/or filter out the header for certain domains.
#### What are the relevant issues?
CSRF headers are send for all requests.