### PR TITLE
Make sure swagger is working with SwaggerRsource containing full URL

### DIFF
--- a/springfox-swagger-ui/src/web/js/springfox.js
+++ b/springfox-swagger-ui/src/web/js/springfox.js
@@ -54,7 +54,7 @@ window.onload = () => {
 
   const prependBaseUrl = (baseUrl, resources) => {
     resources.forEach(function(r) {
-      r.url = baseUrl + r.url;
+      r.url = (r.url && r.url.startWith("http") ? r.url : (baseUrl + r.url);
     })
     return resources;
   };

--- a/springfox-swagger-ui/src/web/js/springfox.js
+++ b/springfox-swagger-ui/src/web/js/springfox.js
@@ -54,7 +54,7 @@ window.onload = () => {
 
   const prependBaseUrl = (baseUrl, resources) => {
     resources.forEach(function(r) {
-      r.url = (r.url && r.url.startWith("http")) ? r.url : (baseUrl + r.url);
+      r.url = (r.url && r.url.startWith("http")) ? r.url : baseUrl + r.url;
     })
     return resources;
   };

--- a/springfox-swagger-ui/src/web/js/springfox.js
+++ b/springfox-swagger-ui/src/web/js/springfox.js
@@ -54,7 +54,7 @@ window.onload = () => {
 
   const prependBaseUrl = (baseUrl, resources) => {
     resources.forEach(function(r) {
-      r.url = (r.url && r.url.startWith("http")) ? r.url : baseUrl + r.url;
+      r.url = (r.url && r.url.startWith("http")) ? r.url : (baseUrl + r.url);
     })
     return resources;
   };

--- a/springfox-swagger-ui/src/web/js/springfox.js
+++ b/springfox-swagger-ui/src/web/js/springfox.js
@@ -54,7 +54,7 @@ window.onload = () => {
 
   const prependBaseUrl = (baseUrl, resources) => {
     resources.forEach(function(r) {
-      r.url = (r.url && r.url.startWith("http") ? r.url : (baseUrl + r.url);
+      r.url = (r.url && r.url.startWith("http")) ? r.url : (baseUrl + r.url);
     })
     return resources;
   };


### PR DESCRIPTION
It fix issue #3413

It was working in swagger 2.x.y

It's mandatory when you aggregate many swagger resources (remote services) into one service with a unique swagger-ui (like api gateway)

Christophe