### PR TITLE
Returning cache to life.

### DIFF
--- a/springfox-core/src/main/java/springfox/documentation/schema/ModelRef.java
+++ b/springfox-core/src/main/java/springfox/documentation/schema/ModelRef.java
@@ -183,6 +183,8 @@ public class ModelRef implements ModelReference {
         && Objects.equals(
         allowableValues,
         that.allowableValues)
-        && modelId.isPresent() == that.modelId.isPresent();
+        && Objects.equals(
+        modelId,
+        that.modelId);
   }
 }

--- a/springfox-schema/src/main/java/springfox/documentation/schema/ModelReferenceProvider.java
+++ b/springfox-schema/src/main/java/springfox/documentation/schema/ModelReferenceProvider.java
@@ -119,6 +119,6 @@ class ModelReferenceProvider implements Function<ResolvedType, ModelReference> {
         || enumTypeDeterminer.isEnum(type.getErasedType())) {
       return null;
     }
-    return context.getTypeId();
+    return context.getModelId();
   }
 }

--- a/springfox-schema/src/main/java/springfox/documentation/schema/TypeNameIndexingAdapter.java
+++ b/springfox-schema/src/main/java/springfox/documentation/schema/TypeNameIndexingAdapter.java
@@ -40,18 +40,18 @@ public class TypeNameIndexingAdapter implements UniqueTypeNameAdapter {
   }
 
   @Override
