### PR TITLE
Fixed issue with model properties sorting

### DIFF
--- a/oas-contract-tests/build.gradle
+++ b/oas-contract-tests/build.gradle
@@ -28,7 +28,6 @@ dependencies {
 
 
   testImplementation libs.test
-  testImplementation "org.skyscreamer:jsonassert:$jsonAssert"
   testImplementation "org.springframework.boot:spring-boot-starter-test"
 
   implementation project(':springfox-boot-starter')

--- a/oas-contract-tests/src/main/java/springfox/test/contract/oas/bugs/Bug3391.java
+++ b/oas-contract-tests/src/main/java/springfox/test/contract/oas/bugs/Bug3391.java
@@ -1,0 +1,27 @@
+package springfox.test.contract.oas.bugs;
+
+import io.swagger.annotations.ApiModelProperty;
+
+public class Bug3391 {
+    @ApiModelProperty(required = true, position = 2)
+    private String bar;
+
+    @ApiModelProperty(required = true, position = 1)
+    private String foo;
+
+    public String getBar() {
+        return bar;
+    }
+
+    public void setBar(String bar) {
+        this.bar = bar;
+    }
+
+    public String getFoo() {
+        return foo;
+    }
+
+    public void setFoo(String foo) {
+        this.foo = foo;
+    }
+}

--- a/oas-contract-tests/src/main/java/springfox/test/contract/oas/bugs/BugsController.java
+++ b/oas-contract-tests/src/main/java/springfox/test/contract/oas/bugs/BugsController.java
@@ -196,4 +196,8 @@ public class BugsController {
   public void bug3087(@RequestBody Bug3087 test) {
   }
 
+  @PostMapping("/bug3391")
+  public void bug3391(@RequestBody Bug3391 test) {
+  }
+
 } 

--- a/oas-contract-tests/src/test/groovy/springfox/test/contract/oas/OpenApiContractSpec.groovy
+++ b/oas-contract-tests/src/test/groovy/springfox/test/contract/oas/OpenApiContractSpec.groovy
@@ -20,8 +20,8 @@
 package springfox.test.contract.oas
 
 import com.fasterxml.classmate.TypeResolver
+import groovy.json.JsonOutput
 import groovy.json.JsonSlurper
-import org.skyscreamer.jsonassert.JSONAssert
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.TestConfiguration
@@ -39,7 +39,6 @@ import springfox.documentation.schema.AlternateTypeRuleConvention
 import springfox.documentation.spring.web.plugins.JacksonSerializerConvention
 
 import static java.nio.charset.StandardCharsets.*
-import static org.skyscreamer.jsonassert.JSONCompareMode.*
 import static org.springframework.boot.test.context.SpringBootTest.*
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, classes = OpenApiApplication)
@@ -84,11 +83,12 @@ class OpenApiContractSpec extends Specification implements FileAccess {
             replace(
                 "localhost:$port",
                 "localhost:__PORT__"))
-    JSONAssert.
-        assertEquals(
-            withPortReplaced,
-            raw,
-            NON_EXTENSIBLE)
+
+    // Compare as text with the same formatting to check property order
+    // (JSON object is an unordered set of name/value pairs by spec)
+    def prettyWithPortReplaced = JsonOutput.prettyPrint(withPortReplaced)
+    def prettyRaw = JsonOutput.prettyPrint(raw)
+    prettyWithPortReplaced == prettyRaw
 
     where:
     contractFile    | groupName

--- a/oas-contract-tests/src/test/resources/contracts/bugs.json
+++ b/oas-contract-tests/src/test/resources/contracts/bugs.json
@@ -638,6 +638,29 @@
                     }
                 }
             }
