### PR TITLE
Set the basePath using the request context path if present

### DIFF
--- a/springfox-swagger2/src/main/java/springfox/documentation/swagger2/web/Swagger2ControllerWebFlux.java
+++ b/springfox-swagger2/src/main/java/springfox/documentation/swagger2/web/Swagger2ControllerWebFlux.java
@@ -88,7 +88,7 @@ public class Swagger2ControllerWebFlux {
       return new ResponseEntity<>(HttpStatus.NOT_FOUND);
     }
     Swagger swagger = mapper.mapDocumentation(documentation);
-    swagger.basePath("/");
+    swagger.basePath(isEmpty(request.getPath().contextPath().value()) ? "/" : request.getPath().contextPath().value());
     if (isEmpty(swagger.getHost())) {
       swagger.host(request.getURI().getAuthority());
     }

--- a/springfox-swagger2/src/test/groovy/springfox/documentation/swagger2/web/Swagger2ControllerWebFluxSpec.groovy
+++ b/springfox-swagger2/src/test/groovy/springfox/documentation/swagger2/web/Swagger2ControllerWebFluxSpec.groovy
@@ -1,0 +1,86 @@
+package springfox.documentation.swagger2.web
+
+import com.fasterxml.classmate.TypeResolver
+import org.springframework.http.server.RequestPath
+import org.springframework.http.server.reactive.ServerHttpRequest
+import spock.lang.Unroll
+import springfox.documentation.spi.DocumentationType
+import springfox.documentation.spi.service.contexts.Defaults
+import springfox.documentation.spring.web.DocumentationCache
+import springfox.documentation.spring.web.json.JsonSerializer
+import springfox.documentation.spring.web.mixins.ApiListingSupport
+import springfox.documentation.spring.web.mixins.AuthSupport
+import springfox.documentation.spring.web.mixins.JsonSupport
+import springfox.documentation.spring.web.paths.DefaultPathProvider
+import springfox.documentation.spring.web.plugins.DefaultConfiguration
+import springfox.documentation.spring.web.plugins.DocumentationContextSpec
+import springfox.documentation.spring.web.scanners.ApiDocumentationScanner
+import springfox.documentation.spring.web.scanners.ApiListingReferenceScanResult
+import springfox.documentation.spring.web.scanners.ApiListingReferenceScanner
+import springfox.documentation.spring.web.scanners.ApiListingScanner
+import springfox.documentation.swagger2.configuration.Swagger2JacksonModule
+import springfox.documentation.swagger2.mappers.MapperSupport
+
+import static springfox.documentation.spi.service.contexts.Orderings.nickNameComparator
+
+@Mixin([ApiListingSupport, AuthSupport])
+class Swagger2ControllerWebFluxSpec extends DocumentationContextSpec
+    implements MapperSupport, JsonSupport {
+
+    Swagger2ControllerWebFlux controller = new Swagger2ControllerWebFlux(
+            new DocumentationCache(),
+            swagger2Mapper(),
+            new JsonSerializer([new Swagger2JacksonModule()])
+    )
+
+    ApiListingReferenceScanner listingReferenceScanner
+    ApiListingScanner listingScanner
+    ServerHttpRequest request;
+
+    def setup() {
+        listingReferenceScanner = Mock(ApiListingReferenceScanner)
+        listingReferenceScanner.scan(_) >> new ApiListingReferenceScanResult(new HashMap<>())
+        listingScanner = Mock(ApiListingScanner)
+        listingScanner.scan(_) >> new HashMap<>()
+    }
+
+    @Unroll("x-forwarded-prefix: #prefix")
+    def "should respect proxy headers ('X-Forwarded-*') when setting host, port and basePath"() {
+        given:
+        def req = serverRequestWithXHeaders(prefix)
+
+        def defaultConfiguration = new DefaultConfiguration(
+                new Defaults(),
+                new TypeResolver(),
+                new DefaultPathProvider())
+
+        this.contextBuilder = defaultConfiguration.create(DocumentationType.SWAGGER_12)
+                .requestHandlers([])
+                .operationOrdering(nickNameComparator())
+
+        ApiDocumentationScanner swaggerApiResourceListing =
+                new ApiDocumentationScanner(listingReferenceScanner, listingScanner)
+        controller.documentationCache.addDocumentation(swaggerApiResourceListing.scan(documentationContext()))
+
+        when:
+        def result = jsonBodyResponse(controller.getDocumentation(null, req).getBody().value())
+
+        then:
+        result.basePath == expectedPath
+
+        where:
+        prefix        | expectedPath
+        "/fooservice" | "/fooservice"
+        "/"           | "/"
+        ""            | "/"
+    }
+
+    def serverRequestWithXHeaders(String prefix) {
+
+        ServerHttpRequest request = Mock()
+        request.path >> RequestPath.parse(new URI("http://localhost${-> prefix}/api"), prefix)
+        request.URI >> URI.create("http://localhost/api-docs")
+
+        request
+    }
+}


### PR DESCRIPTION
This allows the X-Forwarded-Prefix header to work correctly

#### fix for issue #3157

Test with the following steps:
1 - build and install into local maven repo.
2 - clone repo https://github.com/jgcollings/webfluxtest.git
3 - run the project: mvn spring-boot:run
4 - use the following curl command to get the api spec:

curl -X GET \
  http://localhost:8080/v2/api-docs \
  -H 'X-Forwarded-Host: www.acme.com' \
  -H 'X-Forwarded-Port: 80' \
  -H 'X-Forwarded-Prefix: /myprefix' \
  -H 'X-Forwarded-Protocol: http'

Notice that the basePath in the spec is "/myprefix"
