### PR TITLE
Fix method sort order (#182 )

### DIFF
--- a/springfox-data-rest/src/main/java/springfox/documentation/spring/data/rest/ActionSpecification.java
+++ b/springfox-data-rest/src/main/java/springfox/documentation/spring/data/rest/ActionSpecification.java
@@ -39,6 +39,7 @@ class ActionSpecification {
   private final List<ResolvedMethodParameter> parameters;
   private final ResolvedType returnType;
   private final HandlerMethod handlerMethod;
+  private final Class<?> entityType;
   private final String name;
   private final String path;
 
@@ -50,6 +51,7 @@ class ActionSpecification {
       Set<MediaType> produces,
       Set<MediaType> consumes,
       HandlerMethod handlerMethod,
+      Class<?> entityType,
       List<ResolvedMethodParameter> parameters,
       ResolvedType returnType) {
     this.name = name;
@@ -60,6 +62,7 @@ class ActionSpecification {
     this.parameters = parameters;
     this.returnType = returnType;
     this.handlerMethod = handlerMethod;
+    this.entityType = entityType;
   }
 
   public String getName() {
@@ -95,12 +98,12 @@ class ActionSpecification {
   }
 
   public Optional<Class<?>> getDeclaringClass() {
-    return getHandlerMethod().map(input -> {
+    return Optional.ofNullable(getHandlerMethod().map(input -> {
       Object bean = new OptionalDeferencer<>().convert(handlerMethod.getBean());
       if (AopUtils.isAopProxy(bean)) {
         return AopUtils.getTargetClass(bean);
       }
       return (Class<?>) bean;
-    });
+    }).orElse(entityType));
   }
 }

--- a/springfox-data-rest/src/main/java/springfox/documentation/spring/data/rest/SpecificationBuilder.java
+++ b/springfox-data-rest/src/main/java/springfox/documentation/spring/data/rest/SpecificationBuilder.java
@@ -196,6 +196,7 @@ abstract class SpecificationBuilder {
               getProduces(),
               getConsumes(),
               null,
+              getType(),
               getParameters(),
               returnType(resolver))
           );
@@ -208,6 +209,10 @@ abstract class SpecificationBuilder {
       return String.format("%s%s",
           lowerCamelCaseName(entity.getType().getSimpleName()),
           upperCamelCaseName(property.getName()));
+    }
+
+    private Class<?> getType() {
+      return context.getEntityContext().entity().get().getType();
     }
 
     private ResolvedType returnType(TypeResolver resolver) {
@@ -305,6 +310,7 @@ abstract class SpecificationBuilder {
               getProduces(),
               getConsumes(),
               handlerMethod,
+              getType(),
               inputParameters(),
               inferReturnType(context, handlerMethod))
           );
@@ -347,6 +353,10 @@ abstract class SpecificationBuilder {
       return methodResolver.methodParameters(handler).stream()
           .map(EntityActionSpecificationBuilder::transferResolvedMethodParameter)
           .collect(Collectors.toList());
+    }
+
+    private Class<?> getType() {
+      return context.entity().get().getType();
     }
 
     private List<ResolvedMethodParameter> inputParameters() {

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spi/service/contexts/OrderingsSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spi/service/contexts/OrderingsSpec.groovy
@@ -1,12 +1,38 @@
 package springfox.documentation.spi.service.contexts
 
 import spock.lang.Specification
+import springfox.documentation.RequestHandler
+import springfox.documentation.RequestHandlerKey
+import springfox.documentation.service.ResolvedMethodParameter
+import springfox.documentation.service.ResourceGroup
 import springfox.documentation.spi.DocumentationType
 import springfox.documentation.spring.web.plugins.Docket
+import springfox.documentation.spring.web.readers.operation.HandlerMethodResolver
+import springfox.documentation.spring.wrapper.PatternsRequestCondition
+import springfox.documentation.spring.web.dummy.DummyClass
+import springfox.documentation.spring.web.mixins.HandlerMethodsSupport
+import springfox.documentation.spring.web.dummy.models.SameFancyPet
+import springfox.documentation.spring.web.ControllerNamingUtils
+import springfox.documentation.spring.web.dummy.controllers.GenericRestController;
+import springfox.documentation.spring.web.dummy.controllers.PetRepository;
 
 import static java.util.stream.Collectors.*
 
+import java.lang.annotation.Annotation
+
+import com.fasterxml.classmate.ResolvedType
+import com.fasterxml.classmate.TypeResolver
+
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.RequestMethod
+import org.springframework.web.method.HandlerMethod
+import org.springframework.web.servlet.mvc.condition.NameValueExpression
+import org.springframework.web.servlet.mvc.method.RequestMappingInfo
+
 class OrderingsSpec extends Specification {
+
+  def methodResolver = new HandlerMethodResolver(new TypeResolver())
+
   def "Orderings dont crash when docket group names are null" () {
     given:
       Docket docket1 = new Docket(DocumentationType.SPRING_WEB)
@@ -18,5 +44,141 @@ class OrderingsSpec extends Specification {
       ordered[0] == docket3
       ordered[1] == docket1
       ordered[2] == docket2
+  }
+
+  def "Orderings is stable when ResourceGroup is based on empty class" () {
+    given:
+      ResourceGroup group1 =  new ResourceGroup("test", PetRepository, 0)
+      ResourceGroup group2 =  new ResourceGroup("test", GenericRestController, 0)
+      ResourceGroup group3 =  new ResourceGroup("test", null, 0)
+
+    when:
+      def ordered = [group1, group2, group3].stream().sorted(Orderings.resourceGroupComparator()).collect(toList())
+    then:
+      ordered[0] == group3
+      ordered[1] == group2
+      ordered[2] == group1
+  }
+
+  def "Orderings is stable when RequestMappingContext is based on overloaded methods" () {
+    given:
+      DocumentationContext documentationContext = Mock()
+
+      RequestMappingContext context1 =  requestMappingContext("0", documentationContext, SameFancyPet)
+      RequestMappingContext context2 =  requestMappingContext("0", documentationContext, SameFancyPet, String)
+      RequestMappingContext context3 =  requestMappingContext("0", documentationContext, String)
+
+    when:
+      def ordered = [context1, context2, context3].stream().sorted(Orderings.methodComparator()).collect(toList())
+    then:
+      ordered[0] == context3
+      ordered[1] == context2
+      ordered[2] == context1
+  }
+
+  private RequestMappingContext requestMappingContext(String id, DocumentationContext documentationContext, Class<?> ... params) {
+    new RequestMappingContext(
+        id,
+        documentationContext,
+        requestHandler(methodResolver, handlerMethod(params)))
+  }
+
+  private HandlerMethod handlerMethod(Class<?> ... params) {
+    def clazz = new DummyClass()
+    Class c = clazz.getClass();
+    new HandlerMethod(clazz, c.getMethod("methodToTestOrdering", params))
+  }
+
+  def requestHandler(HandlerMethodResolver methodResolver, HandlerMethod handlerMethod) {
+    new RequestHandler() {
+          @Override
+          Class<?> declaringClass() {
+            return null
+          }
+
+          @Override
+          boolean isAnnotatedWith(Class<? extends Annotation> annotation) {
+            return false
+          }
+
+          @Override
+          PatternsRequestCondition getPatternsCondition() {
+            return null
+          }
+
+          @Override
+          String groupName() {
+            return ControllerNamingUtils.controllerNameAsGroup(handlerMethod);
+          }
+
+          @Override
+          String getName() {
+            return handlerMethod.getMethod().getName();
+          }
+
+          @Override
+          Set<RequestMethod> supportedMethods() {
+            return null
+          }
+
+          @Override
+          Set<? extends MediaType> produces() {
+            return null
+          }
+
+          @Override
+          Set<? extends MediaType> consumes() {
+            return null
+          }
+
+          @Override
+          Set<NameValueExpression<String>> headers() {
+            return null
+          }
+
+          @Override
+          Set<NameValueExpression<String>> params() {
+            return null
+          }
+
+          @Override
+          def <T extends Annotation> Optional<T> findAnnotation(Class<T> annotation) {
+            return null
+          }
+
+          RequestHandlerKey key() {
+            handlerKey == null ? null : new RequestHandlerKey([] as Set, [] as Set, [] as Set, [] as Set)
+          }
+
+          @Override
+          List<ResolvedMethodParameter> getParameters() {
+            return methodResolver.methodParameters(handlerMethod);
+          }
+
+          @Override
+          ResolvedType getReturnType() {
+            return methodResolver.methodReturnType(handlerMethod);
+          }
+
+          @Override
+          def <T extends Annotation> Optional<T> findControllerAnnotation(Class<T> annotation) {
+            return null
+          }
+
+          @Override
+          springfox.documentation.spring.wrapper.RequestMappingInfo getRequestMapping() {
+            return null
+          }
+
+          @Override
+          HandlerMethod getHandlerMethod() {
+            return null
+          }
+
+          @Override
+          RequestHandler combine(RequestHandler other) {
+            return null
+          }
+        }
   }
 }

--- a/springfox-spring-web/src/test/java/springfox/documentation/spring/web/dummy/DummyClass.java
+++ b/springfox-spring-web/src/test/java/springfox/documentation/spring/web/dummy/DummyClass.java
@@ -499,6 +499,21 @@ public class DummyClass {
     throw new UnsupportedOperationException();
   }
 
+  @ResponseBody
+  public List<DummyModels.BusinessModel> methodToTestOrdering(@RequestBody SameFancyPet fancyPet) {
+    throw new UnsupportedOperationException();
+  }
+
+  @ResponseBody
+  public List<DummyModels.BusinessModel> methodToTestOrdering(@RequestBody SameFancyPet fancyPet, @RequestParam String id) {
+    throw new UnsupportedOperationException();
+  }
+
+  @ResponseBody
+  public List<DummyModels.BusinessModel> methodToTestOrdering(@RequestParam String id) {
+    throw new UnsupportedOperationException();
+  }
+
   public enum BusinessType {
     PRODUCT(1),
     SERVICE(2);

--- a/springfox-spring-web/src/test/java/springfox/documentation/spring/web/dummy/DummyClass.java
+++ b/springfox-spring-web/src/test/java/springfox/documentation/spring/web/dummy/DummyClass.java
@@ -505,7 +505,8 @@ public class DummyClass {
   }
 
   @ResponseBody
-  public List<DummyModels.BusinessModel> methodToTestOrdering(@RequestBody SameFancyPet fancyPet, @RequestParam String id) {
+  public List<DummyModels.BusinessModel> methodToTestOrdering(@RequestBody SameFancyPet fancyPet,
+      @RequestParam String id) {
     throw new UnsupportedOperationException();
   }
 

--- a/swagger-contract-tests-webflux/src/test/resources/contract/swagger2/swagger.json
+++ b/swagger-contract-tests-webflux/src/test/resources/contract/swagger2/swagger.json
@@ -59,7 +59,7 @@
                         "description": "Pet object that needs to be added to the store",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/Pet"
+                            "$ref": "#/definitions/Pet_1"
                         }
                     }
                 ],
@@ -104,7 +104,7 @@
                         "description": "Pet object that needs to be added to the store",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/Pet"
+                            "$ref": "#/definitions/Pet_1"
                         }
                     }
                 ],
