### PR TITLE
Fixes #2719: Implement support for @NotBlank

### DIFF
--- a/springfox-bean-validators/src/main/java/springfox/bean/validators/configuration/BeanValidatorPluginsConfiguration.java
+++ b/springfox-bean-validators/src/main/java/springfox/bean/validators/configuration/BeanValidatorPluginsConfiguration.java
@@ -20,12 +20,10 @@ package springfox.bean.validators.configuration;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import springfox.bean.validators.plugins.parameter.ExpandedParameterMinMaxAnnotationPlugin;
-import springfox.bean.validators.plugins.parameter.ExpandedParameterNotNullAnnotationPlugin;
-import springfox.bean.validators.plugins.parameter.ExpandedParameterPatternAnnotationPlugin;
-import springfox.bean.validators.plugins.parameter.ExpandedParameterSizeAnnotationPlugin;
+import springfox.bean.validators.plugins.parameter.*;
 import springfox.bean.validators.plugins.schema.DecimalMinMaxAnnotationPlugin;
 import springfox.bean.validators.plugins.schema.MinMaxAnnotationPlugin;
+import springfox.bean.validators.plugins.schema.NotBlankAnnotationPlugin;
 import springfox.bean.validators.plugins.schema.NotNullAnnotationPlugin;
 import springfox.bean.validators.plugins.schema.PatternAnnotationPlugin;
 import springfox.bean.validators.plugins.schema.SizeAnnotationPlugin;
