### PR TITLE
Add support for @Validated groups

### DIFF
--- a/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/Validators.java
+++ b/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/Validators.java
@@ -119,12 +119,11 @@ public class Validators {
     }
 
     Set<Class<?>> validatedGroupsClasses = getGroupClasses(validatedGroups.stream().map(ResolvedType::getErasedType));
-    Set<Class<?>> constraintGroupClasses = getGroupClasses(Stream.of(groupsConstraint));
+    Set<Class<?>> constraintGroupClasses = Stream.of(groupsConstraint).collect(Collectors.toSet());
 
-    // Case #2: Validated groups contains Default.class
-    // Constrain groups contains Default.class
-    if (validatedGroupsClasses.contains(Default.class)) {
-      return constraintGroupClasses.isEmpty() || constraintGroupClasses.contains(Default.class);
+    // Case #2: constraintGroupClasses is empty
+    if (constraintGroupClasses.isEmpty()) {
+      constraintGroupClasses.add(Default.class);
     }
 
     // Case #3: Validated groups does not contain Default.class
@@ -133,16 +132,18 @@ public class Validators {
   }
 
   private static Set<Class<?>> getGroupClasses(Stream<Class<?>> stream) {
-    return stream.flatMap(i -> getSuperClasses(i).stream()).collect(Collectors.toSet());
+    return stream.flatMap(i -> getAllInterfaces(i).stream()).collect(Collectors.toSet());
   }
 
-  public static Set<Class<?>> getSuperClasses(Class<?> c) {
-    Set<Class<?>> classSet = new HashSet<>();
-    classSet.add(c);
-    for (Class<?> superclass = c; superclass != null; c = superclass) {
-      classSet.add(superclass);
-      superclass = c.getSuperclass();
+  public static Set<Class<?>> getAllInterfaces(Class<?> c) {
+    Set<Class<?>> set = new HashSet<>();
+    if (!c.isInterface()) {
+      return set;
     }
-    return classSet;
+    set.add(c);
+    for (Class<?> superInterfaces : c.getInterfaces()) {
+      set.addAll(getAllInterfaces(superInterfaces));
+    }
+    return set;
   }
 }

--- a/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/schema/DecimalMinMaxAnnotationPlugin.java
+++ b/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/schema/DecimalMinMaxAnnotationPlugin.java
@@ -133,10 +133,10 @@ public class DecimalMinMaxAnnotationPlugin implements ModelPropertyBuilderPlugin
   }
 
   private boolean mustBeAppliedAccordingToValidatedGroups(ModelPropertyContext context, DecimalMax max) {
-    return Validators.existsIntersectionBetweenGroupsFromValidatedAndConstraintAnnotations(context, max.groups());
+    return Validators.annotationMustBeApplied(context, max.groups());
   }
 
   private boolean mustBeAppliedAccordingToValidatedGroups(ModelPropertyContext context, DecimalMin min) {
-    return Validators.existsIntersectionBetweenGroupsFromValidatedAndConstraintAnnotations(context, min.groups());
+    return Validators.annotationMustBeApplied(context, min.groups());
   }
 }

--- a/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/schema/IsNullAnnotationPlugin.java
+++ b/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/schema/IsNullAnnotationPlugin.java
@@ -67,6 +67,6 @@ public class IsNullAnnotationPlugin implements ModelPropertyBuilderPlugin {
   }
 
   private boolean mustBeAppliedAccordingToValidatedGroups(ModelPropertyContext context, Null isNull) {
-    return Validators.existsIntersectionBetweenGroupsFromValidatedAndConstraintAnnotations(context, isNull.groups());
+    return Validators.annotationMustBeApplied(context, isNull.groups());
   }
 }

--- a/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/schema/MinMaxAnnotationPlugin.java
+++ b/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/schema/MinMaxAnnotationPlugin.java
@@ -91,10 +91,10 @@ public class MinMaxAnnotationPlugin implements ModelPropertyBuilderPlugin {
   }
 
   public static boolean mustBeAppliedAccordingToValidatedGroups(ModelPropertyContext context, Max max) {
-    return Validators.existsIntersectionBetweenGroupsFromValidatedAndConstraintAnnotations(context, max.groups());
+    return Validators.annotationMustBeApplied(context, max.groups());
   }
 
   public static boolean mustBeAppliedAccordingToValidatedGroups(ModelPropertyContext context, Min min) {
-    return Validators.existsIntersectionBetweenGroupsFromValidatedAndConstraintAnnotations(context, min.groups());
+    return Validators.annotationMustBeApplied(context, min.groups());
   }
 }