+        },
+        "/bugs/bug3391": {
+            "post": {
+                "tags": [
+                    "bugs-controller"
+                ],
+                "summary": "bug3391",
+                "operationId": "bug3391UsingPOST",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Bug3391"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
         }
     },
     "components": {
@@ -673,6 +696,22 @@
                 "type": "object",
                 "properties": {
                     "value": {
+                        "type": "string"
+                    }
+                }
+            },
+            "Bug3391": {
+                "title": "Bug3391",
+                "required": [
+                    "bar",
+                    "foo"
+                ],
+                "type": "object",
+                "properties": {
+                    "foo": {
+                        "type": "string"
+                    },
+                    "bar": {
                         "type": "string"
                     }
                 }

--- a/springfox-oas/src/main/java/springfox/documentation/oas/mappers/SchemaMapper.java
+++ b/springfox-oas/src/main/java/springfox/documentation/oas/mappers/SchemaMapper.java
@@ -25,6 +25,7 @@ import springfox.documentation.service.ModelNamesRegistry;
 import java.math.BigDecimal;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -105,13 +106,11 @@ public abstract class SchemaMapper {
 
     source.getCompound()
         .ifPresent(c -> {
-          Map<String, Schema> modelProperties = new TreeMap<>(Comparator.naturalOrder());
           Map<String, PropertySpecification> properties = c.getProperties().stream()
               .collect(toMap(
                   PropertySpecification::getName,
                   Function.identity()));
-          modelProperties.putAll(mapProperties(properties, namesRegistry));
-          model.setProperties(modelProperties);
+          model.setProperties(mapProperties(properties, namesRegistry));
           List<String> requiredFields = properties.values().stream()
               .filter(PropertySpecification::nullSafeIsRequired)
               .map(PropertySpecification::getName)
@@ -234,9 +233,7 @@ public abstract class SchemaMapper {
                 PropertySpecification::getName,
                 Function.identity())))
         .orElse(new HashMap<>());
-    Map<String, Schema> modelProperties = new TreeMap<>(Comparator.naturalOrder());
-    modelProperties.putAll(mapProperties(properties, namesRegistry));
-    model.setProperties(modelProperties);
+    model.setProperties(mapProperties(properties, namesRegistry));
     return model;
   }
 
@@ -251,7 +248,7 @@ public abstract class SchemaMapper {
             Map.Entry::getKey,
             e -> fromProperty(e.getValue(), modelNamesRegistry),
             (p1, p2) -> p1,
-            TreeMap::new));
+            LinkedHashMap::new));
   }
 
   @SuppressWarnings("unchecked")

--- a/springfox-swagger2/src/main/java/springfox/documentation/swagger2/mappers/ModelSpecificationMapper.java
+++ b/springfox-swagger2/src/main/java/springfox/documentation/swagger2/mappers/ModelSpecificationMapper.java
@@ -23,6 +23,7 @@ import springfox.documentation.service.ModelNamesRegistry;
 
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -83,11 +84,9 @@ public abstract class ModelSpecificationMapper {
 
     toReturn = source.getCompound()
         .map(c -> {
-          Map<String, Property> modelProperties = new TreeMap<>(Comparator.naturalOrder());
           Map<String, PropertySpecification> properties = c.getProperties().stream()
               .collect(toMap(PropertySpecification::getName, Function.identity()));
-          modelProperties.putAll(mapProperties(properties, namesRegistry));
-          model.setProperties(modelProperties);
+          model.setProperties(mapProperties(properties, namesRegistry));
           List<String> requiredFields = properties.values().stream()
               .filter(PropertySpecification::nullSafeIsRequired)
               .map(PropertySpecification::getName)
@@ -227,9 +226,7 @@ public abstract class ModelSpecificationMapper {
         .map(c -> c.getProperties().stream()
             .collect(Collectors.toMap(PropertySpecification::getName, Function.identity())))
         .orElse(new HashMap<>());
-    Map<String, Property> modelProperties = new TreeMap<>(Comparator.naturalOrder());
-    modelProperties.putAll(mapProperties(properties, namesRegistry));
-    model.setProperties(modelProperties);
+    model.setProperties(mapProperties(properties, namesRegistry));
     return model;
   }
 
@@ -244,7 +241,7 @@ public abstract class ModelSpecificationMapper {
             Map.Entry::getKey,
             e -> propertyMapper.fromProperty(e.getValue(), modelNamesRegistry),
             (p1, p2) -> p1,
-            TreeMap::new));
+            LinkedHashMap::new));
   }
 
   private Xml mapXml(springfox.documentation.schema.Xml xml) {


### PR DESCRIPTION
#### What's this PR do/fix?
This PR fies model properties order (not alphabetically ordered now).
#### Are there unit tests? If not how should this be manually tested?
Yes, test case added to `oas-contract-tests`. `JSONAssert` replaced with text comparing to make sure that api returning same response, even the order of keys in objects.
#### Any background context you want to provide?
No.
#### What are the relevant issues?
#3391
