### PR TITLE
Ignore the base class in the list of @JsonSubTypes

### DIFF
--- a/springfox-schema/src/main/java/springfox/documentation/schema/plugins/PropertyDiscriminatorBasedInheritancePlugin.java
+++ b/springfox-schema/src/main/java/springfox/documentation/schema/plugins/PropertyDiscriminatorBasedInheritancePlugin.java
@@ -67,12 +67,15 @@ public class PropertyDiscriminatorBasedInheritancePlugin implements ModelBuilder
   }
 
   private List<ModelReference> modelRefs(ModelContext context) {
-    JsonSubTypes subTypes = AnnotationUtils.getAnnotation(forClass(context), JsonSubTypes.class);
+    Class<?> containingClass = forClass(context);
+    JsonSubTypes subTypes = AnnotationUtils.getAnnotation(containingClass, JsonSubTypes.class);
     List<ModelReference> modelRefs = new ArrayList<>();
     if (subTypes != null) {
       for (JsonSubTypes.Type each : subTypes.value()) {
-        modelRefs.add(modelRefFactory(context, typeNameExtractor)
-            .apply(typeResolver.resolve(each.value())));
+        if (each.value() != containingClass) {
+          modelRefs.add(modelRefFactory(context, typeNameExtractor)
+                .apply(typeResolver.resolve(each.value())));
+        }
       }
     }
     return modelRefs;

--- a/springfox-schema/src/test/groovy/springfox/documentation/schema/plugins/PropertyDiscriminatorBasedInheritancePluginSpec.groovy
+++ b/springfox-schema/src/test/groovy/springfox/documentation/schema/plugins/PropertyDiscriminatorBasedInheritancePluginSpec.groovy
@@ -92,6 +92,7 @@ class PropertyDiscriminatorBasedInheritancePluginSpec extends Specification {
       property = "type"
   )
   @JsonSubTypes([
+    @JsonSubTypes.Type(value = A4, name = "a4"),
     @JsonSubTypes.Type(value = B1, name = "b1"),
     @JsonSubTypes.Type(value = B2, name = "b2")
   ])


### PR DESCRIPTION
Fixes #2724 by ignoring the base class found in the `@JsonSubTypes` annotation.

The generated schema still has issues, but at least it doesn't crash code generators anymore.