### PR TITLE
Feature/3062 : Possibility to define order of produces and consumes attribute by Docket configuration

### DIFF
--- a/springfox-spi/src/main/java/springfox/documentation/spi/service/contexts/DocumentationContextBuilder.java
+++ b/springfox-spi/src/main/java/springfox/documentation/spi/service/contexts/DocumentationContextBuilder.java
@@ -44,6 +44,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -64,8 +65,8 @@ public class DocumentationContextBuilder {
   private final List<AlternateTypeRule> rules = new ArrayList<>();
   private final Map<RequestMethod, List<ResponseMessage>> defaultResponseMessages = new HashMap<>();
   private final Set<String> protocols = new HashSet<>();
-  private final Set<String> produces = new HashSet<>();
-  private final Set<String> consumes = new HashSet<>();
+  private final Set<String> produces = new LinkedHashSet<>();
+  private final Set<String> consumes = new LinkedHashSet<>();
   private final Set<ResolvedType> additionalModels = new HashSet<>();
   private final Set<Tag> tags = new TreeSet<>(Tags.tagComparator());
   private List<VendorExtension> vendorExtensions = new ArrayList<VendorExtension>();

--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/plugins/Docket.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/plugins/Docket.java
@@ -50,10 +50,12 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -77,8 +79,8 @@ public class Docket implements DocumentationPlugin {
   private final List<Function<TypeResolver, AlternateTypeRule>> ruleBuilders = new ArrayList<>();
   private final Set<Class> ignorableParameterTypes = new HashSet<>();
   private final Set<String> protocols = new HashSet<>();
-  private final Set<String> produces = new HashSet<>();
-  private final Set<String> consumes = new HashSet<>();
+  private final Set<String> produces = new LinkedHashSet<>();
+  private final Set<String> consumes = new LinkedHashSet<>();
   private final Set<ResolvedType> additionalModels = new HashSet<>();
   private final Set<Tag> tags = new HashSet<>();
 

--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/plugins/Docket.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/plugins/Docket.java
@@ -55,7 +55,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.stream.Stream;
 


### PR DESCRIPTION
#### What's this PR do/fix?
https://github.com/springfox/springfox/issues/3062
#### Are there unit tests? If not how should this be manually tested?
Manually tested by changed Docket configuration within Swagger2SpringBoot class (added below attributes):
` .produces(new LinkedHashSet<>(Arrays.asList("application/json", "application/xml")))
.consumes(new LinkedHashSet<>(Arrays.asList("application/json", "application/xml"))`

and next generating JSON documentation by accessing http://localhost:8080/v2/api-docs .

