### PR TITLE
Update swagger ui to version without css security issue

### DIFF
--- a/springfox-swagger-ui/build.gradle
+++ b/springfox-swagger-ui/build.gradle
@@ -29,7 +29,7 @@ plugins {
 }
 
 ext {
-  swaggerUiVersion = '3.23.4'
+  swaggerUiVersion = '3.23.11'
   swaggerUiDist = "build/libs/swagger-ui-dist.zip"
   swaggerUiExplodedDir = "swagger-ui-${swaggerUiVersion}/dist/"
   downloadUrl = "https://github.com/swagger-api/swagger-ui/archive/v${swaggerUiVersion}.zip"

--- a/swagger-contract-tests/src/test/groovy/springfox/test/contract/swaggertests/FunctionContractSpec.groovy
+++ b/swagger-contract-tests/src/test/groovy/springfox/test/contract/swaggertests/FunctionContractSpec.groovy
@@ -142,7 +142,8 @@ class FunctionContractSpec extends Specification implements FileAccess {
     then:
     response.statusCode == HttpStatus.OK
 
-    JSONAssert.assertEquals(contract, response.body, NON_EXTENSIBLE)
+    def bodyWithLFOnly = response.body.replaceAll("\\\\r\\\\n", "\\\\n") //Make sure if we're running on windows the line endings which are double-escaped match up with the resource file above.
+    JSONAssert.assertEquals(contract, bodyWithLFOnly, NON_EXTENSIBLE)
   }
 
   @Unroll


### PR DESCRIPTION
#### What's this PR do/fix?
Primarily updates the version of swagger-ui to the micro update that fixes the css vulnerability.
In addition fixes a failing test when the project is built on windows.

#### Are there unit tests? If not how should this be manually tested?
No new features - just a dependant version uptick.  All existing tests pass.

#### Any background context you want to provide?
The reason for this update request is that I'm trying to use geode in a project, however that depends on the current release of springfox-swagger-ui.  This is being flagged as a security issue due to the use of a vulnerable swagger-ui version.  Once this update is included in a versioned build I'll hopefully be doing a similar update to the geode repo.

#### What are the relevant issues?
This issue was already raised in late November by gokumar:
https://github.com/springfox/springfox/issues/3193
