### PR TITLE
Fix Optional parameter detection

### DIFF
--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/parameter/ParameterRequiredReader.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/parameter/ParameterRequiredReader.java
@@ -43,6 +43,7 @@ import java.util.Set;
 import java.util.function.Predicate;
 
 import static java.util.Optional.*;
+import java.util.stream.Stream;
 
 @Component
 @Order(Ordered.HIGHEST_PRECEDENCE)
@@ -119,7 +120,7 @@ public class ParameterRequiredReader implements ParameterBuilderPlugin {
 
   @SuppressWarnings("squid:S1872")
   boolean isOptional(ResolvedMethodParameter methodParameter) {
-    return "com.google.common.base.Optional".equals(methodParameter.getParameterType().getErasedType().getName());
+    return Stream.of("java.util.Optional", "com.google.common.base.Optional").anyMatch(methodParameter.getParameterType().getErasedType().getName()::equals);
   }
 
   private boolean isRequired(RequestParam annotation) {

--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/parameter/ParameterRequiredReader.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/parameter/ParameterRequiredReader.java
@@ -120,7 +120,8 @@ public class ParameterRequiredReader implements ParameterBuilderPlugin {
 
   @SuppressWarnings("squid:S1872")
   boolean isOptional(ResolvedMethodParameter methodParameter) {
-    return Stream.of("java.util.Optional", "com.google.common.base.Optional").anyMatch(methodParameter.getParameterType().getErasedType().getName()::equals);
+    return Stream.of("java.util.Optional", "com.google.common.base.Optional")
+            .anyMatch(methodParameter.getParameterType().getErasedType().getName()::equals);
   }
 
   private boolean isRequired(RequestParam annotation) {


### PR DESCRIPTION
#### What's this PR do/fix?
The parameter should be resolved as `required=false` when using `java.util.Optional`.
#### Are there unit tests? If not how should this be manually tested?
There are no unit tests.
#### Any background context you want to provide?
In this commit https://github.com/springfox/springfox/commit/980379d1a042cc93594dcaf57036680924423654 there was a change from `java.util.Optional` to `com.google.common.base.Optional`. Both should be supported
#### What are the relevant issues?
#3502