### PR TITLE
2967: disable DocumentationPluginsBootstrapper if spring-integration-plugin is present

### DIFF
--- a/springfox-spring-integration/src/main/java/springfox/documentation/spring/web/package-info.java
+++ b/springfox-spring-integration/src/main/java/springfox/documentation/spring/web/package-info.java
@@ -41,7 +41,7 @@
  * <p>
  * Changes in existing code:
  * <ul>
- * <li>{@code @Conditional(SpringIntegrationNotPresentInClassPathCondition.class)} on
+ * <li>{@code @Conditional(SpringIntegrationPluginNotPresentInClassPathCondition.class)} on
  * {@link springfox.documentation.spring.web.plugins.DocumentationPluginsBootstrapper} to avoid bootstrapping
  * the documentation plugins twice</li>
  * <li>Filter for Integration Handler Mappings in WebMvcRequestHandlerProvider and WebFluxRequestHandlerProvider</li>

--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/plugins/DocumentationPluginsBootstrapper.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/plugins/DocumentationPluginsBootstrapper.java
@@ -45,7 +45,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * If no instances DocumentationConfigurer are found a default one is created and executed.
  */
 @Component
-@Conditional(SpringIntegrationNotPresentInClassPathCondition.class)
+@Conditional(SpringIntegrationPluginNotPresentInClassPathCondition.class)
 public class DocumentationPluginsBootstrapper
     extends AbstractDocumentationPluginsBootstrapper
     implements SmartLifecycle {

--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/plugins/SpringIntegrationPluginNotPresentInClassPathCondition.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/plugins/SpringIntegrationPluginNotPresentInClassPathCondition.java
@@ -25,11 +25,12 @@ import org.springframework.util.ClassUtils;
 
 import static org.springframework.util.ClassUtils.*;
 
-public class SpringIntegrationNotPresentInClassPathCondition implements Condition {
+public class SpringIntegrationPluginNotPresentInClassPathCondition implements Condition {
   @Override
   public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
     return !isPresent(
-        "org.springframework.integration.handler.AbstractMessageHandler",
+        "springfox.documentation.spring.web.plugins" +
+            ".SpringIntegrationDocumentationPluginsBootstrapper",
         context.getClassLoader());
   }
 


### PR DESCRIPTION
#### What's this PR do/fix?
Fixes #2967

#### Are there unit tests? If not how should this be manually tested?
Test with https://github.com/springfox/springfox-demos

#### Any background context you want to provide?
Not all users who have spring-integration on the classpath also use spring-integration-webflux or spring-integration-http. We now postpone bootstrapping only if the SpringIntegrationDocumentationPluginsBootstrapper is in fact on the classpath.

#### What are the relevant issues?
In order to access the request mappings of spring-integration, the documentation plugins bootstrapper must execute after the spring-integration RequestHandlerMapping beans have been initialized, which happens later than with the plain RequestHandlerMapping beans.