### PR TITLE
support multiple ApiImplicitParameters

### DIFF
--- a/springfox-spring-web/src/test/java/springfox/documentation/spring/web/dummy/DummyClass.java
+++ b/springfox-spring-web/src/test/java/springfox/documentation/spring/web/dummy/DummyClass.java
@@ -347,6 +347,15 @@ public class DummyClass {
     }
   }
 
+  @ApiImplicitParams({
+          @ApiImplicitParam(name = "common-header", dataType = "string", required = true, paramType = "header")
+  })
+  public class ApiImplicitParamsAllowMultipleClass implements ApiImplicitParamsInterface {
+    @Override
+    public void methodWithApiImplicitParam() {
+    }
+  }
+
   @ResponseBody
   public DummyModels.BusinessModel methodWithConcreteResponseBody() {
     return null;

--- a/springfox-spring-webmvc/src/test/groovy/springfox/documentation/spring/web/mixins/RequestMappingSupport.groovy
+++ b/springfox-spring-webmvc/src/test/groovy/springfox/documentation/spring/web/mixins/RequestMappingSupport.groovy
@@ -86,6 +86,16 @@ class RequestMappingSupport {
     new HandlerMethod(clazz, c.getMethod(methodName, parameterTypes))
   }
 
+  HandlerMethod dummyHandlerMethodIn(
+      Class<?> aClass,
+      String methodName = "dummyMethod",
+      Class<?>... parameterTypes = null) {
+
+    def clazz = aClass.newInstance()
+    Class c = clazz.getClass()
+    new HandlerMethod(clazz, c.getMethod(methodName, parameterTypes))
+  }
+
   HandlerMethod handlerMethodIn(
       Class<?> aClass,
       String methodName = "dummyMethod",
@@ -170,6 +180,10 @@ class RequestMappingSupport {
 
   def apiImplicitParamsClass() {
     DummyClass.ApiImplicitParamsClass.class;
+  }
+
+  def apiImplicitParamsAllowMultipleClass() {
+    DummyClass.ApiImplicitParamsAllowMultipleClass.class;
   }
 
   HandlerMethod ignorableHandlerMethod() {

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/operation/OperationImplicitParametersReader.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/operation/OperationImplicitParametersReader.java
@@ -34,7 +34,6 @@ import springfox.documentation.swagger.common.SwaggerPluginSupport;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import static springfox.documentation.swagger.common.SwaggerPluginSupport.*;
 

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/operation/OperationImplicitParametersReader.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/operation/OperationImplicitParametersReader.java
@@ -59,12 +59,16 @@ public class OperationImplicitParametersReader implements OperationBuilderPlugin
   }
 
   private List<Parameter> readParameters(OperationContext context) {
-    Optional<ApiImplicitParams> annotation = context.findAnnotation(ApiImplicitParams.class);
+    List<Optional<ApiImplicitParams>> annotations = context.findAllAnnotations(ApiImplicitParams.class);
 
     List<Parameter> parameters = new ArrayList<>();
-    if (annotation.isPresent()) {
-      for (ApiImplicitParam param : annotation.get().value()) {
-        parameters.add(OperationImplicitParameterReader.implicitParameter(descriptions, param));
+    if (annotations != null && !annotations.isEmpty()) {
+      for (Optional<ApiImplicitParams> annotation : annotations) {
+        if (annotation.isPresent()) {
+          for (ApiImplicitParam param : annotation.get().value()) {
+            parameters.add(OperationImplicitParameterReader.implicitParameter(descriptions, param));
+          }
+        }
       }
     }
 

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/operation/OperationImplicitParametersReader.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/operation/OperationImplicitParametersReader.java
@@ -59,13 +59,13 @@ public class OperationImplicitParametersReader implements OperationBuilderPlugin
   }
 
   private List<Parameter> readParameters(OperationContext context) {
-    List<Optional<ApiImplicitParams>> annotations = context.findAllAnnotations(ApiImplicitParams.class);
+    List<ApiImplicitParams> annotations = context.findAllAnnotations(ApiImplicitParams.class);
 
     List<Parameter> parameters = new ArrayList<>();
     if (annotations != null && !annotations.isEmpty()) {
-      for (Optional<ApiImplicitParams> annotation : annotations) {
-        if (annotation.isPresent()) {
-          for (ApiImplicitParam param : annotation.get().value()) {
+      for (ApiImplicitParams annotation : annotations) {
+        if (annotation != null) {
+          for (ApiImplicitParam param : annotation.value()) {
             parameters.add(OperationImplicitParameterReader.implicitParameter(descriptions, param));
           }
         }

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/operation/OperationImplicitParametersReader.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/operation/OperationImplicitParametersReader.java
@@ -61,13 +61,11 @@ public class OperationImplicitParametersReader implements OperationBuilderPlugin
     List<ApiImplicitParams> annotations = context.findAllAnnotations(ApiImplicitParams.class);
 
     List<Parameter> parameters = new ArrayList<>();
-    if (annotations != null && !annotations.isEmpty()) {
+    if (!annotations.isEmpty()) {
       for (ApiImplicitParams annotation : annotations) {
-        if (annotation != null) {
           for (ApiImplicitParam param : annotation.value()) {
             parameters.add(OperationImplicitParameterReader.implicitParameter(descriptions, param));
           }
-        }
       }
     }
 

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/operation/OperationImplicitParamsReaderSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/operation/OperationImplicitParamsReaderSpec.groovy
@@ -82,5 +82,6 @@ class OperationImplicitParamsReaderSpec extends DocumentationContextSpec {
     dummyHandlerMethod('methodWithApiImplicitParamAndAllowMultiple', Integer.class) | 2
     dummyHandlerMethod('methodWithApiImplicitParams', Integer.class)                | 3
     handlerMethodIn(apiImplicitParamsClass(), 'methodWithApiImplicitParam')         | 2
+    dummyHandlerMethodIn(apiImplicitParamsAllowMultipleClass(), 'methodWithApiImplicitParam')   | 3
   }
 }


### PR DESCRIPTION
#### What's this PR do/fix?
support multiple ApiImplicitParameters

#### Are there unit tests? If not how should this be manually tested?
None.

#### Any background context you want to provide?
```
@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE, ElementType.TYPE })
@Retention(RetentionPolicy.RUNTIME)
@ApiImplicitParams({
	@ApiImplicitParam(
			name = "common1",
			value = "common1",
			paramType = "header",
			dataType = "String",
			required = true
	),
	@ApiImplicitParam(
			name = "common2",
			value = "common2",
			paramType = "header",
			dataType = "String",
			required = true
	)
})
public @interface ApiImplicitParamsCommon {
}


@ApiImplicitParamsCommon
@ApiImplicitParams({
	@ApiImplicitParam(
			name = "test1",
			value = "test1",
			paramType = "path",
			dataType = "String",
			required = true
	)
})
public void test1(String test1) {}

@ApiImplicitParamsCommon
@ApiImplicitParams({
	@ApiImplicitParam(
			name = "test2",
			value = "test2",
			paramType = "path",
			dataType = "String",
			required = true
	)
})
public void test2(String test2) {}
```

#### What are the relevant issues?
None.
