### PR TITLE
Fixes #2717: Use FormParameter for formData params

### DIFF
--- a/springfox-swagger2/src/main/java/springfox/documentation/swagger2/mappers/ParameterMapper.java
+++ b/springfox-swagger2/src/main/java/springfox/documentation/swagger2/mappers/ParameterMapper.java
@@ -46,8 +46,38 @@ public class ParameterMapper {
   private static final VendorExtensionsMapper vendorMapper = new VendorExtensionsMapper();
 
   public Parameter mapParameter(springfox.documentation.service.Parameter source) {
-    Parameter bodyParameter = bodyParameter(source);
-    return SerializableParameterFactories.create(source).orElse(bodyParameter);
+    Parameter parameter;
+    switch (source.getParamType()) {
+      case "formData":
+        parameter = formParameter(source);
+        break;
+      default:
+        parameter = bodyParameter(source);
+        break;
+    }
+    return SerializableParameterFactories.create(source).orElse(parameter);
+  }
+  
+  private Parameter formParameter(springfox.documentation.service.Parameter source) {
+    FormParameter parameter = new FormParameter()
+            .description(source.getDescription())
+            .type(source.getModelRef().getType())
+            .name(source.getName());
+    parameter.setIn(source.getParamType());
+    parameter.setAccess(source.getParamAccess());
+    parameter.setPattern(source.getPattern());
+    parameter.setRequired(source.isRequired());
+    parameter.getVendorExtensions().putAll(vendorMapper.mapExtensions(source.getVendorExtentions()));
+    for (Entry<String, List<Example>> each : source.getExamples().entrySet()) {
+      Optional<Example> example = each.getValue().stream().findFirst();
+      if (example.isPresent() && example.get().getValue() != null) {
+        // Form parameters only support a single example
+        parameter.example(String.valueOf(example.get().getValue()));
+        break;
+      }
+    }
+
+    return parameter;
   }
 
   private Parameter bodyParameter(springfox.documentation.service.Parameter source) {


### PR DESCRIPTION
Fix for issue #2717 

BodyParameter and FormParameters cannot coexist according to the Swagger 2 spec, so use FormParameters rather than BodyParameters to describe parameters with in=formData, which usually come from non-file parameters annotated with @RequestPart.

I tested this using a local build in my own project so that the generated JSON now validates with openapi-generator et al.