### PR TITLE
Expose the 'showCommonExtensions' configuration available in swagger-ui

### DIFF
--- a/springfox-spring-config/src/main/java/springfox/springconfig/Swagger2SpringBoot.java
+++ b/springfox-spring-config/src/main/java/springfox/springconfig/Swagger2SpringBoot.java
@@ -157,6 +157,7 @@ public class Swagger2SpringBoot {
         .maxDisplayedTags(null)
         .operationsSorter(OperationsSorter.ALPHA)
         .showExtensions(false)
+        .showCommonExtensions(false)
         .tagsSorter(TagsSorter.ALPHA)
         .supportedSubmitMethods(UiConfiguration.Constants.DEFAULT_SUBMIT_METHODS)
         .validatorUrl(null)

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/UiConfiguration.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/UiConfiguration.java
@@ -46,6 +46,7 @@ public class UiConfiguration {
   private final Integer maxDisplayedTags;
   private final OperationsSorter operationsSorter;
   private final Boolean showExtensions;
+  private final Boolean showCommonExtensions;
   private final TagsSorter tagsSorter;
   private final String validatorUrl;
   /**
@@ -192,6 +193,7 @@ public class UiConfiguration {
     this.maxDisplayedTags = null;
     this.operationsSorter = OperationsSorter.of(apisSorter);
     this.showExtensions = false;
+    this.showCommonExtensions = false;
     this.tagsSorter = TagsSorter.of(apisSorter);
   }
 
@@ -260,6 +262,7 @@ public class UiConfiguration {
         maxDisplayedTags,
         operationsSorter,
         showExtensions,
+        false,
         tagsSorter,
         Constants.DEFAULT_SUBMIT_METHODS,
         validatorUrl);
@@ -323,6 +326,86 @@ public class UiConfiguration {
       TagsSorter tagsSorter,
       String[] supportedSubmitMethods,
       String validatorUrl) {
+        this(
+          deepLinking,
+          displayOperationId,
+          defaultModelsExpandDepth,
+          defaultModelExpandDepth,
+          defaultModelRendering,
+          displayRequestDuration,
+          docExpansion,
+          filter,
+          maxDisplayedTags,
+          operationsSorter,
+          showExtensions,
+          false,
+          tagsSorter,
+          supportedSubmitMethods,
+          validatorUrl);
+    this.apisSorter = "alpha";
+  }
+  
+  /**
+   * Default constructor
+   *
+   * @param deepLinking              If set to true, enables deep linking for tags and operations. See the Deep Linking
+   *                                 documentation for more information.
+   * @param displayOperationId       Controls the display of operationId in operations list. The default is false.
+   * @param defaultModelsExpandDepth The default expansion depth for models (set to -1 completely hide the models).
+   * @param defaultModelExpandDepth  The default expansion depth for the model on the model-example section.
+   * @param defaultModelRendering    Controls how the model is shown when the API is first rendered. (The user can
+   *                                 always switch the rendering for a given model by clicking the 'Model' and 'Example
+   *                                 Value' links.)
+   * @param displayRequestDuration   Controls the display of the request duration (in milliseconds) for Try-It-Out
+   *                                 requests.
+   * @param docExpansion             Controls the default expansion setting for the operations and tags. It can be
+   *                                 'list' (expands only the tags), 'full' (expands the tags and operations) or 'none'
+   *                                 (expands nothing).
+   * @param filter                   If set, enables filtering. The top bar will show an edit box that you can use to
+   *                                 filter the tagged operations that are shown. Can be Boolean to enable or disable,
+   *                                 or a string, in which case filtering will be enabled using that string as the
+   *                                 filter expression. Filtering is case sensitive matching the filter expression
+   *                                 anywhere inside the tag.
+   * @param maxDisplayedTags         If set, limits the number of tagged operations displayed to at most this many. The
+   *                                 default is to show all operations.
+   * @param operationsSorter         Apply a sort to the operation list of each API. It can be 'alpha' (sort by paths
+   *                                 alphanumerically), 'method' (sort by HTTP method) or a function (see
+   *                                 Array.prototype.sort() to know how sort function works). Default is the order
+   *                                 returned by the server unchanged.
+   * @param showExtensions           Controls the display of vendor extension (x-) fields and values for Operations,
+   *                                 Parameters, and Schema.
+   * @param showCommonExtensions     Controls the display of extensions (pattern, maxLength, minLength, maximum, 
+   *                                 minimum) fields and values for Parameters.
+   * @param tagsSorter               Apply a sort to the tag list of each API. It can be 'alpha' (sort by paths
+   *                                 alphanumerically) or a function (see Array.prototype.sort() to learn how to write a
+   *                                 sort function). Two tag name strings are passed to the sorter for each pass.
+   *                                 Default is the order determined by Swagger-UI.
+   * @param supportedSubmitMethods   List of HTTP methods that have the Try it out feature enabled. An empty array
+   *                                 disables Try it out for all operations. This does not filter the operations from
+   *                                 the
+   *                                 display.
+   * @param validatorUrl             By default, Swagger-UI attempts to validate specs against swagger.io's online
+   *                                 validator. You can use this parameter to set a different validator URL, for example
+   *                                 for locally deployed validators (Validator Badge). Setting it to null will disable
+   *                                 validation. This parameter is relevant for Swagger 2.0 specs only.
+   */
+  @SuppressWarnings("ParameterNumber")
+  public UiConfiguration(
+      Boolean deepLinking,
+      Boolean displayOperationId,
+      Integer defaultModelsExpandDepth,
+      Integer defaultModelExpandDepth,
+      ModelRendering defaultModelRendering,
+      Boolean displayRequestDuration,
+      DocExpansion docExpansion,
+      Object filter,
+      Integer maxDisplayedTags,
+      OperationsSorter operationsSorter,
+      Boolean showExtensions,
+      Boolean showCommonExtensions,
+      TagsSorter tagsSorter,
+      String[] supportedSubmitMethods,
+      String validatorUrl) {
     this.apisSorter = "alpha";
     this.deepLinking = deepLinking;
     this.displayOperationId = displayOperationId;
@@ -335,6 +418,7 @@ public class UiConfiguration {
     this.maxDisplayedTags = maxDisplayedTags;
     this.operationsSorter = operationsSorter;
     this.showExtensions = showExtensions;
+    this.showCommonExtensions = showCommonExtensions; 
     this.tagsSorter = tagsSorter;
     this.supportedSubmitMethods = supportedSubmitMethods;
     this.validatorUrl = validatorUrl;
@@ -433,6 +517,11 @@ public class UiConfiguration {
   @JsonProperty("showExtensions")
   public Boolean getShowExtensions() {
     return showExtensions;
+  }
+  
+  @JsonProperty("showCommonExtensions")
+  public Boolean getShowCommonExtensions() {
+    return showCommonExtensions;
   }
 
   @JsonProperty("tagsSorter")

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/UiConfigurationBuilder.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/UiConfigurationBuilder.java
@@ -36,6 +36,7 @@ public class UiConfigurationBuilder {
   private Integer maxDisplayedTags;
   private OperationsSorter operationsSorter;
   private Boolean showExtensions;
+  private Boolean showCommonExtensions;
   private TagsSorter tagsSorter;
 
   /*--------------------------------------------*\
@@ -64,6 +65,7 @@ public class UiConfigurationBuilder {
         defaultIfAbsent(maxDisplayedTags, null),
         defaultIfAbsent(operationsSorter, OperationsSorter.ALPHA),
         defaultIfAbsent(showExtensions, false),
+        defaultIfAbsent(showCommonExtensions, false),
         defaultIfAbsent(tagsSorter, TagsSorter.ALPHA),
         defaultIfAbsent(supportedSubmitMethods, UiConfiguration.Constants.DEFAULT_SUBMIT_METHODS),
         defaultIfAbsent(validatorUrl, null)
@@ -178,6 +180,16 @@ public class UiConfigurationBuilder {
    */
   public UiConfigurationBuilder showExtensions(Boolean showExtensions) {
     this.showExtensions = showExtensions;
+    return this;
+  }
+  
+  /**
+   * @param showCommonExtensions     Controls the display of extensions (pattern, maxLength, minLength, maximum, 
+   *                                 minimum) fields and values for Parameters.
+   * @return this
+   */
+  public UiConfigurationBuilder showCommonExtensions(Boolean showCommonExtensions) {
+    this.showCommonExtensions = showCommonExtensions;
     return this;
   }
 

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/web/ApiResourceControllerSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/web/ApiResourceControllerSpec.groovy
@@ -60,6 +60,7 @@ class ApiResourceControllerSpec extends Specification {
     "maxDisplayedTags": 1000,
     "operationsSorter": "alpha",
     "showExtensions": false,
+    "showCommonExtensions": false,
     "tagsSorter": "alpha",
     "supportedSubmitMethods":["get","put","post","delete","options","head","patch","trace"],
     "validatorUrl": "/validate"
@@ -105,6 +106,7 @@ class ApiResourceControllerSpec extends Specification {
           .maxDisplayedTags(1000)
           .operationsSorter(OperationsSorter.ALPHA)
           .showExtensions(false)
+          .showCommonExtensions(false)
           .tagsSorter(TagsSorter.ALPHA)
           .supportedSubmitMethods(UiConfiguration.Constants.DEFAULT_SUBMIT_METHODS)
           .validatorUrl("/validate")

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/web/UiConfigurationBuilderSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/web/UiConfigurationBuilderSpec.groovy
@@ -39,6 +39,7 @@ class UiConfigurationBuilderSpec extends Specification {
       "    \"docExpansion\": \"none\",\n" +
       "    \"filter\": false,\n" +
       "    \"operationsSorter\": \"alpha\",\n" +
+      "    \"showCommonExtensions\": false,\n" +
       "    \"showExtensions\": false,\n" +
       "    \"tagsSorter\": \"alpha\",\n" +
       "    \"supportedSubmitMethods\": [\"get\",\"put\",\"post\",\"delete\",\"options\",\"head\",\"patch\"," +

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/web/UiConfigurationSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/web/UiConfigurationSpec.groovy
@@ -39,6 +39,7 @@ class UiConfigurationSpec extends Specification {
       "    \"docExpansion\": \"none\",\n" +
       "    \"filter\": false,\n" +
       "    \"operationsSorter\": \"alpha\",\n" +
+      "    \"showCommonExtensions\": false,\n" +
       "    \"showExtensions\": false,\n" +
       "    \"tagsSorter\": \"alpha\",\n" +
       "    \"validatorUrl\": \"validator:urn\"\n" +
@@ -58,6 +59,7 @@ class UiConfigurationSpec extends Specification {
       "    \"docExpansion\": \"none\",\n" +
       "    \"filter\": false,\n" +
       "    \"operationsSorter\": \"alpha\",\n" +
+      "    \"showCommonExtensions\": false,\n" +
       "    \"showExtensions\": false,\n" +
       "    \"tagsSorter\": \"alpha\",\n" +
       "    \"validatorUrl\": \"\"\n" +

--- a/springfox-swagger-ui/src/web/js/springfox.js
+++ b/springfox-swagger-ui/src/web/js/springfox.js
@@ -91,6 +91,7 @@ window.onload = () => {
       maxDisplayedTags: configUI.maxDisplayedTags,
       operationsSorter: configUI.operationsSorter,
       showExtensions: configUI.showExtensions,
+      showCommonExtensions: configUI.showCommonExtensions,
       tagSorter: configUI.tagSorter,
       /*--------------------------------------------*\
        * Network


### PR DESCRIPTION


Co-authored-by: Ippei Nawate <saku.ni63@gmail.com>
Co-authored-by: Benoit <b.wiart@ubik-ingenierie.com>

#### What's this PR do/fix?
Expose the 'showCommonExtensions' configuration available in swagger-ui
through springfox UiConfiguration and UiConfigurationBuilder
It's available in swagger-ui since v3.14.0

#### Are there unit tests? If not how should this be manually tested?
Yes

#### Any background context you want to provide?
Based on PR #2663 from Ippei Nawate
Rebased for master 
Add missing modification of springfox ui  js and keep the backward compatibility by adding a new constructor in UiConfiguration

#### What are the relevant issues?
#2402