### PR TITLE
Keep query params on redirect

### DIFF
--- a/docs/asciidoc/common-problems.adoc
+++ b/docs/asciidoc/common-problems.adoc
@@ -259,7 +259,7 @@ For e.g. One could move Swagger UI under `/documentation` using this code.
 	@Override
 	public void addViewControllers(ViewControllerRegistry registry) {
 	
-		registry.addRedirectViewController("/documentation/v2/api-docs", "/v2/api-docs?group=restful-api");
+		registry.addRedirectViewController("/documentation/v2/api-docs", "/v2/api-docs").setKeepQueryParams(true);
         	registry.addRedirectViewController("/documentation/swagger-resources/configuration/ui","/swagger-resources/configuration/ui");
         	registry.addRedirectViewController("/documentation/swagger-resources/configuration/security","/swagger-resources/configuration/security");
         	registry.addRedirectViewController("/documentation/swagger-resources", "/swagger-resources");


### PR DESCRIPTION
Keep the query params when redirecting Swagger-UI.

#### What's this PR do/fix?
Updates a example in the documentation relating to moving swagger-ui. The updated example ensures that the query parameters are kept when redirecting.

#### Are there unit tests? If not how should this be manually tested?
-
#### Any background context you want to provide?
The current example hard codes a query parameter that causes issues.

#### What are the relevant issues?
-