### PR TITLE
Bugfix/3560 log injection

### DIFF
--- a/springfox-swagger2/src/main/java/springfox/documentation/swagger2/util/UserInputLogEncoder.java
+++ b/springfox-swagger2/src/main/java/springfox/documentation/swagger2/util/UserInputLogEncoder.java
@@ -1,0 +1,37 @@
+/*
+ *
+ *  Copyright 2015-2020 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+
+package springfox.documentation.swagger2.util;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+public class UserInputLogEncoder {
+    private UserInputLogEncoder() {
+    }
+
+    public static String urlEncode(String userInput) {
+        try {
+            return URLEncoder.encode(userInput, StandardCharsets.UTF_8.toString());
+        } catch (UnsupportedEncodingException cannotHappen) {
+            return "";
+        }
+    }
+}

--- a/springfox-swagger2/src/main/java/springfox/documentation/swagger2/util/UserInputLogEncoder.java
+++ b/springfox-swagger2/src/main/java/springfox/documentation/swagger2/util/UserInputLogEncoder.java
@@ -28,10 +28,12 @@ public class UserInputLogEncoder {
     }
 
     public static String urlEncode(String userInput) {
+        String sanitizedUserInput = userInput;
         try {
-            return URLEncoder.encode(userInput, StandardCharsets.UTF_8.toString());
-        } catch (UnsupportedEncodingException cannotHappen) {
-            return "";
+            sanitizedUserInput = URLEncoder.encode(userInput, StandardCharsets.UTF_8.toString());
+        } catch (UnsupportedEncodingException ignored) {
+            // cannot happen, UTF_8 is supported
         }
+        return sanitizedUserInput;
     }
 }

--- a/springfox-swagger2/src/main/java/springfox/documentation/swagger2/web/Swagger2ControllerWebFlux.java
+++ b/springfox-swagger2/src/main/java/springfox/documentation/swagger2/web/Swagger2ControllerWebFlux.java
@@ -44,8 +44,8 @@ import springfox.documentation.spring.web.json.Json;
 import springfox.documentation.spring.web.json.JsonSerializer;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.mappers.ServiceModelToSwagger2Mapper;
+import springfox.documentation.swagger2.util.UserInputLogEncoder;
 
-import java.net.URLEncoder;
 import java.util.List;
 import java.util.Optional;
 
@@ -91,7 +91,7 @@ public class Swagger2ControllerWebFlux {
     String groupName = Optional.ofNullable(swaggerGroup).orElse(Docket.DEFAULT_GROUP_NAME);
     Documentation documentation = documentationCache.documentationByGroup(groupName);
     if (documentation == null) {
-      LOGGER.warn("Unable to find specification for group {}", URLEncoder.encode(groupName));
+      LOGGER.warn("Unable to find specification for group {}", UserInputLogEncoder.urlEncode(groupName));
       return new ResponseEntity<>(HttpStatus.NOT_FOUND);
     }
     Swagger swagger = mapper.mapDocumentation(documentation);

--- a/springfox-swagger2/src/main/java/springfox/documentation/swagger2/web/Swagger2ControllerWebFlux.java
+++ b/springfox-swagger2/src/main/java/springfox/documentation/swagger2/web/Swagger2ControllerWebFlux.java
@@ -45,6 +45,7 @@ import springfox.documentation.spring.web.json.JsonSerializer;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.mappers.ServiceModelToSwagger2Mapper;
 
+import java.net.URLEncoder;
 import java.util.List;
 import java.util.Optional;
 
@@ -90,7 +91,7 @@ public class Swagger2ControllerWebFlux {
     String groupName = Optional.ofNullable(swaggerGroup).orElse(Docket.DEFAULT_GROUP_NAME);
     Documentation documentation = documentationCache.documentationByGroup(groupName);
     if (documentation == null) {
-      LOGGER.warn("Unable to find specification for group {}", groupName);
+      LOGGER.warn("Unable to find specification for group {}", URLEncoder.encode(groupName));
       return new ResponseEntity<>(HttpStatus.NOT_FOUND);
     }
     Swagger swagger = mapper.mapDocumentation(documentation);

--- a/springfox-swagger2/src/main/java/springfox/documentation/swagger2/web/Swagger2ControllerWebMvc.java
+++ b/springfox-swagger2/src/main/java/springfox/documentation/swagger2/web/Swagger2ControllerWebMvc.java
@@ -47,6 +47,7 @@ import springfox.documentation.swagger2.mappers.ServiceModelToSwagger2Mapper;
 
 import javax.servlet.http.HttpServletRequest;
 
+import java.net.URLEncoder;
 import java.util.List;
 
 import static java.util.Optional.*;
@@ -93,7 +94,7 @@ public class Swagger2ControllerWebMvc {
     String groupName = ofNullable(swaggerGroup).orElse(Docket.DEFAULT_GROUP_NAME);
     Documentation documentation = documentationCache.documentationByGroup(groupName);
     if (documentation == null) {
-      LOGGER.warn("Unable to find specification for group {}", groupName);
+      LOGGER.warn("Unable to find specification for group {}", URLEncoder.encode(groupName));
       return new ResponseEntity<>(HttpStatus.NOT_FOUND);
     }
     Swagger swagger = mapper.mapDocumentation(documentation);

--- a/springfox-swagger2/src/main/java/springfox/documentation/swagger2/web/Swagger2ControllerWebMvc.java
+++ b/springfox-swagger2/src/main/java/springfox/documentation/swagger2/web/Swagger2ControllerWebMvc.java
@@ -44,10 +44,10 @@ import springfox.documentation.spring.web.json.Json;
 import springfox.documentation.spring.web.json.JsonSerializer;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.mappers.ServiceModelToSwagger2Mapper;
+import springfox.documentation.swagger2.util.UserInputLogEncoder;
 
 import javax.servlet.http.HttpServletRequest;
 
-import java.net.URLEncoder;
 import java.util.List;
 
 import static java.util.Optional.*;
@@ -94,7 +94,7 @@ public class Swagger2ControllerWebMvc {
     String groupName = ofNullable(swaggerGroup).orElse(Docket.DEFAULT_GROUP_NAME);
     Documentation documentation = documentationCache.documentationByGroup(groupName);
     if (documentation == null) {
-      LOGGER.warn("Unable to find specification for group {}", URLEncoder.encode(groupName));
+      LOGGER.warn("Unable to find specification for group {}", UserInputLogEncoder.urlEncode(groupName));
       return new ResponseEntity<>(HttpStatus.NOT_FOUND);
     }
     Swagger swagger = mapper.mapDocumentation(documentation);

--- a/springfox-swagger2/src/test/java/springfox/documentation/swagger2/util/UserInputLogEncoderTest.java
+++ b/springfox-swagger2/src/test/java/springfox/documentation/swagger2/util/UserInputLogEncoderTest.java
@@ -1,0 +1,38 @@
+/*
+ *
+ *  Copyright 2015-2020 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+
+package springfox.documentation.swagger2.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class UserInputLogEncoderTest {
+    @Test
+    public void testUserInputShouldBeSanitized() throws Exception {
+        String encodedValid = UserInputLogEncoder.urlEncode("V2");
+        assertTrue(encodedValid.equals("V2"));
+
+        String encodedLogInject = UserInputLogEncoder.urlEncode("V2\ninjected-line");
+        assertTrue(encodedLogInject.equals("V2%0Ainjected-line"));
+
+        String encodedHtmlJsInject = UserInputLogEncoder.urlEncode("V2<script>alert('hi')</script>");
+        assertTrue(encodedHtmlJsInject.equals("V2%3Cscript%3Ealert%28%27hi%27%29%3C%2Fscript%3E"));
+    }
+}

--- a/swagger-contract-tests-webflux/src/test/groovy/springfox/test/contract/swaggertests/webflux/WebFluxFunctionContractSpec.groovy
+++ b/swagger-contract-tests-webflux/src/test/groovy/springfox/test/contract/swaggertests/webflux/WebFluxFunctionContractSpec.groovy
@@ -75,6 +75,26 @@ class WebFluxFunctionContractSpec extends Specification implements FileAccess {
 
   }
 
+  @Unroll
+  def 'should ignore invalid #groupName'() {
+    given:
+    RequestEntity<Void> request = RequestEntity.get(
+        new URI("http://localhost:$port/v2/api-docs?group=$groupName"))
+        .accept(MediaType.APPLICATION_JSON)
+        .build()
+
+    when:
+    def response = http.exchange(request, String)
+    then:
+    response.body == null
+    response.statusCode == HttpStatus.NOT_FOUND
+
+    where:
+    groupName                                              | _
+    'V2%0Ainjected-line'                                   | _
+    'V2%3Cscript%3Ealert%28%27hi%27%29%3C%2Fscript%3E'     | _
+  }
+
   def "should list swagger resources for swagger 2.0"() {
     given:
     def http = new TestRestTemplate()

--- a/swagger-contract-tests/src/test/groovy/springfox/test/contract/swaggertests/FunctionContractSpec.groovy
+++ b/swagger-contract-tests/src/test/groovy/springfox/test/contract/swaggertests/FunctionContractSpec.groovy
@@ -102,6 +102,26 @@ class FunctionContractSpec extends Specification implements FileAccess {
     'declaration-cyclic-controller.json'                          | 'cyclic'
   }
 
+  @Unroll
+  def 'should ignore invalid #groupName'() {
+    given:
+    RequestEntity<Void> request = RequestEntity.get(
+        new URI("http://localhost:$port/v2/api-docs?group=$groupName"))
+        .accept(MediaType.APPLICATION_JSON)
+        .build()
+
+    when:
+    def response = http.exchange(request, String)
+    then:
+    response.body == null
+    response.statusCode == HttpStatus.NOT_FOUND
+
+    where:
+    groupName                                              | _
+    'V2%0Ainjected-line'                                   | _
+    'V2%3Cscript%3Ealert%28%27hi%27%29%3C%2Fscript%3E'     | _
+  }
+
   def "should list swagger resources for swagger 2.0"() {
     given:
     RequestEntity<Void> request = RequestEntity.get(new URI("http://localhost:$port/swagger-resources"))


### PR DESCRIPTION
#### What's this PR do/fix?

This PR fixes [issue 3560 - log injection in springfox-swagger2](https://github.com/springfox/springfox/issues/3560).

The springfox-swagger2 library in version 3.0.0 and the current mainline allows log injection via the `group` parameter.

#### Are there unit tests? If not how should this be manually tested?

I have added a simple unit test for the encoding utility class, and using your generated IDEA project I can run the test, and it passes, but for some reason that I haven't found yet, the gradle build doesn't seem to run my test at all - it does not show up in the test report. 

_Edit: see comments below - I have now added the relevant contract tests_

Manual verification:

In any spring boot application using either the Swagger2ControllerWebFlux or Swagger2ControllerWebMvc, simply perform

GET on /v2/api-docs?group=lala%0Ainjected-line

(this is assuming the endpoint configuration wasn't changed). You will no longer see "injected-line" in your logs at the start of a new log output line, so the security issue is fixed.

#### Any background context you want to provide?

https://owasp.org/www-community/attacks/Log_Injection

I picked URLencoding as a simple fix because any valid group names shouldn't be altered by it, and hey, it's better than a log injection. Feel free to suggest another solution.

In order to make sure the encoding cannot be circumvented based on knowledge of the system default encoding, I've moved the encoder into a tiny utility class and fixed encoding to UTF-8.

#### What are the relevant issues?

#3560 
