### PR TITLE
Reduce number of Groovy dependencies

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -41,7 +41,9 @@ ext {
           "org.yaml:snakeyaml:${snakeyaml}",
           "org.spockframework:spock-spring:${spock}",
           "org.spockframework:spock-core:${spock}",
-          "org.codehaus.groovy:groovy-all:${groovy}",
+          "org.spockframework:spock-junit4:${spock}",
+          "org.codehaus.groovy:groovy:${groovy}",
+          "org.codehaus.groovy:groovy-json:${groovy}",
           "org.springframework.hateoas:spring-hateoas:${springHateoas}",
           "nl.jqno.equalsverifier:equalsverifier:${equalsverifierVersion}"
       ],
@@ -55,7 +57,9 @@ ext {
           "org.yaml:snakeyaml:${snakeyaml}",
           "org.spockframework:spock-spring:${spock}",
           "org.spockframework:spock-core:${spock}",
-          "org.codehaus.groovy:groovy-all:${groovy}",
+          "org.spockframework:spock-junit4:${spock}",
+          "org.codehaus.groovy:groovy:${groovy}",
+          "org.codehaus.groovy:groovy-json:${groovy}",
           "nl.jqno.equalsverifier:equalsverifier:${equalsverifierVersion}"
       ],
       swagger2Core                       : [


### PR DESCRIPTION
To do not download several (not needed) [`groovy-X.jar`s](https://repo1.maven.org/maven2/org/codehaus/groovy/groovy-all/3.0.4/groovy-all-3.0.4.pom). Possible thanks to changes in Spock 2.0-M3+.

More details:
https://blog.solidsoft.pl/2020/06/16/what-happened-to-groovy-dependencies-in-spock-2.0/

Btw, feel free to wait with a merge until the CI build is stabilized.
Btw2, spock-junit4 is needed as you have JUnit 4 tests. It worked accidentally after the migration as groovy-all depends on groovy-test which depends on junit4.

Found accidentally due to https://github.com/spockframework/spock/issues/1186.