### PR TITLE
Fix #3587, allow strict style-src CSP

### DIFF
--- a/springfox-swagger-ui/src/web/css/springfox.css
+++ b/springfox-swagger-ui/src/web/css/springfox.css
@@ -67,3 +67,27 @@
   url('./fonts/titillium-web-v6-latin-700.woff2') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
   url('./fonts/titillium-web-v6-latin-700.woff') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
+
+html {
+  box-sizing: border-box;
+  overflow: -moz-scrollbars-vertical;
+  overflow-y: scroll;
+}
+
+*,
+*:before,
+*:after {
+  box-sizing: inherit;
+}
+
+body {
+  margin: 0;
+  background: #fafafa;
+}
+
+body > svg {
+  position: absolute;
+  width: 0;
+  height: 0;
+}
+

--- a/springfox-swagger-ui/src/web/swagger-ui.html
+++ b/springfox-swagger-ui/src/web/swagger-ui.html
@@ -8,30 +8,11 @@
   <link rel="stylesheet" type="text/css" href="./swagger-ui.css?v=@VERSION@" >
   <link rel="icon" type="image/png" href="./favicon-32x32.png?v=@VERSION@" sizes="32x32" />
   <link rel="icon" type="image/png" href="./favicon-16x16.png?v=@VERSION@" sizes="16x16" />
-  <style>
-    html
-    {
-      box-sizing: border-box;
-      overflow: -moz-scrollbars-vertical;
-      overflow-y: scroll;
-    }
-    *,
-    *:before,
-    *:after
-    {
-      box-sizing: inherit;
-    }
-
-    body {
-      margin:0;
-      background: #fafafa;
-    }
-  </style>
 </head>
 
 <body>
 
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="position:absolute;width:0;height:0">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <defs>
     <symbol viewBox="0 0 20 20" id="unlocked">
       <path d="M15.8 8H14V5.6C14 2.703 12.665 1 10 1 7.334 1 6 2.703 6 5.6V6h2v-.801C8 3.754 8.797 3 10 3c1.203 0 2 .754 2 2.199V8H4c-.553 0-1 .646-1 1.199V17c0 .549.428 1.139.951 1.307l1.197.387C5.672 18.861 6.55 19 7.1 19h5.8c.549 0 1.428-.139 1.951-.307l1.196-.387c.524-.167.953-.757.953-1.306V9.199C17 8.646 16.352 8 15.8 8z"></path>


### PR DESCRIPTION
#### What's this PR do/fix?
Refer to issue.
#### Are there unit tests? If not how should this be manually tested?

No, set `Content-Security-Policy: style-src 'self'` and verify the swagger-ui page renders as expected.

#### Any background context you want to provide?
Refer to issue.

#### What are the relevant issues?
#3587 
