### PR TITLE
Bump swagger-ui depdency

### DIFF
--- a/springfox-swagger-ui/build.gradle
+++ b/springfox-swagger-ui/build.gradle
@@ -29,7 +29,7 @@ plugins {
 }
 
 ext {
-  swaggerUiVersion = '3.23.4'
+  swaggerUiVersion = '3.23.11'
   swaggerUiDist = "build/libs/swagger-ui-dist.zip"
   swaggerUiExplodedDir = "swagger-ui-${swaggerUiVersion}/dist/"
   downloadUrl = "https://github.com/swagger-api/swagger-ui/archive/v${swaggerUiVersion}.zip"


### PR DESCRIPTION
Security fix detailed in swagger-ui's release notes.
https://github.com/swagger-api/swagger-ui/releases/tag/v3.23.11

#### What's this PR do/fix?
Bumps the swagger-ui dependency.

#### Are there unit tests? If not how should this be manually tested?
No new functionality, just a gradle dependency version change. All of the old tests should be run to verify no breaking changes between versions.

#### Any background context you want to provide?
Swagger-ui has a security fix that addresses a CSS-based input field value exfiltration vulnerability in this release. 

#### What are the relevant issues?
https://github.com/springfox/springfox/issues/3131