### PR TITLE
Improved signature of docket.getGlobalResponseMessage to allow for li…

### DIFF
--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/plugins/Docket.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/plugins/Docket.java
@@ -193,8 +193,7 @@ public class Docket implements DocumentationPlugin {
    */
   public Docket globalResponseMessage(List<RequestMethod> requestMethods,
                                        List<ResponseMessage> responseMessages) {
-    for(RequestMethod requestMethod : requestMethods)
-    {
+    for(RequestMethod requestMethod : requestMethods) {
       this.globalResponseMessage(requestMethod, responseMessages);
     }
 

--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/plugins/Docket.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/plugins/Docket.java
@@ -180,6 +180,28 @@ public class Docket implements DocumentationPlugin {
   }
 
   /**
+   * Convience method to override multiple default http response messages at the http request method level.
+   *
+   * To set specific response messages for specific api operations use the swagger core annotations on
+   * the appropiate controller methods.
+   *
+   * @param requestMethods - list of http request methods for which to apply the message
+   * @param responseMessages - the message
+   * @return this Docket
+   * {@code See swagger annotations <code>@ApiResponse</code>, <code>@ApiResponses</code> }.
+   *  @see springfox.documentation.spi.service.contexts.Defaults#defaultResponseMessages()
+   */
+  public Docket globalResponseMessage(List<RequestMethod> requestMethods,
+                                       List<ResponseMessage> responseMessages) {
+    for(RequestMethod requestMethod : requestMethods)
+    {
+      this.globalResponseMessage(requestMethod, responseMessages);
+    }
+
+    return this;
+  }
+
+  /**
    * Overrides the default http response messages at the http request method level.
    *
    * To set specific response messages for specific api operations use the swagger core annotations on

--- a/springfox-spring-webmvc/src/test/groovy/springfox/documentation/spring/web/plugins/DocketSpec.groovy
+++ b/springfox-spring-webmvc/src/test/groovy/springfox/documentation/spring/web/plugins/DocketSpec.groovy
@@ -94,6 +94,35 @@ class DocketSpec extends DocumentationContextSpec {
     )
   }
 
+  def "Swagger global response messages should override the default for a list of RequestMethods"() {
+    when:
+    plugin
+            .globalResponseMessage(Arrays.asList(GET,POST), [new ResponseMessage(
+            OK.value(),
+            "blah",
+            null,
+            [],
+            [] as Map,
+            [])])
+            .useDefaultResponseMessages(true)
+            .configure(contextBuilder)
+
+    and:
+    def pluginContext = contextBuilder.build()
+
+    then:
+    pluginContext.getGlobalResponseMessages()[GET][0].getMessage() == "blah"
+    pluginContext.getGlobalResponseMessages()[GET].size() == 1
+
+    pluginContext.getGlobalResponseMessages()[POST][0].getMessage() == "blah"
+    pluginContext.getGlobalResponseMessages()[POST].size() == 1
+
+    and: "defaults are preserved"
+    pluginContext.getGlobalResponseMessages().keySet().containsAll(
+            [PUT, DELETE, PATCH, TRACE, OPTIONS, HEAD]
+    )
+  }
+
   def "Verify configurer behavior"() {
     when:
     plugin.enable(true)

--- a/springfox-swagger1/src/test/groovy/springfox/documentation/swagger1/integration/DocketSpec.groovy
+++ b/springfox-swagger1/src/test/groovy/springfox/documentation/swagger1/integration/DocketSpec.groovy
@@ -67,6 +67,35 @@ class DocketSpec extends DocumentationContextSpec {
     pluginContext.pathProvider instanceof DummyPathProvider // this one is dummy as this is what we have in test ctx
   }
 
+  def "Swagger global response messages should override the default for a list of RequestMethods"() {
+    when:
+    plugin
+            .globalResponseMessage(Arrays.asList(GET,POST), [new ResponseMessage(
+            OK.value(),
+            "blah",
+            null,
+            [],
+            [] as Map,
+            [])])
+            .useDefaultResponseMessages(true)
+            .configure(contextBuilder)
+
+    and:
+    def pluginContext = contextBuilder.build()
+
+    then:
+    pluginContext.getGlobalResponseMessages()[GET][0].getMessage() == "blah"
+    pluginContext.getGlobalResponseMessages()[GET].size() == 1
+
+    pluginContext.getGlobalResponseMessages()[POST][0].getMessage() == "blah"
+    pluginContext.getGlobalResponseMessages()[POST].size() == 1
+
+    and: "defaults are preserved"
+    pluginContext.getGlobalResponseMessages().keySet().containsAll(
+            [PUT, DELETE, PATCH, TRACE, OPTIONS, HEAD]
+    )
+  }
+
   def "Swagger global response messages should override the default for a particular RequestMethod"() {
     when:
     plugin


### PR DESCRIPTION
…st of requestMethods.

#### What's this PR do/fix?
This PR adds a new method to the Docket class. The new method overrides the signature of Docket.getGlobalResponseMessage to accept a list of RequestMethods. No changes were made to existing Docket.getGlobalResponseMessage method or tests. 
#### Are there unit tests? If not how should this be manually tested?
Yes, there are two new unit tests under the DocketSpec.groovy test classes. 
#### Any background context you want to provide?
See #2571 for relevant background. 
#### What are the relevant issues?
#2571 
