### PR TITLE
Enhanced the way the Sprigfox machinery figures out whether a propert…

### DIFF
--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/schema/ApiModelPropertyPropertyBuilder.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/schema/ApiModelPropertyPropertyBuilder.java
@@ -19,6 +19,7 @@
 
 package springfox.documentation.swagger.schema;
 
+import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
 import io.swagger.annotations.ApiModelProperty;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.annotation.Order;
@@ -62,7 +63,7 @@ public class ApiModelPropertyPropertyBuilder implements ModelPropertyBuilderPlug
     if (annotation.isPresent()) {
       context.getBuilder()
           .allowableValues(annotation.map(toAllowableValues()).orElse(null))
-          .required(annotation.map(ApiModelProperty::required).orElse(false))
+          .required(isRequired(annotation, context))
           .readOnly(annotation.map(ApiModelProperty::readOnly).orElse(false))
           .description(annotation.map(toDescription(descriptions)).orElse(null))
           .isHidden(annotation.map(ApiModelProperty::hidden).orElse(false))
@@ -70,6 +71,16 @@ public class ApiModelPropertyPropertyBuilder implements ModelPropertyBuilderPlug
           .position(annotation.map(ApiModelProperty::position).orElse(0))
           .example(annotation.map(toExample()).orElse(null));
     }
+  }
+
+  private boolean isRequired(Optional<ApiModelProperty> annotation, ModelPropertyContext context) {
+    return annotation
+            .filter(ApiModelProperty::required)
+            .map(ApiModelProperty::required)
+            .orElse(context.getBeanPropertyDefinition()
+                    .map(BeanPropertyDefinition::isRequired)
+                    .orElse(false)
+            );
   }
 
   @Override

--- a/springfox-swagger-common/src/test/java/springfox/documentation/schema/TypeWithFieldsAndGettersAnnotatedWithJsonPropertyAndApiPropertyModel.java
+++ b/springfox-swagger-common/src/test/java/springfox/documentation/schema/TypeWithFieldsAndGettersAnnotatedWithJsonPropertyAndApiPropertyModel.java
@@ -1,0 +1,56 @@
+package springfox.documentation.schema;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+
+public class TypeWithFieldsAndGettersAnnotatedWithJsonPropertyAndApiPropertyModel {
+
+    @JsonProperty(required = false)
+    @ApiModelProperty(required = true)
+    private int apiModelPropertyAnnotatedField;
+
+    @JsonProperty(required = true)
+    @ApiModelProperty(required = false)
+    private int jsonPropertyAnnotatedField;
+
+    @JsonProperty(required = false)
+    @ApiModelProperty(required = false)
+    private int jsonPropertyAndApiModelPropertyAnnotatedField;
+
+    private int apiModelPropertyAnnotatedGetter;
+
+    private int jsonPropertyAnnotatedGetter;
+
+    private int jsonPropertyAndApiModelPropertyAnnotatedGetter;
+
+
+    public int getApiModelPropertyAnnotatedField() {
+        return apiModelPropertyAnnotatedField;
+    }
+
+    public int getJsonPropertyAnnotatedField() {
+        return jsonPropertyAnnotatedField;
+    }
+
+    public int getJsonPropertyAndApiModelPropertyAnnotatedField() {
+        return jsonPropertyAndApiModelPropertyAnnotatedField;
+    }
+
+    @JsonProperty(required = false)
+    @ApiModelProperty(required = true)
+    public int getApiModelPropertyAnnotatedGetter() {
+        return apiModelPropertyAnnotatedGetter;
+    }
+
+    @JsonProperty(required = true)
+    @ApiModelProperty(required = false)
+    public int getJsonPropertyAnnotatedGetter() {
+        return jsonPropertyAnnotatedGetter;
+    }
+
+    @JsonProperty(required = false)
+    @ApiModelProperty(required = false)
+    public int getJsonPropertyAndApiModelPropertyAnnotatedGetter() {
+        return jsonPropertyAndApiModelPropertyAnnotatedGetter;
+    }
+}


### PR DESCRIPTION
#### What's this PR do/fix?
It enhances the way Springfox machinery figures out whether a property is required or not by honouring Jackson's property configuration when the `@ApiPropertyModel#required`  is `false`
#### Are there unit tests? If not how should this be manually tested?
Yes, there is
#### Any background context you want to provide?
Yes. There are two scenarios where this enhancement fits
1) Honour the Jackson's configuration of `@JsonProperty(required = true)` of third party POJOS (which I don't have control over)
2) Or when there is a Jackson's introspect that manually sets properties required to `true`, for example, when a it finds a project owned annotation such as `@NonNull`
#### What are the relevant issues?