-  public Optional<String> getTypeName(String modelId) {
-    return Optional.ofNullable(knownNames.get(modelId));
+  public Optional<String> getTypeName(String typeId) {
+    return Optional.ofNullable(knownNames.get(typeId));
   }
 
   private boolean checkTypeRegistration(
       String typeName,
-      String modelId) {
-    if (knownNames.containsKey(modelId)) {
-      if (!knownNames.get(modelId).equals(typeName)) {
+      String typeId) {
+    if (knownNames.containsKey(typeId)) {
+      if (!knownNames.get(typeId).equals(typeName)) {
         LOG.info("Rewriting type {} with model id: {} is not allowed, because it is already registered",
                  typeName,
-                 modelId);
+                 typeId);
         throw new IllegalStateException("Model already registered with different name.");
       } else {
         return true;
@@ -64,24 +64,24 @@ public class TypeNameIndexingAdapter implements UniqueTypeNameAdapter {
   @Override
   public void registerType(
       String typeName,
-      String modelId) {
+      String typeId) {
     if (checkTypeRegistration(
         typeName,
-        modelId)) {
+        typeId)) {
       return;
     }
     knownNames.put(
-        modelId,
+        typeId,
         typeName);
   }
 
   @Override
   public void registerUniqueType(
       String typeName,
-      String modelId) {
+      String typeId) {
     if (checkTypeRegistration(
         typeName,
-        modelId)) {
+        typeId)) {
       return;
     }
     Integer nameIndex = 0;
@@ -94,29 +94,29 @@ public class TypeNameIndexingAdapter implements UniqueTypeNameAdapter {
           toString();
     }
     knownNames.put(
-        modelId,
+        typeId,
         tempName);
   }
 
   @Override
   public void setEqualityFor(
-      String modelIdOf,
-      String modelIdTo) {
-    if (!knownNames.containsKey(modelIdTo)) {
+      String typeIdOf,
+      String typeIdTo) {
+    if (!knownNames.containsKey(typeIdTo)) {
       LOG.warn(
           "Model with model id: {} was not found, because it is not registered",
-          modelIdTo);
+          typeIdTo);
       throw new IllegalStateException("Model was not found");
     }
-    if (knownNames.containsKey(modelIdOf) && !knownNames.get(modelIdOf).equals(knownNames.get(modelIdTo))) {
+    if (knownNames.containsKey(typeIdOf) && !knownNames.get(typeIdOf).equals(knownNames.get(typeIdTo))) {
       LOG.warn(
           "Model with model id: {} already has equality to other model",
-          modelIdTo);
+          typeIdTo);
       throw new IllegalStateException("Model already has equality to other model");
     }
     knownNames.put(
-        modelIdOf,
-        knownNames.get(modelIdTo));
+        typeIdOf,
+        knownNames.get(typeIdTo));
   }
 
 }

--- a/springfox-spi/src/main/java/springfox/documentation/spi/schema/UniqueTypeNameAdapter.java
+++ b/springfox-spi/src/main/java/springfox/documentation/spi/schema/UniqueTypeNameAdapter.java
@@ -35,40 +35,40 @@ public interface UniqueTypeNameAdapter {
   /**
    * Returns type for the model
    * 
-   * @param modelId
-   *          - id of model
+   * @param typeId
+   *          - id of model type
    * @return Optional of a model names
    */
-  Optional<String> getTypeName(String modelId);
+  Optional<String> getTypeName(String typeId);
 
   /**
    * Add model name as is without adjusting
    * 
    * @param typeName
    *          - string representation of the models name
-   * @param modelId
-   *          - id of model
+   * @param typeId
+   *          - id of model type
    */
-  void registerType(String typeName, String modelId);
+  void registerType(String typeName, String typeId);
 
   /**
    * Register model name to keep it unique
    * 
    * @param typeName
    *          - string representation of the models name
-   * @param modelId
-   *          - id of model
+   * @param typeId
+   *          - id of model type
    */
-  void registerUniqueType(String typeName, String modelId);
+  void registerUniqueType(String typeName, String typeId);
 
   /**
    * Sets equality of two models to make sure, that models will be treated as one
    * 
    * @param modelIdOf
-   *          - id of the current model
+   *          - id of current model type
    * @param modelIdTo
-   *          - id of the existing model
+   *          - id of existing model type
    */
-  void setEqualityFor(String modelIdOf, String modelIdTo);
+  void setEqualityFor(String typeIdOf, String typeIdTo);
 
 }

--- a/springfox-spi/src/main/java/springfox/documentation/spi/schema/contexts/ModelContext.java
+++ b/springfox-spi/src/main/java/springfox/documentation/spi/schema/contexts/ModelContext.java
@@ -76,10 +76,7 @@ public class ModelContext {
     this.view = view;
     this.validationGroups = new HashSet<>(validationGroups);
     this.modelBuilder =
-        new ModelBuilder(new StringBuilder(parameterId)
-            .append("_")
-            .append(type.getBriefDescription()).
-            toString());
+        new ModelBuilder(getModelId());
   }
 
   @SuppressWarnings("ParameterNumber")
@@ -99,10 +96,7 @@ public class ModelContext {
     this.registeredTypes = parentContext.registeredTypes;
     this.genericNamingStrategy = parentContext.getGenericNamingStrategy();
     this.modelBuilder =
-        new ModelBuilder(new StringBuilder(parameterId)
-            .append("_")
-            .append(type.getBriefDescription()).
-            toString());
+        new ModelBuilder(getModelId());
   }
 
   /**
@@ -120,12 +114,19 @@ public class ModelContext {
   }
 
   /**
-   * @return type id behind this context
+   * @return type id of model behind this context
+   */
+  public String getModelId() {
+    return type.getBriefDescription();
+  }
+
+  /**
+   * @return type id of type behind this context
    */
   public String getTypeId() {
     return new StringBuilder(parameterId)
         .append("_")
-        .append(type.getBriefDescription()).
+        .append(getModelId()).
         toString();
   }
 
@@ -324,8 +325,7 @@ public class ModelContext {
     ModelContext that = (ModelContext) o;
 
     return
-        Objects.equals(parameterId, that.parameterId)
-            && Objects.equals(groupName, that.groupName)
+          Objects.equals(groupName, that.groupName)
             && Objects.equals(type, that.type)
             && Objects.equals(view, that.view)
             && Objects.equals(validationGroups, that.validationGroups)
@@ -344,7 +344,6 @@ public class ModelContext {
   @Override
   public int hashCode() {
     return Objects.hash(
-        parameterId,
         groupName,
         type,
         view,

--- a/springfox-spi/src/main/java/springfox/documentation/spi/service/contexts/OperationModelContextsBuilder.java
+++ b/springfox-spi/src/main/java/springfox/documentation/spi/service/contexts/OperationModelContextsBuilder.java
@@ -62,47 +62,29 @@ public class OperationModelContextsBuilder {
   }
 
   public ModelContext addReturn(ResolvedType type) {
-    return addReturn(
-        type,
-        Optional.empty());
+    return addReturn(type, Optional.empty());
   }
 
-  public ModelContext addReturn(
-      ResolvedType type,
-      Optional<ResolvedType> view) {
-    Optional<ModelContext> context =
-        contexts.stream()
-            .filter(ctx -> ctx.getType().equals(type)
-                && ctx.getView().equals(view)
-                && ctx.getValidationGroups().equals(new HashSet<ResolvedType>())
-                && ctx.isReturnType()).findFirst();
-
-    if (context.isPresent()) {
-      return context.get();
-    } else {
-      ModelContext returnValue = ModelContext.returnValue(
-          String.format(
-              "%s_%s",
-              requestMappingId,
-              parameterIndex),
-          group,
-          type,
-          view,
-          documentationType,
-          alternateTypeProvider,
-          genericsNamingStrategy,
-          ignorableTypes);
-      this.contexts.add(returnValue);
+  public ModelContext addReturn(ResolvedType type, Optional<ResolvedType> view) {
+    ModelContext returnValue = ModelContext.returnValue(
+        String.format("%s_%s", requestMappingId, parameterIndex),
+        group,
+        type,
+        view,
+        documentationType,
+        alternateTypeProvider,
+        genericsNamingStrategy,
+        ignorableTypes);
+    if (this.contexts.add(returnValue)) {
       ++parameterIndex;
       return returnValue;
     }
+
+    return contexts.stream().filter(context -> context.equals(returnValue)).findFirst().get();
   }
 
   public ModelContext addInputParam(ResolvedType type) {
-    return addInputParam(
-        type,
-        Optional.empty(),
-        new HashSet<>());
+    return addInputParam(type, Optional.empty(), new HashSet<>());
   }
 
   public ModelContext addInputParam(
@@ -110,48 +92,30 @@ public class OperationModelContextsBuilder {
       Optional<ResolvedType> view,
       Set<ResolvedType> validationGroups) {
     validationGroups = new HashSet<>(validationGroups);
-    Set<ResolvedType> finalValidationGroups = validationGroups;
-    Optional<ModelContext> context =
-        contexts.stream()
-            .filter(ctx -> ctx.getType().equals(type) &&
-                ctx.getView().equals(view)
-                && ctx.getValidationGroups().equals(finalValidationGroups)
-                && !ctx.isReturnType())
-            .findFirst();
-
-    if (context.isPresent()) {
-      return context.get();
-    } else {
-      ModelContext inputParam = ModelContext.inputParam(
-          String.format(
-              "%s_%s",
-              requestMappingId,
-              parameterIndex),
-          group,
-          type,
-          view,
-          validationGroups,
-          documentationType,
-          alternateTypeProvider,
-          genericsNamingStrategy,
-          ignorableTypes);
-      this.contexts.add(inputParam);
+    ModelContext inputParam = ModelContext.inputParam(
+        String.format("%s_%s", requestMappingId, parameterIndex),
+        group,
+        type,
+        view,
+        validationGroups,
+        documentationType,
+        alternateTypeProvider,
+        genericsNamingStrategy,
+        ignorableTypes);
+    if (this.contexts.add(inputParam)) {
       ++parameterIndex;
       return inputParam;
     }
+
+    return contexts.stream().filter(context -> context.equals(inputParam)).findFirst().get();
   }
 
   public Set<ModelContext> build() {
-    Comparator<ModelContext> byParameterId =
-        Comparator.comparing(ModelContext::getParameterId);
+    Comparator<ModelContext> byParameterId = Comparator.comparing(ModelContext::getParameterId);
 
-    Supplier<TreeSet<ModelContext>> supplier =
-        () -> new TreeSet<>(byParameterId);
+    Supplier<TreeSet<ModelContext>> supplier = () -> new TreeSet<>(byParameterId);
 
-    return contexts.stream()
-        .collect(
-            collectingAndThen(
-                Collectors.toCollection(supplier),
-                Collections::unmodifiableSet));
+    return contexts.stream().collect(
+        collectingAndThen(Collectors.toCollection(supplier), Collections::unmodifiableSet));
   }
 }

--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/scanners/ApiListingScanner.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/scanners/ApiListingScanner.java
@@ -46,7 +46,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.TreeMap;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
@@ -127,7 +126,7 @@ public class ApiListingScanner {
 
     List<SecurityReference> securityReferences = new ArrayList<>();
 
-    Map<String, Set<Model>> globalModelMap = new TreeMap<>();
+    Map<String, Set<Model>> globalModelMap = new HashMap<>();
     for (final ResourceGroup resourceGroup : sortedByName(allResourceGroups)) {
 
       DocumentationContext documentationContext = context.getDocumentationContext();
@@ -150,7 +149,7 @@ public class ApiListingScanner {
           }
         });
         globalModelMap.putAll(currentModelMap);
-        apiDescriptions.addAll(apiDescriptionReader.read(each.withKnownModels(globalModelMap)));
+        apiDescriptions.addAll(apiDescriptionReader.read(each.withKnownModels(currentModelMap)));
       }
 
       List<ApiDescription> additional = additionalListings.stream()

--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/scanners/MergingContext.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/scanners/MergingContext.java
@@ -32,6 +32,7 @@ import java.util.Set;
 public class MergingContext {
 
   private final String rootId;
+  private final String parameterId;
   private final Map<String, Set<String>> circlePath;
   private final Map<String, Set<String>> circleParameters;
   private final Map<String, ComparisonCondition> globalComparisonConditions;
@@ -41,12 +42,13 @@ public class MergingContext {
   private final Map<String, Model> currentBranch;
   private final Set<String> seenModels;
 
-  public MergingContext(
+  public MergingContext(String parameterId,
       Map<String, Set<Model>> typedModelMap,
       Map<String, String> modelIdToParameterId,
       Map<String, Model> currentBranch,
       Map<String, ModelContext> contextMap) {
     this.rootId = "";
+    this.parameterId = parameterId;
     this.globalComparisonConditions = new HashMap<>();
     this.circlePath = new HashMap<>();
     this.circleParameters = new HashMap<>();
@@ -59,6 +61,7 @@ public class MergingContext {
 
   private MergingContext(String rootId, Set<String> seenModels, MergingContext mergingContext) {
     this.rootId = rootId;
+    this.parameterId = mergingContext.parameterId;
     this.circlePath = Collections.unmodifiableMap(copyMap(mergingContext.circlePath));
     this.circleParameters = Collections.unmodifiableMap(copyMap(mergingContext.circleParameters));
     this.globalComparisonConditions = Collections
@@ -70,14 +73,14 @@ public class MergingContext {
     this.seenModels = Collections.unmodifiableSet(seenModels);
   }
 
-  private MergingContext(
-      String rootId,
+  private MergingContext(String rootId,
       Set<String> seenModels,
       Map<String, Set<String>> circlePath,
       Map<String, Set<String>> circleParameters,
       Map<String, ComparisonCondition> globalComparisonConditions,
       MergingContext mergingContext) {
     this.rootId = rootId;
+    this.parameterId = mergingContext.parameterId;
     this.circlePath = Collections.unmodifiableMap(circlePath);
     this.circleParameters = Collections.unmodifiableMap(circleParameters);
     this.globalComparisonConditions = Collections.unmodifiableMap(globalComparisonConditions);
@@ -90,6 +93,10 @@ public class MergingContext {
 
   public String getRootId() {
     return this.rootId;
+  }
+
+  public String getParameterId() {
+    return this.parameterId;
   }
 
   public Optional<ComparisonCondition> getComparisonCondition(String modelFor) {
@@ -135,8 +142,7 @@ public class MergingContext {
     return this.seenModels.contains(modelId);
   }
 
-  public MergingContext toRootId(
-      String rootId,
+  public MergingContext toRootId(String rootId,
       Set<ComparisonCondition> comparisonConditions,
       Set<String> allowedParameters) {
     Set<String> localSeenModels = new HashSet<>(this.seenModels);

--- a/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/mixins/ModelProviderForServiceSupport.groovy
+++ b/springfox-spring-web/src/test/groovy/springfox/documentation/spring/web/mixins/ModelProviderForServiceSupport.groovy
@@ -24,6 +24,8 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.PropertyNamingStrategy
 import org.springframework.plugin.core.OrderAwarePluginRegistry
 import org.springframework.plugin.core.PluginRegistry
+import springfox.documentation.schema.CachingModelDependencyProvider
+import springfox.documentation.schema.CachingModelProvider
 import springfox.documentation.schema.DefaultModelDependencyProvider
 import springfox.documentation.schema.DefaultModelProvider
 import springfox.documentation.schema.DefaultTypeNameProvider
@@ -33,6 +35,7 @@ import springfox.documentation.schema.TypeNameExtractor
 import springfox.documentation.schema.configuration.ObjectMapperConfigured
 import springfox.documentation.schema.mixins.SchemaPluginsSupport
 import springfox.documentation.schema.plugins.SchemaPluginsManager
+import springfox.documentation.schema.property.CachingModelPropertiesProvider
 import springfox.documentation.schema.property.FactoryMethodProvider
 import springfox.documentation.schema.property.ObjectMapperBeanPropertyNamingStrategy
 import springfox.documentation.schema.property.OptimizedModelPropertiesProvider
@@ -74,17 +77,18 @@ class ModelProviderForServiceSupport {
     def modelDependenciesProvider =
         new DefaultModelDependencyProvider(
             typeResolver,
-            modelPropertiesProvider,
+            new CachingModelPropertiesProvider(typeResolver, modelPropertiesProvider),
             typeNameExtractor,
             enumTypeDeterminer,
             defaultSchemaPlugins())
-    new DefaultModelProvider(
-        typeResolver,
-        modelPropertiesProvider,
-        modelDependenciesProvider,
-        pluginsManager,
-        typeNameExtractor,
-        enumTypeDeterminer)
+    new CachingModelProvider(
+        new DefaultModelProvider(
+          typeResolver,
+          modelPropertiesProvider,
+          new CachingModelDependencyProvider(modelDependenciesProvider),
+          pluginsManager,
+          typeNameExtractor,
+          enumTypeDeterminer))
   }
 
   ModelProvider modelProviderWithSnakeCaseNamingStrategy(
@@ -119,6 +123,5 @@ class ModelProviderForServiceSupport {
         typeNameExtractor,
         enumTypeDeterminer)
   }
-
 
 }

--- a/springfox-spring-webmvc/src/test/groovy/springfox/documentation/spring/web/readers/ApiModelReaderSpec.groovy
+++ b/springfox-spring-webmvc/src/test/groovy/springfox/documentation/spring/web/readers/ApiModelReaderSpec.groovy
@@ -440,11 +440,11 @@ class ApiModelReaderSpec extends DocumentationContextSpec {
     and:
     pirate_1.getProperties().containsKey('monkey')
     ModelReference modelRef_1 = pirate_1.getProperties().get('monkey').getModelRef()
-    modelRef_1.getModelId().get() == "0_0_springfox.documentation.spring.web.dummy.models.Monkey"
+    modelRef_1.getModelId().get() == "springfox.documentation.spring.web.dummy.models.Monkey"
 
     monkey_1.getProperties().containsKey('pirate')
     ModelReference modelRef_2 = monkey_1.getProperties().get('pirate').getModelRef()
-    modelRef_2.getModelId().get() == "0_0_springfox.documentation.spring.web.dummy.models.Pirate"
+    modelRef_2.getModelId().get() == "springfox.documentation.spring.web.dummy.models.Pirate"
 
     and:
     Model pirate_2 = models_2[Pirate.simpleName]
@@ -460,11 +460,11 @@ class ApiModelReaderSpec extends DocumentationContextSpec {
     and:
     pirate_2.getProperties().containsKey('monkey')
     ModelReference modelRef_3 = pirate_2.getProperties().get('monkey').getModelRef()
-    modelRef_3.getModelId().get() == "0_1_springfox.documentation.spring.web.dummy.models.Monkey"
+    modelRef_3.getModelId().get() == "springfox.documentation.spring.web.dummy.models.Monkey"
 
     monkey_2.getProperties().containsKey('pirate')
     ModelReference modelRef_4 = monkey_2.getProperties().get('pirate').getModelRef()
-    modelRef_4.getModelId().get() == "0_1_springfox.documentation.spring.web.dummy.models.Pirate"
+    modelRef_4.getModelId().get() == "springfox.documentation.spring.web.dummy.models.Pirate"
 
   }
 
@@ -503,17 +503,17 @@ class ApiModelReaderSpec extends DocumentationContextSpec {
     and:
     recursiveTypeWithConditions_1.getProperties().containsKey('monkey')
     ModelReference modelRef_1 = recursiveTypeWithConditions_1.getProperties().get('monkey').getModelRef()
-    modelRef_1.getModelId().get() == "0_0_springfox.documentation.spring.web.dummy.models.Monkey"
+    modelRef_1.getModelId().get() == "springfox.documentation.spring.web.dummy.models.Monkey"
     modelRef_1.getType() == 'Monkey'
 
     monkey_1.getProperties().containsKey('pirate')
     ModelReference modelRef_2 = monkey_1.getProperties().get('pirate').getModelRef()
-    modelRef_2.getModelId().get() == "0_0_springfox.documentation.spring.web.dummy.models.Pirate"
+    modelRef_2.getModelId().get() == "springfox.documentation.spring.web.dummy.models.Pirate"
     modelRef_2.getType() == 'Pirate'
 
     pirate_1.getProperties().containsKey('monkey')
     ModelReference modelRef_3 = pirate_1.getProperties().get('monkey').getModelRef()
-    modelRef_3.getModelId().get() == "0_0_springfox.documentation.spring.web.dummy.models.Monkey"
+    modelRef_3.getModelId().get() == "springfox.documentation.spring.web.dummy.models.Monkey"
     modelRef_3.getType() == 'Monkey'
 
     and:
@@ -532,19 +532,19 @@ class ApiModelReaderSpec extends DocumentationContextSpec {
     and:
     recursiveTypeWithConditions_2.getProperties().containsKey('monkey')
     ModelReference modelRef_4 = recursiveTypeWithConditions_2.getProperties().get('monkey').getModelRef()
-    modelRef_4.getModelId().get() == "0_1_springfox.documentation.spring.web.dummy.models.Monkey"
+    modelRef_4.getModelId().get() == "springfox.documentation.spring.web.dummy.models.Monkey"
     modelRef_4.getType() == 'Monkey'
 
     recursiveTypeWithConditions_2.getProperties().containsKey('conditionalProperty')
 
     monkey_2.getProperties().containsKey('pirate')
     ModelReference modelRef_5 = monkey_2.getProperties().get('pirate').getModelRef()
-    modelRef_5.getModelId().get() == "0_1_springfox.documentation.spring.web.dummy.models.Pirate"
+    modelRef_5.getModelId().get() == "springfox.documentation.spring.web.dummy.models.Pirate"
     modelRef_5.getType() == 'Pirate'
 
     pirate_2.getProperties().containsKey('monkey')
     ModelReference modelRef_6 = pirate_2.getProperties().get('monkey').getModelRef()
-    modelRef_6.getModelId().get() == "0_1_springfox.documentation.spring.web.dummy.models.Monkey"
+    modelRef_6.getModelId().get() == "springfox.documentation.spring.web.dummy.models.Monkey"
     modelRef_6.getType() == 'Monkey'
 
   }
@@ -655,19 +655,19 @@ class ApiModelReaderSpec extends DocumentationContextSpec {
     recursiveTypeWithConditionsOuter_1.getProperties().containsKey('recursiveTypeWithNonEqualsConditionsMiddle')
     ModelReference modelRef_1 = recursiveTypeWithConditionsOuter_1.getProperties()
         .get('recursiveTypeWithNonEqualsConditionsMiddle').getModelRef()
-    modelRef_1.getModelId().get() == "0_0_springfox.documentation.spring.web.dummy.models.RecursiveTypeWithNonEqualsConditionsMiddle"
+    modelRef_1.getModelId().get() == "springfox.documentation.spring.web.dummy.models.RecursiveTypeWithNonEqualsConditionsMiddle"
     modelRef_1.getType() == 'RecursiveTypeWithNonEqualsConditionsMiddle'
 
     recursiveTypeWithConditionsMiddle_1.getProperties().containsKey('recursiveTypeWithNonEqualsConditionsInner')
     ModelReference modelRef_2 = recursiveTypeWithConditionsMiddle_1.getProperties()
         .get('recursiveTypeWithNonEqualsConditionsInner').getModelRef()
-    modelRef_2.getModelId().get() == "0_0_springfox.documentation.spring.web.dummy.models.RecursiveTypeWithNonEqualsConditionsInner"
+    modelRef_2.getModelId().get() == "springfox.documentation.spring.web.dummy.models.RecursiveTypeWithNonEqualsConditionsInner"
     modelRef_2.getType() == 'RecursiveTypeWithNonEqualsConditionsInner'
 
     recursiveTypeWithConditionsInner_1.getProperties().containsKey('recursiveTypeWithNonEqualsConditionsOuter')
     ModelReference modelRef_3 = recursiveTypeWithConditionsInner_1.getProperties()
         .get('recursiveTypeWithNonEqualsConditionsOuter').getModelRef()
-    modelRef_3.getModelId().get() == "0_0_springfox.documentation.spring.web.dummy.models.RecursiveTypeWithNonEqualsConditionsOuter"
+    modelRef_3.getModelId().get() == "springfox.documentation.spring.web.dummy.models.RecursiveTypeWithNonEqualsConditionsOuter"
     modelRef_3.getType() == 'RecursiveTypeWithNonEqualsConditionsOuter'
 
     and:
@@ -689,19 +689,19 @@ class ApiModelReaderSpec extends DocumentationContextSpec {
     recursiveTypeWithConditionsOuter_2.getProperties().containsKey('recursiveTypeWithNonEqualsConditionsMiddle')
     ModelReference modelRef_4 = recursiveTypeWithConditionsOuter_2.getProperties()
         .get('recursiveTypeWithNonEqualsConditionsMiddle').getModelRef()
-    modelRef_4.getModelId().get() == "0_1_springfox.documentation.spring.web.dummy.models.RecursiveTypeWithNonEqualsConditionsMiddle"
+    modelRef_4.getModelId().get() == "springfox.documentation.spring.web.dummy.models.RecursiveTypeWithNonEqualsConditionsMiddle"
     modelRef_4.getType() == 'RecursiveTypeWithNonEqualsConditionsMiddle_1'
 
     recursiveTypeWithConditionsMiddle_2.getProperties().containsKey('recursiveTypeWithNonEqualsConditionsInner')
     ModelReference modelRef_5 = recursiveTypeWithConditionsMiddle_2.getProperties()
         .get('recursiveTypeWithNonEqualsConditionsInner').getModelRef()
-    modelRef_5.getModelId().get() == "0_1_springfox.documentation.spring.web.dummy.models.RecursiveTypeWithNonEqualsConditionsInner"
+    modelRef_5.getModelId().get() == "springfox.documentation.spring.web.dummy.models.RecursiveTypeWithNonEqualsConditionsInner"
     modelRef_5.getType() == 'RecursiveTypeWithNonEqualsConditionsInner_1'
 
     recursiveTypeWithConditionsInner_2.getProperties().containsKey('recursiveTypeWithNonEqualsConditionsOuter')
     ModelReference modelRef_6 = recursiveTypeWithConditionsInner_2.getProperties()
         .get('recursiveTypeWithNonEqualsConditionsOuter').getModelRef()
-    modelRef_6.getModelId().get() == "0_1_springfox.documentation.spring.web.dummy.models.RecursiveTypeWithNonEqualsConditionsOuter"
+    modelRef_6.getModelId().get() == "springfox.documentation.spring.web.dummy.models.RecursiveTypeWithNonEqualsConditionsOuter"
     modelRef_6.getType() == 'RecursiveTypeWithNonEqualsConditionsOuter_1'
 
   }
@@ -1090,7 +1090,7 @@ class ApiModelReaderSpec extends DocumentationContextSpec {
     recursiveTypeWithNonEqualsConditionsOuterWithSubTypes.getProperties().size() == 1
     recursiveTypeWithNonEqualsConditionsOuterWithSubTypes.getSubTypes().size() == 1
     ModelReference modelRef = recursiveTypeWithNonEqualsConditionsOuterWithSubTypes.getSubTypes().get(0)
-    modelRef.getModelId().get() == "2_0_springfox.documentation.spring.web.dummy.models.RecursiveTypeWithConditions"
+    modelRef.getModelId().get() == "springfox.documentation.spring.web.dummy.models.RecursiveTypeWithConditions"
     modelRef.getType() == 'RecursiveTypeWithConditions'
     recursiveTypeWithConditions_3.equalsIgnoringName(recursiveTypeWithConditions_1)
 
@@ -1187,7 +1187,7 @@ class ApiModelReaderSpec extends DocumentationContextSpec {
     ModelReference modelRef_1 = fancyPet_1.getProperties().get('categories').getModelRef()
     modelRef_1.isCollection()
     modelRef_1.itemModel().get()
-        .getModelId().get() == "0_0_springfox.documentation.spring.web.dummy.models.Category"
+        .getModelId().get() == "springfox.documentation.spring.web.dummy.models.Category"
     and:
     category_1.getProperties().size() == 1
     category_1.getProperties().containsKey('name')
@@ -1208,7 +1208,7 @@ class ApiModelReaderSpec extends DocumentationContextSpec {
     ModelReference modelRef_2 = fancyPet_2.getProperties().get('categories').getModelRef()
     modelRef_2.isCollection()
     modelRef_2.itemModel().get()
-        .getModelId().get() == "0_1_springfox.documentation.spring.web.dummy.models.Category"
+        .getModelId().get() == "springfox.documentation.spring.web.dummy.models.Category"
     and:
     category_2.getProperties().size() == 1
     category_2.getProperties().containsKey('name')

--- a/springfox-swagger2/src/test/groovy/springfox/documentation/swagger2/mappers/ModelMapperSpec.groovy
+++ b/springfox-swagger2/src/test/groovy/springfox/documentation/swagger2/mappers/ModelMapperSpec.groovy
@@ -141,9 +141,9 @@ class ModelMapperSpec extends SchemaSpecification {
 
 
     then:
-    mapped.containsKey("0_0_java.util.Map<java.lang.String,java.lang.String>")
+    mapped.containsKey("java.util.Map<java.lang.String,java.lang.String>")
     and:
-    def mappedModel = mapped.get("0_0_java.util.Map<java.lang.String,java.lang.String>")
+    def mappedModel = mapped.get("java.util.Map<java.lang.String,java.lang.String>")
     mappedModel.name == "MapOfstringAndstring"
     mappedModel.additionalProperties instanceof StringProperty
   }
@@ -168,9 +168,9 @@ class ModelMapperSpec extends SchemaSpecification {
             Function.identity())))
 
     then:
-    mapped.containsKey("0_0_org.springframework.ui.ModelMap")
+    mapped.containsKey("org.springframework.ui.ModelMap")
     and:
-    def mappedModel = mapped.get("0_0_org.springframework.ui.ModelMap")
+    def mappedModel = mapped.get("org.springframework.ui.ModelMap")
     mappedModel.name == "ModelMap"
     mappedModel.additionalProperties instanceof ObjectProperty
 
@@ -196,10 +196,10 @@ class ModelMapperSpec extends SchemaSpecification {
             Function.identity())))
 
     then:
-    mapped.containsKey("0_0_java.util.Map<java.lang.String,springfox.documentation.schema.SimpleType>")
-    mapped.containsKey("0_0_springfox.documentation.schema.SimpleType")
+    mapped.containsKey("java.util.Map<java.lang.String,springfox.documentation.schema.SimpleType>")
+    mapped.containsKey("springfox.documentation.schema.SimpleType")
     and:
-    def mappedModel = mapped.get("0_0_java.util.Map<java.lang.String,springfox.documentation.schema.SimpleType>")
+    def mappedModel = mapped.get("java.util.Map<java.lang.String,springfox.documentation.schema.SimpleType>")
     mappedModel.name == "MapOfstringAndSimpleType"
     mappedModel.additionalProperties instanceof RefProperty
 


### PR DESCRIPTION
This PR returns support for cache. Variable `parameterId` has been removed from `.equals()` and `.hashCode()`  methods of `ModelContext`. Speed  on load testing shows increasing from _**130**_ test controllers to _**300**_ controllers per second.