### PR TITLE
Create a FormParameter model object instead of BodyParameter

### DIFF
--- a/springfox-swagger2/src/main/java/springfox/documentation/swagger2/mappers/ParameterMapper.java
+++ b/springfox-swagger2/src/main/java/springfox/documentation/swagger2/mappers/ParameterMapper.java
@@ -62,13 +62,10 @@ public class ParameterMapper {
 
   public Parameter mapParameter(springfox.documentation.service.Parameter source) {
     Parameter parameter;
-    switch (source.getParamType()) {
-      case "formData":
-        parameter = formParameter(source);
-        break;
-      default:
-        parameter = bodyParameter(source);
-        break;
+    if ("formData".equals(source.getParamType())) {
+      parameter = formParameter(source);
+    } else {
+      parameter = bodyParameter(source);
     }
     return SerializableParameterFactories.create(source).orElse(parameter);
   }

--- a/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-bugs-different-service.json
+++ b/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-bugs-different-service.json
@@ -220,8 +220,8 @@
         "/bugs/1420": {
             "get": {
                 "tags": [
-                    "foo",
-                    "Bugs"
+                    "Bugs",
+                    "foo"
                 ],
                 "summary": "issue1420",
                 "operationId": "issue1420UsingGET_2",
@@ -493,8 +493,8 @@
                         "required": false,
                         "type": "integer",
                         "default": 0,
-                        "allowEmptyValue": false,
-                        "format": "int32"
+                        "format": "int32",
+                        "allowEmptyValue": false
                     }
                 ],
                 "responses": {
@@ -803,8 +803,8 @@
                 "summary": "method1",
                 "operationId": "method1UsingGET_2",
                 "produces": [
-                    "application/atom+xml",
-                    "application/json;charset=UTF-8"
+                    "application/json;charset=UTF-8",
+                    "application/atom+xml"
                 ],
                 "responses": {
                     "200": {
@@ -1115,8 +1115,8 @@
                         }
                     },
                     {
-                        "in": "formData",
                         "name": "sfId",
+                        "in": "formData",
                         "description": "sfId",
                         "required": true,
                         "type": "integer",
@@ -1146,72 +1146,73 @@
                 ],
                 "parameters": [
                     {
-                        "in": "formData",
                         "name": "allCapsSet",
+                        "in": "formData",
                         "description": "description of allCapsSet",
                         "required": false,
                         "type": "array",
                         "items": {
                             "type": "string"
-                        }
+                        },
+                        "collectionFormat": "multi"
                     },
                     {
-                        "in": "formData",
                         "name": "annotatedEnumType",
+                        "in": "formData",
                         "description": "description of annotatedEnumType",
                         "required": false,
                         "type": "string"
                     },
                     {
-                        "in": "formData",
                         "name": "bar",
+                        "in": "formData",
                         "description": "description of bar",
                         "required": false,
                         "type": "integer",
                         "format": "int32"
                     },
                     {
-                        "in": "formData",
                         "name": "enumType",
+                        "in": "formData",
                         "required": false,
                         "type": "string"
                     },
                     {
-                        "in": "formData",
                         "name": "foo",
+                        "in": "formData",
                         "description": "description of foo",
                         "required": true,
                         "type": "string"
                     },
                     {
-                        "in": "formData",
                         "name": "localDateTime",
+                        "in": "formData",
                         "description": "local date time desc dd-MM-yyyy hh:mm:ss",
                         "required": true,
                         "type": "string",
                         "format": "date-time"
                     },
                     {
-                        "in": "formData",
                         "name": "nestedType.name",
+                        "in": "formData",
                         "required": false,
                         "type": "string"
                     },
                     {
-                        "in": "formData",
                         "name": "parentBeanProperty",
+                        "in": "formData",
                         "required": false,
                         "type": "string"
                     },
                     {
-                        "in": "formData",
                         "name": "propertyWithNoSetterMethod",
+                        "in": "formData",
                         "required": false,
                         "type": "string"
                     },
                     {
-                        "in": "formData",
                         "name": "readOnlyString",
+                        "in": "formData",
                         "description": "A read only string",
                         "required": false,
                         "type": "string"
@@ -1443,8 +1444,8 @@
         "/bugs/2268{?$filter}": {
             "get": {
                 "tags": [
-                    "example",
-                    "Bugs"
+                    "Bugs",
+                    "example"
                 ],
                 "summary": "Get all examples",
                 "description": "Get all examples ",

--- a/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-bugs-different-service.json
+++ b/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-bugs-different-service.json
@@ -1119,10 +1119,8 @@
                         "name": "sfId",
                         "description": "sfId",
                         "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int32"
-                        }
+                        "type": "integer",
+                        "format": "int32"
                     }
                 ],
                 "responses": {
@@ -1152,11 +1150,9 @@
                         "name": "allCapsSet",
                         "description": "description of allCapsSet",
                         "required": false,
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
+                        "type": "array",
+                        "items": {
+                            "type": "string"
                         }
                     },
                     {
@@ -1164,79 +1160,61 @@
                         "name": "annotatedEnumType",
                         "description": "description of annotatedEnumType",
                         "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     {
                         "in": "formData",
                         "name": "bar",
                         "description": "description of bar",
                         "required": false,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int32"
-                        }
+                        "type": "integer",
+                        "format": "int32"
                     },
                     {
                         "in": "formData",
                         "name": "enumType",
                         "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     {
                         "in": "formData",
                         "name": "foo",
                         "description": "description of foo",
                         "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     {
                         "in": "formData",
                         "name": "localDateTime",
                         "description": "local date time desc dd-MM-yyyy hh:mm:ss",
                         "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "date-time"
-                        }
+                        "type": "string",
+                        "format": "date-time"
                     },
                     {
                         "in": "formData",
                         "name": "nestedType.name",
                         "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     {
                         "in": "formData",
                         "name": "parentBeanProperty",
                         "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     {
                         "in": "formData",
                         "name": "propertyWithNoSetterMethod",
                         "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     {
                         "in": "formData",
                         "name": "readOnlyString",
                         "description": "A read only string",
                         "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     }
                 ],
                 "responses": {

--- a/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-bugs-different-service.json
+++ b/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-bugs-different-service.json
@@ -220,8 +220,8 @@
         "/bugs/1420": {
             "get": {
                 "tags": [
-                    "Bugs",
-                    "foo"
+                    "foo",
+                    "Bugs"
                 ],
                 "summary": "issue1420",
                 "operationId": "issue1420UsingGET_2",
@@ -493,8 +493,8 @@
                         "required": false,
                         "type": "integer",
                         "default": 0,
-                        "format": "int32",
-                        "allowEmptyValue": false
+                        "allowEmptyValue": false,
+                        "format": "int32"
                     }
                 ],
                 "responses": {
@@ -803,8 +803,8 @@
                 "summary": "method1",
                 "operationId": "method1UsingGET_2",
                 "produces": [
-                    "application/json;charset=UTF-8",
-                    "application/atom+xml"
+                    "application/atom+xml",
+                    "application/json;charset=UTF-8"
                 ],
                 "responses": {
                     "200": {
@@ -1115,8 +1115,8 @@
                         }
                     },
                     {
-                        "name": "sfId",
                         "in": "formData",
+                        "name": "sfId",
                         "description": "sfId",
                         "required": true,
                         "type": "integer",
@@ -1146,8 +1146,8 @@
                 ],
                 "parameters": [
                     {
-                        "name": "allCapsSet",
                         "in": "formData",
+                        "name": "allCapsSet",
                         "description": "description of allCapsSet",
                         "required": false,
                         "type": "array",
@@ -1157,62 +1157,62 @@
                         "collectionFormat": "multi"
                     },
                     {
-                        "name": "annotatedEnumType",
                         "in": "formData",
+                        "name": "annotatedEnumType",
                         "description": "description of annotatedEnumType",
                         "required": false,
                         "type": "string"
                     },
                     {
-                        "name": "bar",
                         "in": "formData",
+                        "name": "bar",
                         "description": "description of bar",
                         "required": false,
                         "type": "integer",
                         "format": "int32"
                     },
                     {
-                        "name": "enumType",
                         "in": "formData",
+                        "name": "enumType",
                         "required": false,
                         "type": "string"
                     },
                     {
-                        "name": "foo",
                         "in": "formData",
+                        "name": "foo",
                         "description": "description of foo",
                         "required": true,
                         "type": "string"
                     },
                     {
-                        "name": "localDateTime",
                         "in": "formData",
+                        "name": "localDateTime",
                         "description": "local date time desc dd-MM-yyyy hh:mm:ss",
                         "required": true,
                         "type": "string",
                         "format": "date-time"
                     },
                     {
+                        "in": "formData",
                         "name": "nestedType.name",
-                        "in": "formData",
                         "required": false,
                         "type": "string"
                     },
                     {
+                        "in": "formData",
                         "name": "parentBeanProperty",
-                        "in": "formData",
                         "required": false,
                         "type": "string"
                     },
                     {
+                        "in": "formData",
                         "name": "propertyWithNoSetterMethod",
-                        "in": "formData",
                         "required": false,
                         "type": "string"
                     },
                     {
-                        "name": "readOnlyString",
                         "in": "formData",
+                        "name": "readOnlyString",
                         "description": "A read only string",
                         "required": false,
                         "type": "string"

--- a/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-bugs-service.json
+++ b/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-bugs-service.json
@@ -213,8 +213,8 @@
         "/bugs/1420": {
             "get": {
                 "tags": [
-                    "Bugs",
-                    "foo"
+                    "foo",
+                    "Bugs"
                 ],
                 "summary": "issue1420",
                 "operationId": "issue1420UsingGET_1",
@@ -497,8 +497,8 @@
                         "required": false,
                         "type": "integer",
                         "default": 0,
-                        "format": "int32",
-                        "allowEmptyValue": false
+                        "allowEmptyValue": false,
+                        "format": "int32"
                     }
                 ],
                 "responses": {
@@ -807,8 +807,8 @@
                 "summary": "method1",
                 "operationId": "method1UsingGET_1",
                 "produces": [
-                    "application/json;charset=UTF-8",
-                    "application/atom+xml"
+                    "application/atom+xml",
+                    "application/json;charset=UTF-8"
                 ],
                 "responses": {
                     "200": {
@@ -1119,8 +1119,8 @@
                         }
                     },
                     {
-                        "name": "sfId",
                         "in": "formData",
+                        "name": "sfId",
                         "description": "sfId",
                         "required": true,
                         "type": "integer",
@@ -1150,8 +1150,8 @@
                 ],
                 "parameters": [
                     {
-                        "name": "allCapsSet",
                         "in": "formData",
+                        "name": "allCapsSet",
                         "description": "description of allCapsSet",
                         "required": false,
                         "type": "array",
@@ -1161,62 +1161,62 @@
                         "collectionFormat": "multi"
                     },
                     {
-                        "name": "annotatedEnumType",
                         "in": "formData",
+                        "name": "annotatedEnumType",
                         "description": "description of annotatedEnumType",
                         "required": false,
                         "type": "string"
                     },
                     {
-                        "name": "bar",
                         "in": "formData",
+                        "name": "bar",
                         "description": "description of bar",
                         "required": false,
                         "type": "integer",
                         "format": "int32"
                     },
                     {
-                        "name": "enumType",
                         "in": "formData",
+                        "name": "enumType",
                         "required": false,
                         "type": "string"
                     },
                     {
-                        "name": "foo",
                         "in": "formData",
+                        "name": "foo",
                         "description": "description of foo",
                         "required": true,
                         "type": "string"
                     },
                     {
-                        "name": "localDateTime",
                         "in": "formData",
+                        "name": "localDateTime",
                         "description": "local date time desc dd-MM-yyyy hh:mm:ss",
                         "required": true,
                         "type": "string",
                         "format": "date-time"
                     },
                     {
+                        "in": "formData",
                         "name": "nestedType.name",
-                        "in": "formData",
                         "required": false,
                         "type": "string"
                     },
                     {
+                        "in": "formData",
                         "name": "parentBeanProperty",
-                        "in": "formData",
                         "required": false,
                         "type": "string"
                     },
                     {
+                        "in": "formData",
                         "name": "propertyWithNoSetterMethod",
-                        "in": "formData",
                         "required": false,
                         "type": "string"
                     },
                     {
-                        "name": "readOnlyString",
                         "in": "formData",
+                        "name": "readOnlyString",
                         "description": "A read only string",
                         "required": false,
                         "type": "string"
@@ -1448,8 +1448,8 @@
         "/bugs/2268{?$filter}": {
             "get": {
                 "tags": [
-                    "Bugs",
-                    "example"
+                    "example",
+                    "Bugs"
                 ],
                 "summary": "Get all examples",
                 "description": "Get all examples ",

--- a/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-bugs-service.json
+++ b/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-bugs-service.json
@@ -213,8 +213,8 @@
         "/bugs/1420": {
             "get": {
                 "tags": [
-                    "foo",
-                    "Bugs"
+                    "Bugs",
+                    "foo"
                 ],
                 "summary": "issue1420",
                 "operationId": "issue1420UsingGET_1",
@@ -497,8 +497,8 @@
                         "required": false,
                         "type": "integer",
                         "default": 0,
-                        "allowEmptyValue": false,
-                        "format": "int32"
+                        "format": "int32",
+                        "allowEmptyValue": false
                     }
                 ],
                 "responses": {
@@ -807,8 +807,8 @@
                 "summary": "method1",
                 "operationId": "method1UsingGET_1",
                 "produces": [
-                    "application/atom+xml",
-                    "application/json;charset=UTF-8"
+                    "application/json;charset=UTF-8",
+                    "application/atom+xml"
                 ],
                 "responses": {
                     "200": {
@@ -1119,8 +1119,8 @@
                         }
                     },
                     {
-                        "in": "formData",
                         "name": "sfId",
+                        "in": "formData",
                         "description": "sfId",
                         "required": true,
                         "type": "integer",
@@ -1150,69 +1150,73 @@
                 ],
                 "parameters": [
                     {
-                        "in": "formData",
                         "name": "allCapsSet",
+                        "in": "formData",
                         "description": "description of allCapsSet",
                         "required": false,
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi"
                     },
                     {
-                        "in": "formData",
                         "name": "annotatedEnumType",
+                        "in": "formData",
                         "description": "description of annotatedEnumType",
                         "required": false,
                         "type": "string"
                     },
                     {
-                        "in": "formData",
                         "name": "bar",
+                        "in": "formData",
                         "description": "description of bar",
                         "required": false,
                         "type": "integer",
                         "format": "int32"
                     },
                     {
-                        "in": "formData",
                         "name": "enumType",
+                        "in": "formData",
                         "required": false,
                         "type": "string"
                     },
                     {
-                        "in": "formData",
                         "name": "foo",
+                        "in": "formData",
                         "description": "description of foo",
                         "required": true,
                         "type": "string"
                     },
                     {
-                        "in": "formData",
                         "name": "localDateTime",
+                        "in": "formData",
                         "description": "local date time desc dd-MM-yyyy hh:mm:ss",
                         "required": true,
                         "type": "string",
                         "format": "date-time"
                     },
                     {
-                        "in": "formData",
                         "name": "nestedType.name",
+                        "in": "formData",
                         "required": false,
                         "type": "string"
                     },
                     {
-                        "in": "formData",
                         "name": "parentBeanProperty",
+                        "in": "formData",
                         "required": false,
                         "type": "string"
                     },
                     {
-                        "in": "formData",
                         "name": "propertyWithNoSetterMethod",
+                        "in": "formData",
                         "required": false,
                         "type": "string"
                     },
                     {
-                        "in": "formData",
                         "name": "readOnlyString",
+                        "in": "formData",
                         "description": "A read only string",
                         "required": false,
                         "type": "string"
@@ -1444,8 +1448,8 @@
         "/bugs/2268{?$filter}": {
             "get": {
                 "tags": [
-                    "example",
-                    "Bugs"
+                    "Bugs",
+                    "example"
                 ],
                 "summary": "Get all examples",
                 "description": "Get all examples ",

--- a/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-bugs-service.json
+++ b/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-bugs-service.json
@@ -1123,10 +1123,8 @@
                         "name": "sfId",
                         "description": "sfId",
                         "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int32"
-                        }
+                        "type": "integer",
+                        "format": "int32"
                     }
                 ],
                 "responses": {
@@ -1156,91 +1154,68 @@
                         "name": "allCapsSet",
                         "description": "description of allCapsSet",
                         "required": false,
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        }
+                        "type": "string"
                     },
                     {
                         "in": "formData",
                         "name": "annotatedEnumType",
                         "description": "description of annotatedEnumType",
                         "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     {
                         "in": "formData",
                         "name": "bar",
                         "description": "description of bar",
                         "required": false,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int32"
-                        }
+                        "type": "integer",
+                        "format": "int32"
                     },
                     {
                         "in": "formData",
                         "name": "enumType",
                         "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     {
                         "in": "formData",
                         "name": "foo",
                         "description": "description of foo",
                         "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     {
                         "in": "formData",
                         "name": "localDateTime",
                         "description": "local date time desc dd-MM-yyyy hh:mm:ss",
                         "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "date-time"
-                        }
+                        "type": "string",
+                        "format": "date-time"
                     },
                     {
                         "in": "formData",
                         "name": "nestedType.name",
                         "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     {
                         "in": "formData",
                         "name": "parentBeanProperty",
                         "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     {
                         "in": "formData",
                         "name": "propertyWithNoSetterMethod",
                         "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     {
                         "in": "formData",
                         "name": "readOnlyString",
                         "description": "A read only string",
                         "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     }
                 ],
                 "responses": {


### PR DESCRIPTION
This fixes  #2717 by creating the right Swagger model class for parameters of type "formData".
Since those parameters only support a single example, I've also opted to simply copy over the first one.