### PR TITLE
doc: Align the documentation and examples

### DIFF
--- a/docs/asciidoc/common-problems.adoc
+++ b/docs/asciidoc/common-problems.adoc
@@ -72,7 +72,7 @@ public class MyWebAutoConfiguration extends WebMvcConfigurerAdapter {
 }
 ----
 
-[[q5]]*Q. How do we use Java 8 types easily. LocalDateTime?*
+[[q5]]*Q. How do we use Java 8 date/time types easily?*
 
 A. The easiest way to to configure dates is via `Docket#directModelSubstitute(LocalDateTime.class, String.class)`. If
 these are ISO 8601 dates that conform to a string format i.e. `yyyy-MM-dd'T'HH:mm'Z'`. However you won't have any format or validation info.

--- a/docs/asciidoc/getting_started.adoc
+++ b/docs/asciidoc/getting_started.adoc
@@ -190,7 +190,7 @@ via swagger.
 <7> The selector needs to be built after configuring the api and path selectors.
 <8> Adds a servlet path mapping, when the servlet has a path mapping.
 This prefixes paths with the provided path mapping.
-<9> Convenience rule builder that substitutes `LocalDate` with `String` when rendering model properties
+<9> Convenience rule builder that substitutes `LocalDate` with `java.sql.Date` when rendering model properties, see <<common-problems.adoc,Common Problems>> and the question "How do we use Java 8 date/time types easily?"
 <10> Convenience rule builder that substitutes a generic type with one type parameter with the type
 parameter. In this example `ResponseEntity<T>` with `T`.
 `alternateTypeRules` allows custom rules that are a bit more involved.

--- a/springfox-spring-config/src/main/java/springfox/springconfig/Swagger2SpringBoot.java
+++ b/springfox-spring-config/src/main/java/springfox/springconfig/Swagger2SpringBoot.java
@@ -80,7 +80,7 @@ public class Swagger2SpringBoot {
         .paths(PathSelectors.any()) //<6>
         .build() //<7>
         .pathMapping("/") //<8>
-        .directModelSubstitute(LocalDate.class, String.class) //<9>
+        .directModelSubstitute(LocalDate.class, java.sql.Date.class) //<9>
         .genericModelSubstitutes(ResponseEntity.class)
         .alternateTypeRules(
             newRule(typeResolver.resolve(DeferredResult.class,

--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/plugins/Docket.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/plugins/Docket.java
@@ -318,8 +318,10 @@ public class Docket implements DocumentationPlugin {
   /**
    * Directly substitutes a model class with the supplied substitute
    * e.g
-   * <code>directModelSubstitute(LocalDate.class, Date.class)</code>
-   * would substitute LocalDate with Date
+   * <code>directModelSubstitute(java.util.LocalDate.class, java.sql.Date.class)</code>
+   * would substitute LocalDate with java.sql.Date
+   *
+   * NOTE: @see <a href="http://springfox.github.io/springfox/docs/current/#answers-to-common-questions-and-problems</a>
    *
    * @param clazz class to substitute
    * @param with  the class which substitutes 'clazz'


### PR DESCRIPTION
Map date/times a suggested in the section "Answers to common questions and
problems"

http://springfox.github.io/springfox/docs/current/#answers-to-common-questions-and-problems

#### Are there unit tests? If not how should this be manually tested?
No.
#### Any background context you want to provide?
Thanks for the great work! 🎉 
#### What are the relevant issues?
I find it confusing when the documentation gives tips and then doesn't apply them in the examples. Or at least mention them...