@@ -170,7 +170,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/Pet_1"
+                                "$ref": "#/definitions/Pet"
                             }
                         }
                     },
@@ -217,7 +217,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/Pet_1"
+                                "$ref": "#/definitions/Pet"
                             }
                         }
                     },
@@ -263,7 +263,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/Pet_1"
+                            "$ref": "#/definitions/Pet"
                         }
                     },
                     "400": {
@@ -834,9 +834,6 @@
     "definitions": {
         "Category": {
             "type": "object",
-            "required": [
-                "id"
-            ],
             "properties": {
                 "id": {
                     "type": "integer",
@@ -850,6 +847,9 @@
         },
         "Category_1": {
             "type": "object",
+            "required": [
+                "id"
+            ],
             "properties": {
                 "id": {
                     "type": "integer",
@@ -909,6 +909,10 @@
                     "type": "integer",
                     "format": "int64"
                 },
+                "identifier": {
+                    "type": "integer",
+                    "format": "int64"
+                },
                 "name": {
                     "type": "string"
                 },
@@ -943,10 +947,6 @@
                     "$ref": "#/definitions/Category_1"
                 },
                 "id": {
-                    "type": "integer",
-                    "format": "int64"
-                },
-                "identifier": {
                     "type": "integer",
                     "format": "int64"
                 },

--- a/swagger-contract-tests/src/test/resources/contract/swagger/declaration-concrete-controller.json
+++ b/swagger-contract-tests/src/test/resources/contract/swagger/declaration-concrete-controller.json
@@ -20,7 +20,7 @@
                             "description": "toCreate",
                             "name": "body",
                             "paramType": "body",
-                            "type": "Resource«Pet»",
+                            "type": "Resource«Pet»_1",
                             "required": true
                         }
                     ],
@@ -131,7 +131,7 @@
                         {
                             "code": 200,
                             "message": "OK",
-                            "responseModel": "Resource«Pet»_1"
+                            "responseModel": "Resource«Pet»"
                         },
                         {
                             "code": 401,
@@ -151,7 +151,7 @@
                         }
                     ],
                     "deprecated": "false",
-                    "type": "Resource«Pet»_1"
+                    "type": "Resource«Pet»"
                 }
             ],
             "path": "/foo/get-t/{id}"
