### PR TITLE
Readme/Docs: mention @EnableWebMvc for Spring Boot migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ NOTE: Would love feedback to make this better
 4. Springfox 3.x removes dependencies on guava and other 3rd party libraries (not zero dep yet! depends on spring plugin
 and open api libraries for annotations and models) so if you used guava predicates/functions those will need to 
 transition to java 8 function interfaces 
+5. If you are using WebMvc but you don't use the [`@EnableWebMvc`](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/servlet/config/annotation/EnableWebMvc.html) annotation yet, add this annotation.
 
 #### Regular spring mvc  
 NOTE: Would love feedback to make this experience better

--- a/docs/asciidoc/getting_started.adoc
+++ b/docs/asciidoc/getting_started.adoc
@@ -121,6 +121,7 @@ dependencies {
 4. Springfox 3.x removes dependencies on guava and other 3rd party libraries (not zero dep yet! depends on spring plugin
 and open api libraries for annotations and models) so if you used guava predicates/functions those will need to
 transition to java 8 function interfaces
+5. If you are using WebMvc but you don't use the https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/servlet/config/annotation/EnableWebMvc.html[`@EnableWebMvc`] annotation yet, add this annotation.
 
 ===== Regular spring mvc
 1. Remove library inclusions of earlier releases. Specifically remove `springfox-swagger2` and `springfox-swagger-ui` inclusions.


### PR DESCRIPTION
I upgraded from Springfox 2.9.2 to 3.0.0 in our Spring Boot application. We were using WebMvc without the `@EnableWebMvc` annotation and the swagger UI wasn't reachable. The problem was that Springfox' `SwaggerUiWebMvcConfigurer` was never called. After adding `@EnableWebMvc` to our WebMvc configuration class, http://localhost:8080/swagger-ui/index.html does now work fine.

To keep others from running into the same problem, this PR adds information about `@EnableWebMvc` to the Spring Boot migration sections in Readme and docs.

By the way, http://localhost:8080/swagger-ui/ still doesn't work in our application, but I haven't yet figured out what the problem is.