### PR TITLE
Only hidden operation when the hidden property is true

### DIFF
--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/operation/OperationHiddenReader.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/operation/OperationHiddenReader.java
@@ -37,7 +37,7 @@ public class OperationHiddenReader implements OperationBuilderPlugin {
   public void apply(OperationContext context) {
 
     Optional<ApiOperation> methodAnnotation = context.findAnnotation(ApiOperation.class);
-    if (methodAnnotation.isPresent()) {
+    if (methodAnnotation.isPresent() && methodAnnotation.get().hidden()) {
       context.operationBuilder().hidden(methodAnnotation.get().hidden());
     }
   }


### PR DESCRIPTION
I have custom constraint check on the swagger specification. I need hidden the operation which violated the constraint; But it is not work on the parameter constraint check which extended `ParameterBuilderPlugin`; When deep into the source code of `springfox`, i found the `OperationHiddenReader` set hidden false. And it processing after the  `ParameterBuilderPlugin` lifecycle. So can only hidden operation when the hidden property is true? It is convenient for developer to do custom constraint check.