@@ -178,7 +178,7 @@
                 "links": {
                     "required": false,
                     "items": {
-                        "type": "Link_1"
+                        "type": "Link"
                     },
                     "type": "array"
                 },
@@ -194,7 +194,7 @@
             "properties": {
                 "body": {
                     "required": false,
-                    "type": "Resource«Pet»_1"
+                    "type": "Resource«Pet»"
                 }
             }
         },
@@ -286,7 +286,7 @@
                 "links": {
                     "required": false,
                     "items": {
-                        "type": "Link"
+                        "type": "Link_1"
                     },
                     "type": "array"
                 },

--- a/swagger-contract-tests/src/test/resources/contract/swagger/declaration-fancy-pet-service.json
+++ b/swagger-contract-tests/src/test/resources/contract/swagger/declaration-fancy-pet-service.json
@@ -7,7 +7,7 @@
                 {
                     "method": "POST",
                     "summary": "createObject",
-                    "nickname": "createObjectUsingPOST",
+                    "nickname": "createObjectUsingPOST_1",
                     "produces": [
                         "*/*"
                     ],
@@ -111,7 +111,7 @@
                 {
                     "method": "POST",
                     "summary": "createObject",
-                    "nickname": "createObjectUsingPOST_1",
+                    "nickname": "createObjectUsingPOST",
                     "produces": [
                         "*/*"
                     ],

--- a/swagger-contract-tests/src/test/resources/contract/swagger/resource-listing.json
+++ b/swagger-contract-tests/src/test/resources/contract/swagger/resource-listing.json
@@ -2,17 +2,17 @@
     "apiVersion": "1.0",
     "apis": [
         {
-            "description": "Address Entity\nSimple Jpa Repository",
+            "description": "Address\nSimple Jpa Repository",
             "path": "/default/Address Entity",
             "position": 0
         },
         {
-            "description": "Person Entity\nSimple Jpa Repository",
+            "description": "Person\nSimple Jpa Repository",
             "path": "/default/Person Entity",
             "position": 0
         },
         {
-            "description": "Simple Jpa Repository\nTag Entity",
+            "description": "Simple Jpa Repository\nTag",
             "path": "/default/Tag Entity",
             "position": 0
         },

--- a/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-concrete-controller.json
+++ b/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-concrete-controller.json
@@ -43,7 +43,7 @@
                         "description": "toCreate",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/Resource«Pet»"
+                            "$ref": "#/definitions/Resource«Pet»_1"
                         }
                     }
                 ],