@@ -41,6 +39,11 @@ public class BeanValidatorPluginsConfiguration {
   @Bean
   public ExpandedParameterNotNullAnnotationPlugin expanderNotNull() {
     return new ExpandedParameterNotNullAnnotationPlugin();
+  }
+
+  @Bean
+  public ExpandedParameterNotBlankAnnotationPlugin expanderNotBlank() {
+    return new ExpandedParameterNotBlankAnnotationPlugin();
   }
 
   @Bean
@@ -61,6 +64,11 @@ public class BeanValidatorPluginsConfiguration {
   @Bean
   public springfox.bean.validators.plugins.parameter.NotNullAnnotationPlugin parameterNotNull() {
     return new springfox.bean.validators.plugins.parameter.NotNullAnnotationPlugin();
+  }
+
+  @Bean
+  public springfox.bean.validators.plugins.parameter.NotBlankAnnotationPlugin parameterNotBlank() {
+    return new springfox.bean.validators.plugins.parameter.NotBlankAnnotationPlugin();
   }
 
   @Bean
@@ -91,6 +99,11 @@ public class BeanValidatorPluginsConfiguration {
   @Bean
   public NotNullAnnotationPlugin notNullPlugin() {
     return new NotNullAnnotationPlugin();
+  }
+
+  @Bean
+  public NotBlankAnnotationPlugin notBlankPlugin() {
+    return new NotBlankAnnotationPlugin();
   }
 
   @Bean

--- a/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/parameter/ExpandedParameterNotBlankAnnotationPlugin.java
+++ b/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/parameter/ExpandedParameterNotBlankAnnotationPlugin.java
@@ -1,0 +1,55 @@
+/*
+ *
+ *  Copyright 2015-2017 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package springfox.bean.validators.plugins.parameter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import springfox.bean.validators.plugins.Validators;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.service.ExpandedParameterBuilderPlugin;
+import springfox.documentation.spi.service.contexts.ParameterExpansionContext;
+
+import javax.validation.constraints.NotBlank;
+import java.util.Optional;
+
+@Component
+@Order(Validators.BEAN_VALIDATOR_PLUGIN_ORDER)
+public class ExpandedParameterNotBlankAnnotationPlugin implements ExpandedParameterBuilderPlugin {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ExpandedParameterNotBlankAnnotationPlugin.class);
+
+  @Override
+  public boolean supports(DocumentationType delimiter) {
+    // we simply support all documentationTypes!
+    return true;
+  }
+
+  @Override
+  public void apply(ParameterExpansionContext context) {
+
+    Optional<NotBlank> notBlank = context.findAnnotation(NotBlank.class);
+
+    if (notBlank.isPresent()) {
+      LOG.debug("@NotBlank present: setting parameter as required and not allowing empty values");
+      context.getParameterBuilder().required(true);
+    }
+  }
+}

--- a/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/parameter/NotBlankAnnotationPlugin.java
+++ b/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/parameter/NotBlankAnnotationPlugin.java
@@ -1,0 +1,58 @@
+/*
+ *
+ *  Copyright 2015-2017 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package springfox.bean.validators.plugins.parameter;
+
+
+import com.fasterxml.classmate.ResolvedType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import springfox.bean.validators.plugins.Validators;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.service.ParameterBuilderPlugin;
+import springfox.documentation.spi.service.contexts.ParameterContext;
+
+import javax.validation.constraints.NotBlank;
+import java.util.Optional;
+
+import static springfox.bean.validators.plugins.Validators.annotationFromParameter;
+
+@Component
+@Order(Validators.BEAN_VALIDATOR_PLUGIN_ORDER)
+public class NotBlankAnnotationPlugin implements ParameterBuilderPlugin {
+
+  private static final Logger LOG = LoggerFactory.getLogger(NotBlankAnnotationPlugin.class);
+
+  @Override
+  public boolean supports(DocumentationType delimiter) {
+    // we simply support all documentationTypes!
+    return true;
+  }
+
+  @Override
+  public void apply(ParameterContext context) {
+    Optional<NotBlank> notBlank = annotationFromParameter(context, NotBlank.class);
+
+    if (notBlank.isPresent()) {
+      LOG.debug("@NotBlank present: setting parameter as required and not allowing empty values");
+      context.parameterBuilder().required(true);
+    }
+  }
+}

--- a/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/parameter/NotBlankAnnotationPlugin.java
+++ b/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/parameter/NotBlankAnnotationPlugin.java
@@ -19,7 +19,6 @@
 package springfox.bean.validators.plugins.parameter;
 
 
-import com.fasterxml.classmate.ResolvedType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.annotation.Order;

--- a/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/schema/NotBlankAnnotationPlugin.java
+++ b/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/schema/NotBlankAnnotationPlugin.java
@@ -1,0 +1,62 @@
+/*
+ *
+ *  Copyright 2016-2017 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package springfox.bean.validators.plugins.schema;
+
+
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import springfox.bean.validators.plugins.Validators;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.schema.ModelPropertyBuilderPlugin;
+import springfox.documentation.spi.schema.contexts.ModelPropertyContext;
+
+import javax.validation.constraints.NotBlank;
+import java.util.Optional;
+
+import static springfox.bean.validators.plugins.Validators.annotationFromBean;
+import static springfox.bean.validators.plugins.Validators.annotationFromField;
+
+@Component
+@Order(Validators.BEAN_VALIDATOR_PLUGIN_ORDER)
+public class NotBlankAnnotationPlugin implements ModelPropertyBuilderPlugin {
+
+  /**
+   * support all documentationTypes
+   */
+  @Override
+  public boolean supports(DocumentationType delimiter) {
+    // we simply support all documentationTypes!
+    return true;
+  }
+
+  /**
+   * read NotNull annotation
+   */
+  @Override
+  public void apply(ModelPropertyContext context) {
+    Optional<NotBlank> notBlank = extractAnnotation(context);
+    if (notBlank.isPresent()) {
+      context.getBuilder().required(true);
+    }
+  }
+
+  private Optional<NotBlank> extractAnnotation(ModelPropertyContext context) {
+    return annotationFromBean(context, NotBlank.class).map(Optional::of).orElse(annotationFromField(context, NotBlank.class));
+  }
+}

--- a/springfox-bean-validators/src/test/groovy/springfox/bean/validators/plugins/AnnotationsSupport.groovy
+++ b/springfox-bean-validators/src/test/groovy/springfox/bean/validators/plugins/AnnotationsSupport.groovy
@@ -10,6 +10,9 @@ trait AnnotationsSupport {
   NotNull notNull() {
     [] as NotNull
   }
+  NotBlank notBlank() {
+    [] as NotBlank
+  }
   Min min(value) {
     [value: { -> value}] as Min
   }

--- a/springfox-bean-validators/src/test/groovy/springfox/bean/validators/plugins/parameter/ExpandedParameterNotBlankAnnotationPluginSpec.groovy
+++ b/springfox-bean-validators/src/test/groovy/springfox/bean/validators/plugins/parameter/ExpandedParameterNotBlankAnnotationPluginSpec.groovy
@@ -11,9 +11,9 @@ import springfox.documentation.spi.DocumentationType
 import springfox.documentation.spi.service.contexts.ParameterExpansionContext
 import springfox.documentation.spring.web.readers.parameter.ModelAttributeParameterMetadataAccessor
 
-import javax.validation.constraints.NotNull
+import javax.validation.constraints.NotBlank
 
-class ExpandedParameterNotNullAnnotationPluginSpec
+class ExpandedParameterNotBlankAnnotationPluginSpec
     extends Specification
     implements AnnotationsSupport, ReflectionSupport {
   @Shared
@@ -21,16 +21,16 @@ class ExpandedParameterNotNullAnnotationPluginSpec
 
   def "Always supported"() {
     expect:
-    new ExpandedParameterNotNullAnnotationPlugin().supports(types)
+    new ExpandedParameterNotBlankAnnotationPlugin().supports(types)
 
     where:
     types << [DocumentationType.SPRING_WEB, DocumentationType.SWAGGER_2, DocumentationType.SWAGGER_12]
   }
 
   @Unroll
-  def "@NotNull annotations are reflected in the model for #fieldName"() {
+  def "@NotBlank annotations are reflected in the model for #fieldName"() {
     given:
-    def sut = new ExpandedParameterNotNullAnnotationPlugin()
+    def sut = new ExpandedParameterNotBlankAnnotationPlugin()
     ParameterExpansionContext context = new ParameterExpansionContext(
         "Test",
         "",
@@ -57,7 +57,7 @@ class ExpandedParameterNotNullAnnotationPluginSpec
 
   class Subject {
     String noAnnotation
-    @NotNull
+    @NotBlank
     String annotated
   }
 }

--- a/springfox-bean-validators/src/test/groovy/springfox/bean/validators/plugins/parameter/NotBlankAnnotationPluginSpec.groovy
+++ b/springfox-bean-validators/src/test/groovy/springfox/bean/validators/plugins/parameter/NotBlankAnnotationPluginSpec.groovy
@@ -1,0 +1,64 @@
+/*
+ *
+ *  Copyright 2017-2018 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package springfox.bean.validators.plugins.parameter
+
+import com.fasterxml.classmate.ResolvedType
+import spock.lang.Specification
+import spock.lang.Unroll
+import springfox.bean.validators.plugins.AnnotationsSupport
+import springfox.documentation.builders.ParameterBuilder
+import springfox.documentation.service.ResolvedMethodParameter
+import springfox.documentation.spi.DocumentationType
+import springfox.documentation.spi.schema.GenericTypeNamingStrategy
+import springfox.documentation.spi.service.contexts.DocumentationContext
+import springfox.documentation.spi.service.contexts.OperationContext
+import springfox.documentation.spi.service.contexts.ParameterContext
+
+class NotBlankAnnotationPluginSpec extends Specification implements AnnotationsSupport {
+  def "Always supported" () {
+    expect:
+      new NotBlankAnnotationPlugin().supports(types)
+    where:
+      types << [DocumentationType.SPRING_WEB, DocumentationType.SWAGGER_2, DocumentationType.SWAGGER_12]
+  }
+
+  @Unroll
+  def "@NotBlank annotations are reflected in the model #propertyName that are AnnotatedElements"()  {
+    given:
+      def sut = new NotBlankAnnotationPlugin()
+      def resolvedMethodParameter =
+        new ResolvedMethodParameter(0, "", [annotation], Mock(ResolvedType))
+      ParameterContext context = new ParameterContext(
+          resolvedMethodParameter,
+          new ParameterBuilder(),
+          Mock(DocumentationContext),
+          Mock(GenericTypeNamingStrategy),
+          Mock(OperationContext))
+
+    when:
+      sut.apply(context)
+      def property = context.parameterBuilder().build()
+    then:
+      property.required == required
+    where:
+      annotationDescription | required  | annotation
+      "none"                | false     | null
+      "@NotBlank"           | true      | notBlank()
+  }
+}

--- a/springfox-bean-validators/src/test/groovy/springfox/bean/validators/plugins/schema/ModelPropertyNotBlankAnnotationPluginSpec.groovy
+++ b/springfox-bean-validators/src/test/groovy/springfox/bean/validators/plugins/schema/ModelPropertyNotBlankAnnotationPluginSpec.groovy
@@ -1,0 +1,100 @@
+/*
+ *
+ *  Copyright 2015-2018 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package springfox.bean.validators.plugins.schema
+
+import com.fasterxml.classmate.TypeResolver
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.type.TypeFactory
+import spock.lang.Specification
+import spock.lang.Unroll
+import springfox.bean.validators.plugins.models.NullabilityTestModel
+import springfox.documentation.builders.ModelPropertyBuilder
+import springfox.documentation.spi.DocumentationType
+import springfox.documentation.spi.schema.contexts.ModelPropertyContext
+
+class ModelPropertyNotBlankAnnotationPluginSpec extends Specification {
+  def "Always supported"() {
+    expect:
+    new NotBlankAnnotationPlugin().supports(types)
+    where:
+    types << [DocumentationType.SPRING_WEB, DocumentationType.SWAGGER_2, DocumentationType.SWAGGER_12]
+  }
+
+  @Unroll
+  def "@NotBlank annotations are reflected in the model properties that are AnnotatedElements"() {
+    given:
+    def sut = new NotBlankAnnotationPlugin()
+    def element = NullabilityTestModel.getDeclaredField(propertyName)
+    def context = new ModelPropertyContext(
+        new ModelPropertyBuilder(),
+        element,
+        new TypeResolver(),
+        DocumentationType.SWAGGER_12)
+
+    when:
+    sut.apply(context)
+    def property = context.builder.build()
+
+    then:
+    property.isRequired() == required
+
+    where:
+    propertyName     | required
+    "notBlankString" | true
+    "notBlankGetter" | false
+    "string"         | false
+
+  }
+
+  @Unroll
+  def "@NotBlank annotations are reflected in the model properties that are BeanPropertyDefinitions"() {
+    given:
+    def sut = new NotBlankAnnotationPlugin()
+    def beanProperty = beanProperty(propertyName)
+    def context = new ModelPropertyContext(
+        new ModelPropertyBuilder(),
+        beanProperty,
+        new TypeResolver(),
+        DocumentationType.SWAGGER_12)
+
+    when:
+    sut.apply(context)
+    def property = context.builder.build()
+
+    then:
+    property.isRequired() == required
+
+    where:
+    propertyName     | required
+    "notBlankString" | true
+    "notBlankGetter" | true
+    "string"         | false
+
+  }
+
+  def beanProperty(property) {
+    def mapper = new ObjectMapper()
+    mapper
+        .serializationConfig
+        .introspect(TypeFactory.defaultInstance().constructType(NullabilityTestModel))
+        .findProperties()
+        .find { p -> (property == p.name) }
+  }
+
+}

--- a/springfox-bean-validators/src/test/java/springfox/bean/validators/plugins/models/NullabilityTestModel.java
+++ b/springfox-bean-validators/src/test/java/springfox/bean/validators/plugins/models/NullabilityTestModel.java
@@ -18,6 +18,7 @@
  */
 package springfox.bean.validators.plugins.models;
 
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
 public class NullabilityTestModel {
@@ -25,6 +26,9 @@ public class NullabilityTestModel {
   private String notNullString;
   private String string;
   private String notNullGetter;
+  @NotBlank
+  private String notBlankString;
+  private String notBlankGetter;
 
   public String getNotNullString() {
     return notNullString;
@@ -50,4 +54,22 @@ public class NullabilityTestModel {
   public void setNotNullGetter(String notNullGetter) {
     this.notNullGetter = notNullGetter;
   }
+
+  @NotBlank
+  public String getNotBlankGetter() {
+    return notBlankGetter;
+  }
+
+  public String getNotBlankString() {
+    return notBlankString;
+  }
+
+  public void setNotBlankString(String notBlankString) {
+    this.notBlankString = notBlankString;
+  }
+
+  public void setNotBlankGetter(String notBlankGetter) {
+    this.notBlankGetter = notBlankGetter;
+  }
+
 }


### PR DESCRIPTION
Added initial support for bean validation 2.0 @NotBlank annotation.
This currently doesn't go beyond the same handling that @NotNull has, but I still split it out into separate plugins because it MIGHT be possible to extend this going forward.
Possible extensions are somehow setting minLength=1 (for strings) / minItems=1 (for collections), but I didn't find an easy way to get this through to the Swagger JSON through Springfox's internal model.
I also copied the unit tests for NotNull and adapted them accordingly.