--- a/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/schema/NotBlankAnnotationPlugin.java
+++ b/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/schema/NotBlankAnnotationPlugin.java
@@ -69,6 +69,6 @@ public class NotBlankAnnotationPlugin implements ModelPropertyBuilderPlugin {
   }
 
   private boolean mustBeAppliedAccordingToValidatedGroups(ModelPropertyContext context, NotBlank notBlank) {
-    return Validators.existsIntersectionBetweenGroupsFromValidatedAndConstraintAnnotations(context, notBlank.groups());
+    return Validators.annotationMustBeApplied(context, notBlank.groups());
   }
 }

--- a/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/schema/NotNullAnnotationPlugin.java
+++ b/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/schema/NotNullAnnotationPlugin.java
@@ -68,6 +68,6 @@ public class NotNullAnnotationPlugin implements ModelPropertyBuilderPlugin {
   }
 
   private boolean mustBeAppliedAccordingToValidatedGroups(ModelPropertyContext context, NotNull notNull) {
-    return Validators.existsIntersectionBetweenGroupsFromValidatedAndConstraintAnnotations(context, notNull.groups());
+    return Validators.annotationMustBeApplied(context, notNull.groups());
   }
 }

--- a/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/schema/PatternAnnotationPlugin.java
+++ b/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/schema/PatternAnnotationPlugin.java
@@ -71,6 +71,6 @@ public class PatternAnnotationPlugin implements ModelPropertyBuilderPlugin {
   }
 
   private boolean mustBeAppliedAccordingToValidatedGroups(ModelPropertyContext context, Pattern pattern) {
-    return Validators.existsIntersectionBetweenGroupsFromValidatedAndConstraintAnnotations(context, pattern.groups());
+    return Validators.annotationMustBeApplied(context, pattern.groups());
   }
 }

--- a/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/schema/SizeAnnotationPlugin.java
+++ b/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/schema/SizeAnnotationPlugin.java
@@ -78,6 +78,6 @@ public class SizeAnnotationPlugin implements ModelPropertyBuilderPlugin {
   }
 
   public static boolean mustBeAppliedAccordingToValidatedGroups(ModelPropertyContext context, Size size) {
-    return Validators.existsIntersectionBetweenGroupsFromValidatedAndConstraintAnnotations(context, size.groups());
+    return Validators.annotationMustBeApplied(context, size.groups());
   }
 }

