### PR TITLE
if ParameterType is query,append ParentName to parameterName

### DIFF
--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/parameter/SwaggerExpandedParameterBuilder.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/parameter/SwaggerExpandedParameterBuilder.java
@@ -141,6 +141,9 @@ public class SwaggerExpandedParameterBuilder implements ExpandedParameterBuilder
       ParameterExpansionContext context,
       String parameterName) {
     if (!isEmpty(parameterName)) {
+      if ("query".equals(context.getParameterType()) && !isEmpty(context.getParentName())){
+        parameterName = String.format("%s.%s", context.getParentName(), parameterName);
+      }
       context.getParameterBuilder().name(parameterName);
       context.getRequestParameterBuilder().name(parameterName);
     }


### PR DESCRIPTION
#### What's this PR do/fix?
if ParameterType is query,append ParentName to parameterName

#### Are there unit tests? If not how should this be manually tested?
Test code is here: https://github.com/xiejx618/demo

#### Any background context you want to provide?
https://github.com/springfox/springfox/issues/3499

#### What are the relevant issues?
https://github.com/springfox/springfox/issues/3499

Because this situation is treated as the same parameter, deduplication is triggered, and then a null pointer exception is triggered
https://github.com/springfox/springfox/pull/3490
