### PR TITLE
Sort parameters by their order before sorting them by their name

### DIFF
--- a/springfox-core/src/main/java/springfox/documentation/service/Operation.java
+++ b/springfox-core/src/main/java/springfox/documentation/service/Operation.java
@@ -81,7 +81,7 @@ public class Operation {
     this.isHidden = isHidden;
     this.securityReferences = toAuthorizationsMap(securityReferences);
     this.parameters = parameters.stream()
-        .sorted(byParameterName()).collect(toList());
+        .sorted(byOrder().thenComparing(byParameterName())).collect(toList());
     this.responseMessages = responseMessages;
     this.deprecated = deprecated;
     this.vendorExtensions = new ArrayList<>(vendorExtensions);
@@ -154,6 +154,10 @@ public class Operation {
 
   public List<VendorExtension> getVendorExtensions() {
     return vendorExtensions;
+  }
+
+  private Comparator<Parameter> byOrder() {
+    return Comparator.comparingInt(Parameter::getOrder);
   }
 
   private Comparator<Parameter> byParameterName() {

--- a/springfox-core/src/test/groovy/springfox/service/model/builder/OperationBuilderSpec.groovy
+++ b/springfox-core/src/test/groovy/springfox/service/model/builder/OperationBuilderSpec.groovy
@@ -30,6 +30,8 @@ import springfox.documentation.service.ResponseMessage
 import springfox.documentation.service.SecurityReference
 import springfox.documentation.service.VendorExtension
 
+import java.util.stream.Collectors
+
 import static java.util.Collections.*
 
 class OperationBuilderSpec extends Specification {
@@ -45,6 +47,20 @@ class OperationBuilderSpec extends Specification {
           .message("OK")
           .responseModel(new ModelRef("String"))
           .build()
+
+  def "Parameters are ordered by order first, then alphabetically" () {
+    when:
+      sut.parameters(Arrays.asList(
+        new ParameterBuilder().name("a").order(2).build(),
+        new ParameterBuilder().name("b").order(2).build(),
+        new ParameterBuilder().name("z").order(1).build(),
+        new ParameterBuilder().name("y").order(1).build()
+      ))
+    and:
+      def operation = sut.build()
+    then:
+      operation.parameters.stream().map { it.name }.collect(Collectors.toList()) == Arrays.asList("y", "z", "a", "b")
+  }
 
   def "Merges response messages when new response messages are applied" () {
     given:


### PR DESCRIPTION
Rather than sorting parameters only by their name, sort them by their existing order field first, then use the name as a tiebreaker.
Parameter already implements Ordered, so this seems like a natural way of sorting parameters.
This also enables plugins to apply any custom parameter order they want, while the current sorting prevents that.
Currently parameters all have the initial order value of Integer.MIN_VALUE, so this change should not affect the current ordering without any additional plugins applied.