### PR TITLE
Expose GenericTypeNamingStrategy in the Docket

### DIFF
--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/plugins/Docket.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/plugins/Docket.java
@@ -364,11 +364,25 @@ public class Docket implements DocumentationPlugin {
    *
    * @param forCodeGen - true|false determines the naming strategy used
    * @return this Docket
+   * @see #genericTypeNamingStrategy
    */
   public Docket forCodeGeneration(boolean forCodeGen) {
     if (forCodeGen) {
       genericsNamingStrategy = new CodeGenGenericTypeNamingStrategy();
     }
+    return this;
+  }
+  
+  /**
+   * Replaces the springfox.documentation.spi.schema.GenericTypeNamingStrategy.
+   * This allows to replace the influence the strategy to provide names for generic types in the swagger output.
+   *
+   * @param strategy - the new strategy
+   * @return this Docket
+   * @see #forCodeGeneration
+   */
+  public Docket genericTypeNamingStrategy(GenericTypeNamingStrategy strategy){
+    genericsNamingStrategy = strategy;
     return this;
   }
 


### PR DESCRIPTION
The current `forCodeGeneration` method only allows to switch between two hardcoded  `GenericTypeNamingStrategy` implementations. Neither of them can deal with both generics and spaces. E.g. if you have a class

````
@ApiModel(value = "Foo Bar", description = "lorem ipsum")
public final class FooBar<T>{

}
````
the generated Swagger specification file still results in  `$ref values must be RFC3986-compliant percent-encoded URIs` warnings, even when calling `forCodeGeneration(true)`.

By allowing to replace the `GenericTypeNamingStrategy`, people can set their own naming strategy

#### What's this PR do/fix?
#### Are there unit tests? If not how should this be manually tested?
#### Any background context you want to provide?
#### What are the relevant issues?