@@ -105,7 +105,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/Resource«Pet»_1"
+                            "$ref": "#/definitions/Resource«Pet»"
                         }
                     },
                     "405": {
@@ -137,12 +137,12 @@
             "type": "object",
             "properties": {
                 "body": {
-                    "$ref": "#/definitions/Resource«Pet»_1"
+                    "$ref": "#/definitions/Resource«Pet»"
                 }
             },
             "title": "HttpEntity«Resource«Pet»»"
         },
-        "Link_1": {
+        "Link": {
             "type": "object",
             "properties": {
                 "deprecation": {
@@ -205,7 +205,7 @@
                     }
                 }
             },
-            "title": "Link_1",
+            "title": "Link",
             "xml": {
                 "name": "link",
                 "namespace": "http://www.w3.org/2005/Atom",
@@ -213,7 +213,7 @@
                 "wrapped": false
             }
         },
-        "Link": {
+        "Link_1": {
             "type": "object",
             "properties": {
                 "deprecation": {
@@ -273,7 +273,7 @@
                     }
                 }
             },
-            "title": "Link",
+            "title": "Link_1",
             "xml": {
                 "name": "link",
                 "namespace": "http://www.w3.org/2005/Atom",
@@ -297,7 +297,7 @@
             },
             "title": "Pet"
         },
