### PR TITLE
add support for deprecated controllers

### DIFF
--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/operation/OperationDeprecatedReader.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/operation/OperationDeprecatedReader.java
@@ -34,8 +34,11 @@ import java.util.Optional;
 public class OperationDeprecatedReader implements OperationBuilderPlugin {
   @Override
   public void apply(OperationContext context) {
-    Optional<Deprecated> annotation = context.findAnnotation(Deprecated.class);
-    context.operationBuilder().deprecated(String.valueOf(annotation.isPresent()));
+    Optional<Deprecated> annotationOnMethod = context.findAnnotation(Deprecated.class);
+    Optional<Deprecated> annotationOnController = context.findControllerAnnotation(Deprecated.class);
+
+    context.operationBuilder().deprecated(String.valueOf(annotationOnMethod.isPresent() ||
+                                                         annotationOnController.isPresent()));
   }
 
   @Override

--- a/springfox-spring-web/src/test/java/springfox/documentation/spring/web/dummy/DummyController.java
+++ b/springfox-spring-web/src/test/java/springfox/documentation/spring/web/dummy/DummyController.java
@@ -27,6 +27,6 @@ import org.springframework.stereotype.Controller;
 public class DummyController {
 
   public void dummyMethod() {
-
+    //just a dummy method for testing
   }
 }

--- a/springfox-spring-web/src/test/java/springfox/documentation/spring/web/dummy/DummyDeprecatedController.java
+++ b/springfox-spring-web/src/test/java/springfox/documentation/spring/web/dummy/DummyDeprecatedController.java
@@ -1,0 +1,31 @@
+/*
+ *
+ *  Copyright 2015 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+
+package springfox.documentation.spring.web.dummy;
+
+import org.springframework.stereotype.Controller;
+
+@Controller
+@Deprecated
+public class DummyDeprecatedController {
+
+  public void dummyMethod() {
+
+  }
+}

--- a/springfox-spring-webmvc/src/test/groovy/springfox/documentation/spring/web/mixins/RequestMappingSupport.groovy
+++ b/springfox-spring-webmvc/src/test/groovy/springfox/documentation/spring/web/mixins/RequestMappingSupport.groovy
@@ -38,6 +38,7 @@ import springfox.documentation.spring.web.dummy.DummyController
 import springfox.documentation.spring.web.dummy.DummyControllerWithApiDescription
 import springfox.documentation.spring.web.dummy.DummyControllerWithResourcePath
 import springfox.documentation.spring.web.dummy.DummyControllerWithTags
+import springfox.documentation.spring.web.dummy.DummyDeprecatedController
 import springfox.documentation.spring.web.dummy.controllers.FancyPetService
 import springfox.documentation.spring.web.dummy.controllers.PetGroomingService
 import springfox.documentation.spring.web.dummy.controllers.PetService
@@ -149,6 +150,15 @@ class RequestMappingSupport {
       parameterTypes = String) {
 
     def clazz = new PetGroomingService()
+    Class c = clazz.getClass()
+    new HandlerMethod(clazz, c.getMethod(methodName, parameterTypes))
+  }
+
+  HandlerMethod dummyDeprecatedController(
+          String methodName = "dummyMethod",
+          Class<?>... parameterTypes = null) {
+
+    def clazz = new DummyDeprecatedController()
     Class c = clazz.getClass()
     new HandlerMethod(clazz, c.getMethod(methodName, parameterTypes))
   }

--- a/springfox-spring-webmvc/src/test/groovy/springfox/documentation/spring/web/readers/operation/OperationCommandReaderSpec.groovy
+++ b/springfox-spring-webmvc/src/test/groovy/springfox/documentation/spring/web/readers/operation/OperationCommandReaderSpec.groovy
@@ -47,6 +47,7 @@ class OperationCommandReaderSpec extends DocumentationContextSpec {
       new DefaultOperationReader()    | 'uniqueId'   | dummyHandlerMethod()                       | 'dummyMethodUsingGET'
       new DefaultOperationReader()    | 'position'   | dummyHandlerMethod()                       | CURRENT_COUNT
       new OperationDeprecatedReader() | 'deprecated' | dummyHandlerMethod('methodWithDeprecated') | 'true'
+      new OperationDeprecatedReader() | 'deprecated' | dummyDeprecatedController()                | 'true'
       new OperationDeprecatedReader() | 'deprecated' | dummyHandlerMethod()                       | 'false'
   }
 


### PR DESCRIPTION
#### What's this PR do/fix?

Fixes #2638 and adds support for deprecated controllers

#### Are there unit tests? If not how should this be manually tested?

Added a test to `OperationCommandReaderSpec`.

#### Any background context you want to provide?

The change should be clear by itself I guess.

#### What are the relevant issues?

#2638 