### PR TITLE
OAS3 API doc does not contain "servers" in reactive-based web application

### DIFF
--- a/springfox-oas/src/main/java/springfox/documentation/oas/web/OpenApiControllerWebFlux.java
+++ b/springfox-oas/src/main/java/springfox/documentation/oas/web/OpenApiControllerWebFlux.java
@@ -88,7 +88,7 @@ public class OpenApiControllerWebFlux {
     OpenAPI oas = mapper.mapDocumentation(documentation);
     OpenApiTransformationContext<ServerHttpRequest> context
         = new OpenApiTransformationContext<>(oas, serverRequest);
-    List<WebFluxOpenApiTransformationFilter> filters = transformations.getPluginsFor(DocumentationType.SWAGGER_2);
+    List<WebFluxOpenApiTransformationFilter> filters = transformations.getPluginsFor(DocumentationType.OAS_30);
     for (WebFluxOpenApiTransformationFilter each : filters) {
       context = context.next(each.transform(context));
     }


### PR DESCRIPTION
#### What's this PR do/fix?
Fix OpenApiControllerWebFlux transformation filters retrieval

#### Are there unit tests? If not how should this be manually tested?
No unit tests. Should I create a new `oas-contract-tests-webflux` module for this?

#### Any background context you want to provide?

#### What are the relevant issues?
#3650