-        "Resource«Pet»_1": {
+        "Resource«Pet»": {
             "type": "object",
             "properties": {
                 "age": {
@@ -316,21 +316,21 @@
                         "wrapped": false
                     },
                     "items": {
-                        "$ref": "#/definitions/Link_1"
+                        "$ref": "#/definitions/Link"
                     }
                 },
                 "name": {
                     "type": "string"
                 }
             },
-            "title": "Resource«Pet»_1",
+            "title": "Resource«Pet»",
             "xml": {
                 "name": "Resource«Pet»",
                 "attribute": false,
                 "wrapped": false
             }
         },
-        "Resource«Pet»": {
+        "Resource«Pet»_1": {
             "type": "object",
             "properties": {
                 "age": {
@@ -343,14 +343,14 @@
                 "links": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/Link"
+                        "$ref": "#/definitions/Link_1"
                     }
                 },
                 "name": {
                     "type": "string"
                 }
             },
-            "title": "Resource«Pet»",
+            "title": "Resource«Pet»_1",
             "xml": {
                 "name": "Resource«Pet»",
                 "attribute": false,

--- a/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-same-controller.json
+++ b/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-same-controller.json
@@ -43,7 +43,7 @@
                         "description": "toCreate",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/ModelWithSameNameClasses"
+                            "$ref": "#/definitions/ModelWithSameNameClasses_1"
                         }
                     }
                 ],
@@ -75,7 +75,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/ModelWithSameNameClasses_1"
+                            "$ref": "#/definitions/ModelWithSameNameClasses"
                         }
                     },
                     "405": {
@@ -266,7 +266,7 @@
             },
             "title": "ModelWithSameNameClasses_1"
         },
