### PR TITLE
Use context path (which takes into account X-Forwarded-Prefix) when constructing OpenAPI 3 server URLs

### DIFF
--- a/oas-contract-tests/src/test/resources/contracts/bugs.json
+++ b/oas-contract-tests/src/test/resources/contracts/bugs.json
@@ -15,7 +15,7 @@
     },
     "servers": [
         {
-            "url": "http://localhost:__PORT__",
+            "url": "__SERVER_URL__",
             "description": "Inferred Url"
         }
     ],

--- a/oas-contract-tests/src/test/resources/contracts/features.json
+++ b/oas-contract-tests/src/test/resources/contracts/features.json
@@ -15,7 +15,7 @@
     },
     "servers": [
         {
-            "url": "http://localhost:__PORT__",
+            "url": "__SERVER_URL__",
             "description": "Inferred Url"
         }
     ],

--- a/oas-contract-tests/src/test/resources/contracts/petstore.json
+++ b/oas-contract-tests/src/test/resources/contracts/petstore.json
@@ -15,7 +15,7 @@
     },
     "servers": [
         {
-            "url": "http://localhost:__PORT__",
+            "url": "__SERVER_URL__",
             "description": "Inferred Url"
         }
     ],

--- a/springfox-oas/src/main/java/springfox/documentation/oas/web/ForwardedHeaderExtractingRequest.java
+++ b/springfox-oas/src/main/java/springfox/documentation/oas/web/ForwardedHeaderExtractingRequest.java
@@ -87,9 +87,10 @@ class ForwardedHeaderExtractingRequest {
   }
 
   public String adjustedRequestURL() {
-    return String.format("%s://%s:%s",
+    return String.format("%s://%s:%s%s",
         getScheme(),
         getServerName(),
-        getServerPort());
+        getServerPort(),
+        getContextPath());
   }
 }

--- a/springfox-oas/src/main/java/springfox/documentation/oas/web/SpecGeneration.java
+++ b/springfox-oas/src/main/java/springfox/documentation/oas/web/SpecGeneration.java
@@ -27,7 +27,7 @@ public class SpecGeneration {
     String serverUrl = requestUrl.replace(requestPrefix, "");
     try {
       URI url = new URI(requestUrl);
-      serverUrl = String.format("%s://%s:%s", url.getScheme(), url.getHost(), url.getPort());
+      serverUrl = String.format("%s://%s:%s%s", url.getScheme(), url.getHost(), url.getPort(), url.getPath());
     } catch (URISyntaxException e) {
       LOGGER.error("Unable to parse request url:" + requestUrl);
     }


### PR DESCRIPTION
Use context path (which takes into account X-Forwarded-Prefix) when constructing OpenAPI 3 server URLs

#### What's this PR do/fix?

Resolves  by taking into account the context path when building OA3 server URLs.

#### Are there unit tests? If not how should this be manually tested?

Added automated test to OpenApiContractSpec (includeds test for X-Forwarded-[Proto,Host,Port,Prefix])

Can also be manually tested by:
* building springfox from this PR (to build 3.0.1-SNAPSHOT): gradlew clean build publishToMavenLocal
* git clone https://github.com/alimac87/springfox-oa3-x-forward-prefix-demo 
* cd springfox-oa3-x-forward-prefix-demo
* gradlew bootRun
* Run: curl -H "X-Forwarded-Prefix: /XXXXX" http://localhost:8080/v3/api-docs
* Expected result: the "servers" section should include "url":"http://localhost:8080/XXXXX"

#### Any background context you want to provide?
#### What are the relevant issues?

#3445