### PR TITLE
Issue 3255

### DIFF
--- a/springfox-swagger2/src/main/java/springfox/documentation/swagger2/mappers/EnumMapper.java
+++ b/springfox-swagger2/src/main/java/springfox/documentation/swagger2/mappers/EnumMapper.java
@@ -21,7 +21,14 @@ package springfox.documentation.swagger2.mappers;
 
 import io.swagger.models.ModelImpl;
 import io.swagger.models.parameters.SerializableParameter;
-import io.swagger.models.properties.*;
+import io.swagger.models.properties.AbstractNumericProperty;
+import io.swagger.models.properties.DoubleProperty;
+import io.swagger.models.properties.FloatProperty;
+import io.swagger.models.properties.IntegerProperty;
+import io.swagger.models.properties.LongProperty;
+import io.swagger.models.properties.Property;
+import io.swagger.models.properties.StringProperty;
+import io.swagger.models.properties.ArrayProperty;
 import springfox.documentation.service.AllowableListValues;
 import springfox.documentation.service.AllowableRangeValues;
 import springfox.documentation.service.AllowableValues;

--- a/springfox-swagger2/src/main/java/springfox/documentation/swagger2/mappers/EnumMapper.java
+++ b/springfox-swagger2/src/main/java/springfox/documentation/swagger2/mappers/EnumMapper.java
@@ -21,13 +21,7 @@ package springfox.documentation.swagger2.mappers;
 
 import io.swagger.models.ModelImpl;
 import io.swagger.models.parameters.SerializableParameter;
-import io.swagger.models.properties.AbstractNumericProperty;
-import io.swagger.models.properties.DoubleProperty;
-import io.swagger.models.properties.FloatProperty;
-import io.swagger.models.properties.IntegerProperty;
-import io.swagger.models.properties.LongProperty;
-import io.swagger.models.properties.Property;
-import io.swagger.models.properties.StringProperty;
+import io.swagger.models.properties.*;
 import springfox.documentation.service.AllowableListValues;
 import springfox.documentation.service.AllowableRangeValues;
 import springfox.documentation.service.AllowableValues;
@@ -129,6 +123,12 @@ public class EnumMapper {
         numeric.exclusiveMaximum(range.getExclusiveMax());
         numeric.setMinimum(safeBigDecimal(range.getMin()));
         numeric.exclusiveMinimum(range.getExclusiveMin());
+      }
+      if (property instanceof ArrayProperty) {
+        ArrayProperty arrayProperty = (ArrayProperty) property;
+        AllowableRangeValues allowableRangeValues = (AllowableRangeValues) allowableValues;
+        arrayProperty.setMinItems(safeInteger(allowableRangeValues.getMin()));
+        arrayProperty.setMaxItems(safeInteger(allowableRangeValues.getMax()));
       }
     }
     return property;

--- a/springfox-swagger2/src/test/groovy/springfox/documentation/swagger2/mappers/EnumMapperSpec.groovy
+++ b/springfox-swagger2/src/test/groovy/springfox/documentation/swagger2/mappers/EnumMapperSpec.groovy
@@ -19,6 +19,7 @@
 package springfox.documentation.swagger2.mappers
 
 import io.swagger.models.parameters.QueryParameter
+import io.swagger.models.properties.ArrayProperty
 import io.swagger.models.properties.DoubleProperty
 import io.swagger.models.properties.FloatProperty
 import io.swagger.models.properties.IntegerProperty
@@ -82,6 +83,20 @@ class EnumMapperSpec extends Specification {
     new LongProperty()    | 2      | 8      | false     | false     | new AllowableRangeValues("2", false, "8", false)
     new DoubleProperty()  | 3      | 9      | false     | true      | new AllowableRangeValues("3", false, "9", true)
     new FloatProperty()   | 4      | 10     | true      | false     | new AllowableRangeValues("4", true, "10", false)
+  }
+
+  @Unroll("Exclusive #property.class.simpleName")
+  def "adds enum values with exclusive for array properties"() {
+    when:
+    maybeAddAllowableValues(property, allowableValues)
+    then:
+    property.minItems == expMinItems
+    property.maxItems == expMaxItems
+    where:
+    property              | expMinItems | expMaxItems | allowableValues
+    new ArrayProperty()   | 1           | 7           | new AllowableRangeValues("1", null, "7", null)
+    new ArrayProperty()   | 1           | 7           | new AllowableRangeValues("1", true, "7", false)
+    new ArrayProperty()   | 2           | 8           | new AllowableRangeValues("2", null, "8", null)
   }
 
   @Unroll("#allowableValues?.class.simpleName")


### PR DESCRIPTION
#### What's this PR do/fix?
fix `@Size` annotation does not work properly on `List`
#### Are there unit tests? If not how should this be manually tested?
You can write the following code in the bean
```Java
@ApiModelProperty("list1")
@Size(min = 1, max = 200, message = "1-200")
private List<String> list1;
```
Then you can see in the generated swagger json
```json
list1:- {
type: "array",
description: "list1",
items:- {
  type: "string"
},
maxItems: 200,
minItems: 1
}
```

#### Any background context you want to provide?
As above
#### What are the relevant issues?
[3255](https://github.com/springfox/springfox/issues/3255)