### PR TITLE
[Document] Update swagger-ui URL location.

### DIFF
--- a/docs/asciidoc/getting_started.adoc
+++ b/docs/asciidoc/getting_started.adoc
@@ -136,7 +136,7 @@ NOTE: For non-boot applications `springfox-swagger-ui` is no longer automaticall
 using a resource handler configurer (`WebFluxConfigurer` or `WebMvcConfigurer`). Here is how it is configured in
 `springfox-boot-starter`
 
-NOTE: swagger-ui location has moved from `http://host/context-path/swagger-ui.html`  to `http://host/context-path/swagger-ui/index.html`
+NOTE: swagger-ui location has moved from `http://host/context-path/`  to `http://host/context-path/swagger-ui/index.html`
 OR `http://host/context-path/swagger-ui/` for short. This makes it work much better with pulling it as a web jar and turning it off
 using configuration properties if not needed.
 
@@ -339,7 +339,7 @@ dependencies {
 
 Pulling in the dependency creates a webjar containing the swagger-ui static content. It adds a JSON endpoint
 `/swagger-resources` which lists all of the swagger resources and versions configured for a given
-application. The Swagger UI page should then be available at http://localhost:8080/swagger-ui.html[]
+application. The Swagger UI page should then be available at http://localhost:8080/swagger-ui/index.html[]
 
 image::springfox-swagger-ui.png[Swagger UI]
 
@@ -347,7 +347,7 @@ The swagger ui version is specified in ./build.gradle where `swaggerUiVersion` i
 https:// github.com/swagger-api/swagger-ui[swagger-ui repo].
 
 All content is served from a webjar convention, relative url taking the following form:
-`webjars/springfox-swagger-ui/{releaseVersion}/swagger-ui.html`
+`webjars/springfox-swagger-ui/{releaseVersion}/swagger-ui/index.html`
 
 By default Spring Boot has sensible defaults for serving content from webjars. To configure vanilla spring web mvc
 apps to serve webjar content see the http://www.webjars.org/documentation#springmvc[webjar documentation]

--- a/docs/asciidoc/getting_started.adoc
+++ b/docs/asciidoc/getting_started.adoc
@@ -136,7 +136,7 @@ NOTE: For non-boot applications `springfox-swagger-ui` is no longer automaticall
 using a resource handler configurer (`WebFluxConfigurer` or `WebMvcConfigurer`). Here is how it is configured in
 `springfox-boot-starter`
 
-NOTE: swagger-ui location has moved from `http://host/context-path/`  to `http://host/context-path/swagger-ui/index.html`
+NOTE: swagger-ui location has moved from `http://host/context-path/swagger-ui.html`  to `http://host/context-path/swagger-ui/index.html`
 OR `http://host/context-path/swagger-ui/` for short. This makes it work much better with pulling it as a web jar and turning it off
 using configuration properties if not needed.
 


### PR DESCRIPTION
#### What's this PR do/fix?
There are some documents which refers that swagger-ui location is `http://{host}/swagger-ui.html`.
This PR fixes those issues.

#### Are there unit tests? If not how should this be manually tested?
no, this fixes only documents.

#### Any background context you want to provide?
I wasted 1 hour to find out correct path, so I don't like to made mistakes like me.

#### What are the relevant issues?