-        "SameCategory_1": {
+        "SameCategory": {
             "type": "object",
             "properties": {
                 "_type": {
@@ -278,9 +278,9 @@
                     "type": "string"
                 }
             },
-            "title": "SameCategory_1"
+            "title": "SameCategory"
         },
-        "SameCategory": {
+        "SameCategory_1": {
             "type": "object",
             "required": [
                 "id"
@@ -295,29 +295,7 @@
                     "type": "string"
                 }
             },
-            "title": "SameCategory"
-        },
-        "SameFancyPet_1": {
-            "type": "object",
-            "properties": {
-                "age": {
-                    "type": "integer",
-                    "format": "int32"
-                },
-                "color": {
-                    "type": "string"
-                },
-                "extendedCategory": {
-                    "$ref": "#/definitions/SameCategory_1"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                }
-            },
-            "title": "SameFancyPet_1"
+            "title": "SameCategory_1"
         },
         "SameFancyPet": {
             "type": "object",
@@ -337,13 +315,35 @@
                 },
                 "name": {
                     "type": "string"
+                }
+            },
+            "title": "SameFancyPet"
+        },
+        "SameFancyPet_1": {
+            "type": "object",
+            "properties": {
+                "age": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "color": {
+                    "type": "string"
+                },
+                "extendedCategory": {
+                    "$ref": "#/definitions/SameCategory_1"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
                 },
                 "pet_weight": {
                     "type": "number",
                     "format": "double"
                 }
             },
-            "title": "SameFancyPet"
+            "title": "SameFancyPet_1"
         }
     }
 }

--- a/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-spring-data-rest.json
+++ b/swagger-contract-tests/src/test/resources/contract/swagger2/declaration-spring-data-rest.json
@@ -863,7 +863,7 @@
                     "Person Entity"
                 ],
                 "summary": "personTags",
-                "operationId": "personTagsUsingGET_4",
+                "operationId": "personTagsUsingGET_5",
                 "produces": [
                     "application/hal+json"
                 ],
@@ -976,7 +976,7 @@
                     "Person Entity"
                 ],
                 "summary": "personTags",
-                "operationId": "personTagsUsingDELETE_4",
+                "operationId": "personTagsUsingDELETE_5",
                 "consumes": [
                     "text/uri-list",
                     "application/x-spring-data-compact+json"
@@ -1047,7 +1047,7 @@
                     "Person Entity"
                 ],
                 "summary": "personTags",
-                "operationId": "personTagsUsingGET_5",
+                "operationId": "personTagsUsingGET_4",
                 "consumes": [
                     "application/hal+json"
                 ],
@@ -1083,7 +1083,7 @@
                     "Person Entity"
                 ],
                 "summary": "personTags",
-                "operationId": "personTagsUsingDELETE_5",
+                "operationId": "personTagsUsingDELETE_4",
                 "consumes": [
                     "text/uri-list",
                     "application/x-spring-data-compact+json"
@@ -1356,7 +1356,7 @@
                     "Tag Entity"
                 ],
                 "summary": "tagPeople",
-                "operationId": "tagPeopleUsingGET_4",
+                "operationId": "tagPeopleUsingGET_5",
                 "produces": [
                     "application/hal+json"
                 ],
@@ -1469,7 +1469,7 @@
                     "Tag Entity"
                 ],
                 "summary": "tagPeople",
-                "operationId": "tagPeopleUsingDELETE_4",
+                "operationId": "tagPeopleUsingDELETE_5",
                 "consumes": [
                     "text/uri-list",
                     "application/x-spring-data-compact+json"
@@ -1540,7 +1540,7 @@
                     "Tag Entity"
                 ],
                 "summary": "tagPeople",
-                "operationId": "tagPeopleUsingGET_5",
+                "operationId": "tagPeopleUsingGET_4",
                 "consumes": [
                     "application/hal+json"
                 ],
@@ -1576,7 +1576,7 @@
                     "Tag Entity"
                 ],
                 "summary": "tagPeople",
-                "operationId": "tagPeopleUsingDELETE_5",
+                "operationId": "tagPeopleUsingDELETE_4",
                 "consumes": [
                     "text/uri-list",
                     "application/x-spring-data-compact+json"


### PR DESCRIPTION
If controller class contains overloaded methods, or methods types with same names it leads to instability of a sort order and influence to output definitions, it changes from run to run.

Spring Data Rest bean names for AssociationAction in some cases can not be defined. In that case Entity class name will be used.

That PR fixes all cases that could lead to instability of definitions.