--- a/springfox-schema/build.gradle
+++ b/springfox-schema/build.gradle
@@ -13,6 +13,7 @@ dependencies {
   api project(':springfox-core')
   api project(':springfox-spi')
 
+  compileOnly "javax.validation:validation-api:$validationApiVersion"
   compileOnly "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:${jackson}"
   compileOnly libs.springProvided
   compileOnly libs.clientProvided

--- a/springfox-schema/src/main/java/springfox/documentation/schema/ValidatedProvider.java
+++ b/springfox-schema/src/main/java/springfox/documentation/schema/ValidatedProvider.java
@@ -1,0 +1,102 @@
+/*
+ *
+ *  Copyright 2017 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+
+package springfox.documentation.schema;
+
+import com.fasterxml.classmate.ResolvedType;
+import com.fasterxml.classmate.TypeResolver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+import springfox.documentation.service.ResolvedMethodParameter;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.schema.ValidatedProviderPlugin;
+import springfox.documentation.spi.service.contexts.OperationContext;
+import springfox.documentation.spi.service.contexts.RequestMappingContext;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Component
+@Order
+public class ValidatedProvider implements ValidatedProviderPlugin {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ValidatedProvider.class);
+
+  private final TypeResolver typeResolver;
+
+  @Autowired
+  public ValidatedProvider(TypeResolver typeResolver) {
+    this.typeResolver = typeResolver;
+  }
+
+  @Override
+  public boolean supports(DocumentationType delimiter) {
+    return true;
+  }
+
+  @Override
+  public Set<ResolvedType> validationFor(
+      ResolvedMethodParameter parameter) {
+    return validationFor(
+        String.format("Parameter name: %s @ index: %s",
+                      parameter.defaultName().orElse("<none>"),
+                      parameter.getParameterIndex()),
+        parameter.findAnnotation(Validated.class)
+                 .orElse(null));
+  }
+
+  @Override
+  public Set<ResolvedType> validationFor(
+      RequestMappingContext context) {
+    return validationFor(
+        String.format("Request Mapping: %s", context.getRequestMappingPattern()),
+        context.findAnnotation(Validated.class)
+               .orElse(null));
+  }
+
+  @Override
+  public Set<ResolvedType> validationFor(
+      OperationContext context) {
+    return validationFor(
+        String.format("Operation: %s", context.getName()),
+        context.findAnnotation(Validated.class).orElse(null));
+  }
+
+  private Set<ResolvedType> validationFor(
+      String context,
+      Validated annotation) {
+    Set<ResolvedType> resolvedTypes = new HashSet<>();
+    if (annotation != null) {
+      Class<?>[] validatedGroups = annotation.value();
+      resolvedTypes = Stream.of(validatedGroups).map(typeResolver::resolve).collect(Collectors.toSet());
+      LOG.debug(
+          "Found validation groups {} for type {}",
+          resolvedTypes.stream().map(ResolvedTypes::resolvedTypeSignature).toString(),
+          context);
+    }
+
+    return resolvedTypes;
+  }
+}

--- a/springfox-schema/src/main/java/springfox/documentation/schema/configuration/ModelsConfiguration.java
+++ b/springfox-schema/src/main/java/springfox/documentation/schema/configuration/ModelsConfiguration.java
@@ -28,6 +28,7 @@ import springfox.documentation.spi.schema.ModelBuilderPlugin;
 import springfox.documentation.spi.schema.ModelPropertyBuilderPlugin;
 import springfox.documentation.spi.schema.SyntheticModelProviderPlugin;
 import springfox.documentation.spi.schema.TypeNameProviderPlugin;
+import springfox.documentation.spi.schema.ValidatedProviderPlugin;
 import springfox.documentation.spi.schema.ViewProviderPlugin;
 
 @Configuration
@@ -40,6 +41,7 @@ import springfox.documentation.spi.schema.ViewProviderPlugin;
     TypeNameProviderPlugin.class,
     SyntheticModelProviderPlugin.class,
     ViewProviderPlugin.class,
+    ValidatedProviderPlugin.class,
 })
 public class ModelsConfiguration {
   @Bean

--- a/springfox-schema/src/main/java/springfox/documentation/schema/plugins/SchemaPluginsManager.java
+++ b/springfox-schema/src/main/java/springfox/documentation/schema/plugins/SchemaPluginsManager.java
@@ -29,6 +29,7 @@ import springfox.documentation.schema.PropertySpecification;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spi.schema.ModelBuilderPlugin;
 import springfox.documentation.spi.schema.ModelPropertyBuilderPlugin;
+import springfox.documentation.spi.schema.ValidatedProviderPlugin;
 import springfox.documentation.spi.schema.ViewProviderPlugin;
 import springfox.documentation.spi.schema.SyntheticModelProviderPlugin;
 import springfox.documentation.spi.schema.contexts.ModelContext;
@@ -45,6 +46,7 @@ public class SchemaPluginsManager {
   private final PluginRegistry<ModelPropertyBuilderPlugin, DocumentationType> propertyEnrichers;
   private final PluginRegistry<ModelBuilderPlugin, DocumentationType> modelEnrichers;
   private final PluginRegistry<ViewProviderPlugin, DocumentationType> viewProviders;
+  private final PluginRegistry<ValidatedProviderPlugin, DocumentationType> validatedProviders;
   private final PluginRegistry<SyntheticModelProviderPlugin, ModelContext> syntheticModelProviders;
 
   @Autowired
@@ -55,11 +57,14 @@ public class SchemaPluginsManager {
           PluginRegistry<ModelBuilderPlugin, DocumentationType> modelEnrichers,
       @Qualifier("viewProviderPluginRegistry")
           PluginRegistry<ViewProviderPlugin, DocumentationType> viewProviders,
+      @Qualifier("validatedProviderPluginRegistry")
+          PluginRegistry<ValidatedProviderPlugin, DocumentationType> validatedProviders,
       @Qualifier("syntheticModelProviderPluginRegistry")
           PluginRegistry<SyntheticModelProviderPlugin, ModelContext> syntheticModelProviders) {
     this.propertyEnrichers = propertyEnrichers;
     this.modelEnrichers = modelEnrichers;
     this.viewProviders = viewProviders;
+    this.validatedProviders = validatedProviders;
     this.syntheticModelProviders = syntheticModelProviders;
   }
 
@@ -94,6 +99,11 @@ public class SchemaPluginsManager {
   public ViewProviderPlugin viewProvider(DocumentationType documentationType) {
     return viewProviders.getPluginFor(documentationType)
         .orElseThrow(() -> new IllegalStateException("No ViewProviderPlugin for " + documentationType.getName()));
+  }
+
+  public ValidatedProviderPlugin validatedProvider(DocumentationType documentationType) {
+    return validatedProviders.getPluginFor(documentationType)
+        .orElseThrow(() -> new IllegalStateException("No ValidatedProviderPlugin for " + documentationType.getName()));
   }
 
   /**

--- a/springfox-schema/src/test/groovy/springfox/documentation/schema/mixins/SchemaPluginsSupport.groovy
+++ b/springfox-schema/src/test/groovy/springfox/documentation/schema/mixins/SchemaPluginsSupport.groovy
@@ -25,6 +25,7 @@ import springfox.documentation.schema.DefaultTypeNameProvider
 import springfox.documentation.schema.JacksonEnumTypeDeterminer
 import springfox.documentation.schema.JacksonJsonViewProvider
 import springfox.documentation.schema.TypeNameExtractor
+import springfox.documentation.schema.ValidatedProvider
 import springfox.documentation.schema.plugins.PropertyDiscriminatorBasedInheritancePlugin
 import springfox.documentation.schema.plugins.SchemaPluginsManager
 import springfox.documentation.schema.property.ModelSpecificationFactory
@@ -33,6 +34,7 @@ import springfox.documentation.spi.schema.ModelBuilderPlugin
 import springfox.documentation.spi.schema.ModelPropertyBuilderPlugin
 import springfox.documentation.spi.schema.SyntheticModelProviderPlugin
 import springfox.documentation.spi.schema.TypeNameProviderPlugin
+import springfox.documentation.spi.schema.ValidatedProviderPlugin
 import springfox.documentation.spi.schema.ViewProviderPlugin
 import springfox.documentation.spi.schema.contexts.ModelContext
 
@@ -62,9 +64,12 @@ trait SchemaPluginsSupport {
     PluginRegistry<ViewProviderPlugin, DocumentationType> viewProviderRegistry =
         OrderAwarePluginRegistry.of([new JacksonJsonViewProvider(new TypeResolver())])
 
+    PluginRegistry<ValidatedProviderPlugin, DocumentationType> validatedProviderRegistry =
+        OrderAwarePluginRegistry.of([new ValidatedProvider(new TypeResolver())])
+
     PluginRegistry<SyntheticModelProviderPlugin, ModelContext> syntheticModelRegistry =
         OrderAwarePluginRegistry.of(new ArrayList<>())
 
-    new SchemaPluginsManager(propRegistry, modelRegistry, viewProviderRegistry, syntheticModelRegistry)
+    new SchemaPluginsManager(propRegistry, modelRegistry, viewProviderRegistry, validatedProviderRegistry, syntheticModelRegistry)
   }
 }

--- a/springfox-spi/src/main/java/springfox/documentation/spi/schema/ValidatedProviderPlugin.java
+++ b/springfox-spi/src/main/java/springfox/documentation/spi/schema/ValidatedProviderPlugin.java
@@ -1,0 +1,51 @@
+/*
+ *
+ *  Copyright 2017 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+
+package springfox.documentation.spi.schema;
+
+import com.fasterxml.classmate.ResolvedType;
+import org.springframework.plugin.core.Plugin;
+import springfox.documentation.service.ResolvedMethodParameter;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.service.contexts.OperationContext;
+import springfox.documentation.spi.service.contexts.RequestMappingContext;
+
+import java.util.Set;
+
+public interface ValidatedProviderPlugin extends Plugin<DocumentationType> {
+
+  /**
+   * Finds active validations for the parameter type
+   * @param parameter - resolved method parameter to take additional information from, if needed
+   */
+  Set<ResolvedType> validationFor(ResolvedMethodParameter parameter);
+
+  /**
+   * Finds active validations for the parameter type
+   * @param context - method context to take additional information from, if needed
+   */
+  Set<ResolvedType> validationFor(RequestMappingContext context);
+
+  /**
+   * Finds active validations for the return type
+   * @param context - operation context to take additional information from, if needed
+   */
+  Set<ResolvedType> validationFor(OperationContext context);
+
+}

