### PR TITLE
#3189 - handle defaults in Spring placeholders

### DIFF
--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/DescriptionResolver.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/DescriptionResolver.java
@@ -29,7 +29,7 @@ import java.util.regex.Pattern;
 import static org.springframework.util.StringUtils.*;
 
 public class DescriptionResolver {
-  private static final Pattern PATTERN = Pattern.compile("\\Q${\\E(.+?)\\Q}\\E");
+  private static final Pattern PATTERN = Pattern.compile("\\Q${\\E(.+?)(:.*)?\\Q}\\E");
   private final Environment environment;
   private Map<String, String> cache;
 

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/DescriptionResolverSpec.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/DescriptionResolverSpec.groovy
@@ -20,6 +20,8 @@ class DescriptionResolverSpec extends Specification {
       value         | key
       "key1value"   | '${key1}'
       "key2value"   | '${key2}'
+      "key2value"   | '${key2:}'
+      "key2value"   | '${key2:key2default}'
       '${unknown}'  | '${unknown}'
       "key1"        | 'key1'
       "key2"        | 'key2'


### PR DESCRIPTION
#### What's this PR do/fix?
Issue #3189

#### Are there unit tests? If not how should this be manually tested?
Few test cases added

#### Any background context you want to provide?
As per http://springfox.github.io/springfox/docs/snapshot/#property-file-lookup there is support for Spring properties resolution but default values like `${propertyName:defualt}` are not handled. I'm wondering if there are other places I need to update?

#### What are the relevant issues?
Issue #3189