--- a/springfox-spi/src/main/java/springfox/documentation/spi/schema/contexts/ModelContext.java
+++ b/springfox-spi/src/main/java/springfox/documentation/spi/schema/contexts/ModelContext.java
@@ -262,6 +262,44 @@ public class ModelContext {
   }
 
   /**
+   * Convenience method to provide an new context for an return parameter
+   *
+   * @param parameterId           - parameter id
+   * @param groupName             - group name of the docket
+   * @param type                  - type
+   * @param view                  - view
+   * @param documentationType     - for documentation type
+   * @param alternateTypeProvider - alternate type provider
+   * @param genericNamingStrategy - how generic types should be named
+   * @param ignorableTypes        - types that can be ignored
+   * @return new context
+   */
+  @SuppressWarnings("ParameterNumber")
+  public static ModelContext returnValue(
+      String parameterId,
+      String groupName,
+      ResolvedType type,
+      Optional<ResolvedType> view,
+      DocumentationType documentationType,
+      AlternateTypeProvider alternateTypeProvider,
+      GenericTypeNamingStrategy genericNamingStrategy,
+      Set<Class> ignorableTypes,
+      Set<ResolvedType> validationGroups) {
+
+    return new ModelContext(
+        parameterId,
+        groupName,
+        type,
+        true,
+        view,
+        validationGroups,
+        documentationType,
+        alternateTypeProvider,
+        genericNamingStrategy,
+        ignorableTypes);
+  }
+
+  /**
    * Convenience method to provide an new context for an input parameter
    *
    * @param context - parent context

--- a/springfox-spi/src/main/java/springfox/documentation/spi/service/contexts/ModelSpecificationRegistry.java
+++ b/springfox-spi/src/main/java/springfox/documentation/spi/service/contexts/ModelSpecificationRegistry.java
@@ -4,6 +4,7 @@ import springfox.documentation.schema.ModelKey;
 import springfox.documentation.schema.ModelSpecification;
 
 import java.util.Collection;
+import java.util.Map;
 import java.util.Set;
 
 public interface ModelSpecificationRegistry {
@@ -11,7 +12,7 @@ public interface ModelSpecificationRegistry {
 
   boolean hasRequestResponsePairs(ModelKey test);
 
-  Collection<ModelKey> modelsDifferingOnlyInValidationGroups(ModelKey test);
+  Map<ModelKey, String> getSuffixesForEqualsModels(ModelKey test);
 
   Collection<ModelKey> modelsWithSameNameAndDifferentNamespace(ModelKey test);
 

--- a/springfox-spi/src/main/java/springfox/documentation/spi/service/contexts/OperationModelContextsBuilder.java
+++ b/springfox-spi/src/main/java/springfox/documentation/spi/service/contexts/OperationModelContextsBuilder.java
@@ -66,6 +66,10 @@ public class OperationModelContextsBuilder {
   }
 
   public ModelContext addReturn(ResolvedType type, Optional<ResolvedType> view) {
+    return addReturn(type, view, new HashSet<>());
+  }
+
+  public ModelContext addReturn(ResolvedType type, Optional<ResolvedType> view, Set<ResolvedType> validationGroups) {
     ModelContext returnValue = ModelContext.returnValue(
         String.format("%s_%s", requestMappingId, parameterIndex),
         group,
@@ -74,7 +78,8 @@ public class OperationModelContextsBuilder {
         documentationType,
         alternateTypeProvider,
         genericsNamingStrategy,
-        ignorableTypes);
+        ignorableTypes,
+        validationGroups);
     if (this.contexts.add(returnValue)) {
       ++parameterIndex;
       return returnValue;

--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/operation/OperationModelsProvider.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/operation/OperationModelsProvider.java
@@ -83,7 +83,7 @@ public class OperationModelsProvider implements OperationModelsProviderPlugin {
     context.operationModelsBuilder()
            .addReturn(
                modelType,
-               viewForReturn(context));
+               viewForReturn(context), validatedForReturn(context));
   }
 
   private void collectParameters(RequestMappingContext context) {
@@ -135,5 +135,11 @@ public class OperationModelsProvider implements OperationModelsProviderPlugin {
     ValidatedProviderPlugin validatedProviderPlugin =
         pluginsManager.validatedProvider(context.getDocumentationContext().getDocumentationType());
     return validatedProviderPlugin.validationFor(parameter);
+  }
+
+  private Set<ResolvedType> validatedForReturn(RequestMappingContext context) {
+    ValidatedProviderPlugin validatedProviderPlugin =
+        pluginsManager.validatedProvider(context.getDocumentationContext().getDocumentationType());
+    return validatedProviderPlugin.validationFor(context);
   }
 }

--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/operation/OperationModelsProvider.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/operation/OperationModelsProvider.java
@@ -31,13 +31,14 @@ import org.springframework.web.bind.annotation.RequestPart;
 import springfox.documentation.schema.plugins.SchemaPluginsManager;
 import springfox.documentation.service.ResolvedMethodParameter;
 import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.schema.ValidatedProviderPlugin;
 import springfox.documentation.spi.schema.ViewProviderPlugin;
 import springfox.documentation.spi.service.OperationModelsProviderPlugin;
 import springfox.documentation.spi.service.contexts.RequestMappingContext;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static springfox.documentation.schema.ResolvedTypes.*;
 
@@ -103,7 +104,7 @@ public class OperationModelsProvider implements OperationModelsProviderPlugin {
             viewForParameter(
                 context,
                 parameterType),
-            new HashSet<>());
+                validatedForParameter(context, parameterType));
       }
     }
     LOG.debug(
@@ -125,5 +126,14 @@ public class OperationModelsProvider implements OperationModelsProviderPlugin {
         pluginsManager.viewProvider(context.getDocumentationContext().getDocumentationType());
     return viewProvider.viewFor(
         parameter);
+  }
+
+  private Set<ResolvedType> validatedForParameter(
+     RequestMappingContext context,
+     ResolvedMethodParameter parameter) {
+
+    ValidatedProviderPlugin validatedProviderPlugin =
+        pluginsManager.validatedProvider(context.getDocumentationContext().getDocumentationType());
+    return validatedProviderPlugin.validationFor(parameter);
   }
 }

--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/operation/OperationResponseClassReader.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/operation/OperationResponseClassReader.java
@@ -29,6 +29,7 @@ import springfox.documentation.schema.TypeNameExtractor;
 import springfox.documentation.schema.plugins.SchemaPluginsManager;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spi.schema.EnumTypeDeterminer;
+import springfox.documentation.spi.schema.ValidatedProviderPlugin;
 import springfox.documentation.spi.schema.ViewProviderPlugin;
 import springfox.documentation.spi.schema.contexts.ModelContext;
 import springfox.documentation.spi.service.OperationBuilderPlugin;
@@ -67,9 +68,13 @@ public class OperationResponseClassReader implements OperationBuilderPlugin {
     ViewProviderPlugin viewProvider = 
         pluginsManager.viewProvider(context.getDocumentationContext().getDocumentationType());
 
+    ValidatedProviderPlugin validatedProviderPlugin =
+        pluginsManager.validatedProvider(context.getDocumentationContext().getDocumentationType());
+
     ModelContext modelContext = context.operationModelsBuilder().addReturn(
         returnType,
-        viewProvider.viewFor(context));
+        viewProvider.viewFor(context),
+        validatedProviderPlugin.validationFor(context));
 
     Map<String, String> knownNames;
     knownNames = new HashMap<>();

--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/operation/ResponseMessagesReader.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/operation/ResponseMessagesReader.java
@@ -31,6 +31,7 @@ import springfox.documentation.schema.plugins.SchemaPluginsManager;
 import springfox.documentation.schema.property.ModelSpecificationFactory;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spi.schema.EnumTypeDeterminer;
+import springfox.documentation.spi.schema.ValidatedProviderPlugin;
 import springfox.documentation.spi.schema.ViewProviderPlugin;
 import springfox.documentation.spi.schema.contexts.ModelContext;
 import springfox.documentation.spi.service.OperationBuilderPlugin;
@@ -46,8 +47,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import static java.util.Collections.*;
-import static springfox.documentation.schema.ResolvedTypes.*;
+import static java.util.Collections.singleton;
+import static springfox.documentation.schema.ResolvedTypes.isVoid;
+import static springfox.documentation.schema.ResolvedTypes.modelRefFactory;
 
 @Component
 @Order(Ordered.HIGHEST_PRECEDENCE)
@@ -98,11 +100,15 @@ public class ResponseMessagesReader implements OperationBuilderPlugin {
     ViewProviderPlugin viewProvider =
         pluginsManager.viewProvider(context.getDocumentationContext().getDocumentationType());
 
+    ValidatedProviderPlugin validatedProviderPlugin =
+        pluginsManager.validatedProvider(context.getDocumentationContext().getDocumentationType());
+
     ResponseContext responseContext = new ResponseContext(context.getDocumentationContext(), context);
     if (!isVoid(returnType)) {
       ModelContext modelContext = context.operationModelsBuilder()
           .addReturn(returnType,
-              viewProvider.viewFor(context));
+              viewProvider.viewFor(context),
+                  validatedProviderPlugin.validationFor(context));
 
       Map<String, String> knownNames = new HashMap<>();
       Optional.ofNullable(context.getKnownModels().get(modelContext.getParameterId()))

--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/parameter/ParameterDataTypeReader.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/parameter/ParameterDataTypeReader.java
@@ -39,12 +39,12 @@ import springfox.documentation.schema.property.ModelSpecificationFactory;
 import springfox.documentation.service.ResolvedMethodParameter;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spi.schema.EnumTypeDeterminer;
+import springfox.documentation.spi.schema.ValidatedProviderPlugin;
 import springfox.documentation.spi.schema.ViewProviderPlugin;
 import springfox.documentation.spi.schema.contexts.ModelContext;
 import springfox.documentation.spi.service.ParameterBuilderPlugin;
 import springfox.documentation.spi.service.contexts.ParameterContext;
 
-import java.util.HashSet;
 import java.util.Optional;
 
 import static springfox.documentation.schema.Collections.*;
@@ -164,12 +164,16 @@ public class ParameterDataTypeReader implements ParameterBuilderPlugin {
         .viewProvider(context.getDocumentationContext()
             .getDocumentationType());
 
+    ValidatedProviderPlugin validatedProviderPlugin = pluginsManager
+        .validatedProvider(context.getDocumentationContext()
+            .getDocumentationType());
+
     return context.getOperationContext()
         .operationModelsBuilder()
         .addInputParam(
             parameterType,
             viewProvider.viewFor(methodParameter),
-            new HashSet<>());
+            validatedProviderPlugin.validationFor(methodParameter));
   }
 
   private boolean treatRequestParamAsString(ResolvedType parameterType) {

--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/scanners/DefaultModelNamesRegistryFactory.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/scanners/DefaultModelNamesRegistryFactory.java
@@ -44,7 +44,7 @@ public class DefaultModelNamesRegistryFactory implements ModelNamesRegistryFacto
               k -> String.format(
                   "%s%s%s",
                   modelStems.get(k),
-                      equalsModelsSuffixes.getOrDefault(
+                  equalsModelsSuffixes.getOrDefault(
                       k,
                       ""),
                   requestResponseSuffixes.getOrDefault(

--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/scanners/ModelSpecificationRegistryBuilder.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/scanners/ModelSpecificationRegistryBuilder.java
@@ -20,10 +20,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static org.slf4j.LoggerFactory.*;
+import static org.slf4j.LoggerFactory.getLogger;
 
 public class ModelSpecificationRegistryBuilder {
   private static final Logger LOGGER = getLogger(ModelSpecificationRegistryBuilder.class);
@@ -301,13 +302,17 @@ public class ModelSpecificationRegistryBuilder {
     }
 
     @Override
-    public Collection<ModelKey> modelsDifferingOnlyInValidationGroups(ModelKey test) {
+    public Map<ModelKey, String> getSuffixesForEqualsModels(ModelKey test) {
+      AtomicInteger count = new AtomicInteger(0);
       return modelsLookupByKey.keySet().stream()
-                              .filter(mk -> mk.getQualifiedModelName().equals(test.getQualifiedModelName())
-                                  && Objects.equals(mk.getViewDiscriminator(), test.getViewDiscriminator())
-                                  && mk.isResponse() == test.isResponse()
-                                  && !areEquivalent(mk, test))
-                              .collect(Collectors.toSet());
+              .filter(mk -> mk.getQualifiedModelName().equals(test.getQualifiedModelName()))
+              .filter(mk -> Objects.equals(mk.getViewDiscriminator(), test.getViewDiscriminator()))
+              .filter(mk -> mk.isResponse() == test.isResponse())
+              .filter(mk -> !areEquivalent(mk, test))
+              .collect(Collectors.toMap(Function.identity(), v -> {
+                int index = count.getAndIncrement();
+                return index == 0 ? "" : String.valueOf(index);
+              }));
     }
 
     @Override

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/operation/SwaggerResponseMessageReader.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/operation/SwaggerResponseMessageReader.java
@@ -39,6 +39,7 @@ import springfox.documentation.service.Header;
 import springfox.documentation.service.Response;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spi.schema.EnumTypeDeterminer;
+import springfox.documentation.spi.schema.ValidatedProviderPlugin;
 import springfox.documentation.spi.schema.ViewProviderPlugin;
 import springfox.documentation.spi.schema.contexts.ModelContext;
 import springfox.documentation.spi.service.OperationBuilderPlugin;
@@ -134,6 +135,9 @@ public class SwaggerResponseMessageReader implements OperationBuilderPlugin {
     ViewProviderPlugin viewProvider =
             pluginsManager.viewProvider(context.getDocumentationContext().getDocumentationType());
 
+    ValidatedProviderPlugin validatedProviderPlugin =
+            pluginsManager.validatedProvider(context.getDocumentationContext().getDocumentationType());
+
     Map<Integer, ApiResponse> seenResponsesByCode = new HashMap<>();
     for (ApiResponse apiResponse : allApiResponses) {
       if (!seenResponsesByCode.containsKey(apiResponse.code())) {
@@ -147,7 +151,8 @@ public class SwaggerResponseMessageReader implements OperationBuilderPlugin {
         ModelContext modelContext = context.operationModelsBuilder()
             .addReturn(
                 typeResolver.resolve(apiResponse.response()),
-                viewProvider.viewFor(context));
+                viewProvider.viewFor(context),
+                validatedProviderPlugin.validationFor(context));
         Optional<ResolvedType> type = resolvedType(apiResponse);
         if (isSuccessful(apiResponse.code())) {
           type = type.map(Optional::of).orElse(operationResponse);
@@ -209,7 +214,8 @@ public class SwaggerResponseMessageReader implements OperationBuilderPlugin {
     if (operationResponse.isPresent()) {
       ModelContext modelContext = context.operationModelsBuilder().addReturn(
           operationResponse.get(),
-          viewProvider.viewFor(context));
+          viewProvider.viewFor(context),
+          validatedProviderPlugin.validationFor(context));
       ResolvedType resolvedType = context.alternateFor(operationResponse.get());
 
       Map<String, String> knownNames = new HashMap<>();

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/operation/SwaggerResponseMessageReader.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/operation/SwaggerResponseMessageReader.java
@@ -33,11 +33,13 @@ import springfox.documentation.builders.ExampleBuilder;
 import springfox.documentation.common.Compatibility;
 import springfox.documentation.schema.Example;
 import springfox.documentation.schema.TypeNameExtractor;
+import springfox.documentation.schema.plugins.SchemaPluginsManager;
 import springfox.documentation.schema.property.ModelSpecificationFactory;
 import springfox.documentation.service.Header;
 import springfox.documentation.service.Response;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spi.schema.EnumTypeDeterminer;
+import springfox.documentation.spi.schema.ViewProviderPlugin;
 import springfox.documentation.spi.schema.contexts.ModelContext;
 import springfox.documentation.spi.service.OperationBuilderPlugin;
 import springfox.documentation.spi.service.contexts.OperationContext;
@@ -72,6 +74,7 @@ public class SwaggerResponseMessageReader implements OperationBuilderPlugin {
   private final TypeResolver typeResolver;
   private final ModelSpecificationFactory modelSpecifications;
   private final DocumentationPluginsManager documentationPlugins;
+  private final SchemaPluginsManager pluginsManager;
 
   @Autowired
   public SwaggerResponseMessageReader(
@@ -79,12 +82,14 @@ public class SwaggerResponseMessageReader implements OperationBuilderPlugin {
       TypeNameExtractor typeNameExtractor,
       TypeResolver typeResolver,
       ModelSpecificationFactory modelSpecifications,
-      DocumentationPluginsManager documentationPlugins) {
+      DocumentationPluginsManager documentationPlugins,
+      SchemaPluginsManager schemaPluginsManager) {
     this.enumTypeDeterminer = enumTypeDeterminer;
     this.typeNameExtractor = typeNameExtractor;
     this.typeResolver = typeResolver;
     this.modelSpecifications = modelSpecifications;
     this.documentationPlugins = documentationPlugins;
+    this.pluginsManager = schemaPluginsManager;
   }
 
   @Override
@@ -126,6 +131,9 @@ public class SwaggerResponseMessageReader implements OperationBuilderPlugin {
     Set<springfox.documentation.service.ResponseMessage> responseMessages = new HashSet<>();
     Set<Response> responses = new HashSet<>();
 
+    ViewProviderPlugin viewProvider =
+            pluginsManager.viewProvider(context.getDocumentationContext().getDocumentationType());
+
     Map<Integer, ApiResponse> seenResponsesByCode = new HashMap<>();
     for (ApiResponse apiResponse : allApiResponses) {
       if (!seenResponsesByCode.containsKey(apiResponse.code())) {
@@ -139,7 +147,7 @@ public class SwaggerResponseMessageReader implements OperationBuilderPlugin {
         ModelContext modelContext = context.operationModelsBuilder()
             .addReturn(
                 typeResolver.resolve(apiResponse.response()),
-                Optional.empty());
+                viewProvider.viewFor(context));
         Optional<ResolvedType> type = resolvedType(apiResponse);
         if (isSuccessful(apiResponse.code())) {
           type = type.map(Optional::of).orElse(operationResponse);
@@ -201,7 +209,7 @@ public class SwaggerResponseMessageReader implements OperationBuilderPlugin {
     if (operationResponse.isPresent()) {
       ModelContext modelContext = context.operationModelsBuilder().addReturn(
           operationResponse.get(),
-          Optional.empty());
+          viewProvider.viewFor(context));
       ResolvedType resolvedType = context.alternateFor(operationResponse.get());
 
       Map<String, String> knownNames = new HashMap<>();


### PR DESCRIPTION
**What's this PR do/fix?**

This PR fixes #2307

1. Add support for `@Validated` groups
Supported annotations:
- `@NotNull` and `@NotNull.List`
- `@Pattern` and `@Pattern.List`
- `@DecimalMin`/`@DecimalMax` and `@DecimalMin.List`/`@DecimalMax.List`
- `@Null` and `@Null.List`
- `@Min`/`@Max` and `@Min.List`/`@Max.List`
- `@NotBlank` and `@NotBlank.List`
- `@Size` and `@Size.List`

2. `@Validated` can be applied for parameter (request model) and method (response model).

**Are there unit tests? If not how should this be manually tested?**
There are no tests at this time. I added a [demonstration project][1] with modified libraries and [the resulting schema][2] from the /v3/api.

[1]: https://github.com/meose/springfox-validation-example
[2]: https://github.com/meose/springfox-validation-example/blob/master/src/main/java/springfox/validation/example/output.json