### PR TITLE
fix infinite loop (memory leak) when recursive schemas

### DIFF
--- a/springfox-schema/src/main/java/springfox/documentation/schema/DefaultModelDependencyProvider.java
+++ b/springfox-schema/src/main/java/springfox/documentation/schema/DefaultModelDependencyProvider.java
@@ -77,7 +77,6 @@ public class DefaultModelDependencyProvider implements ModelDependencyProvider {
   @Override
   public Set<ResolvedType> dependentModels(ModelContext modelContext) {
     return Stream.concat(resolvedDependencies(modelContext).stream()
-            .filter(ignorableTypes(modelContext))
             .filter(baseTypes(modelContext).negate()),
         schemaPluginsManager.dependencies(modelContext).stream())
         .collect(toSet());
@@ -91,12 +90,6 @@ public class DefaultModelDependencyProvider implements ModelDependencyProvider {
     String typeName = nameExtractor.typeName(modelContext);
     return Types.isBaseType(typeName);
   }
-
-  private Predicate<ResolvedType> ignorableTypes(final ModelContext modelContext) {
-    return input -> !modelContext.hasSeenBefore(input);
-  }
-
-
   private Set<ResolvedType> resolvedDependencies(ModelContext modelContext) {
     ResolvedType resolvedType = modelContext.alternateEvaluatedType();
     if (isBaseType(ModelContext.fromParent(modelContext, resolvedType))) {

--- a/springfox-schema/src/main/java/springfox/documentation/schema/DefaultModelProvider.java
+++ b/springfox-schema/src/main/java/springfox/documentation/schema/DefaultModelProvider.java
@@ -83,7 +83,7 @@ public class DefaultModelProvider implements ModelProvider {
         || isMapType(propertiesHost)
         || enumTypeDeterminer.isEnum(propertiesHost.getErasedType())
         || springfox.documentation.schema.Types.isBaseType(propertiesHost)
-        || modelContext.hasSeenBefore(propertiesHost)) {
+        || modelContext.isProcessed(propertiesHost)) {
       LOG.debug(
           "Skipping model of type {} as its either a container type, map, enum or base type, or its already "
               + "been handled",
@@ -166,7 +166,7 @@ public class DefaultModelProvider implements ModelProvider {
   private Optional<Model> mapModel(
       ModelContext parentContext,
       ResolvedType resolvedType) {
-    if (isMapType(resolvedType) && !parentContext.hasSeenBefore(resolvedType)) {
+    if (isMapType(resolvedType) && !parentContext.isProcessed(resolvedType)) {
       String typeName = typeNameExtractor.typeName(parentContext);
 
       return Optional.of(parentContext.getBuilder()

--- a/springfox-schema/src/main/java/springfox/documentation/schema/DefaultModelSpecificationProvider.java
+++ b/springfox-schema/src/main/java/springfox/documentation/schema/DefaultModelSpecificationProvider.java
@@ -85,7 +85,7 @@ public class DefaultModelSpecificationProvider implements ModelSpecificationProv
         || isMapType(propertiesHost)
         || enumTypeDeterminer.isEnum(propertiesHost.getErasedType())
         || ScalarTypes.builtInScalarType(propertiesHost).isPresent()
-        || modelContext.hasSeenBefore(propertiesHost)) {
+        || modelContext.isProcessed(propertiesHost)) {
       LOG.debug(
           "Skipping model of type {} as its either a container type, map, enum or base type, or its already "
               + "been handled",
@@ -166,7 +166,7 @@ public class DefaultModelSpecificationProvider implements ModelSpecificationProv
   private Optional<ModelSpecification> mapModel(
       ModelContext mapContext,
       ResolvedType resolvedType) {
-    if (isMapType(resolvedType) && !mapContext.hasSeenBefore(resolvedType)) {
+    if (isMapType(resolvedType) && !mapContext.isProcessed(resolvedType)) {
       ResolvedType keyType = resolver.resolve(String.class);
       ModelContext keyContext = ModelContext.fromParent(
           mapContext,

--- a/springfox-schema/src/test/groovy/springfox/documentation/schema/ModelProviderSpec.groovy
+++ b/springfox-schema/src/test/groovy/springfox/documentation/schema/ModelProviderSpec.groovy
@@ -56,7 +56,7 @@ class ModelProviderSpec extends Specification implements ModelProviderSupport {
         alternateTypeProvider(),
         namingStrategy,
         emptySet())
-    context.seen(new TypeResolver().resolve(HttpHeaders))
+    context.processed(new TypeResolver().resolve(HttpHeaders))
     def dependentTypeNames = sut.dependencies(context).values().stream()
         .collect(Collectors.toMap(getNames,
             Function.identity()))

--- a/springfox-schema/src/test/groovy/springfox/documentation/schema/property/OptimizedModelPropertiesProviderSpec.groovy
+++ b/springfox-schema/src/test/groovy/springfox/documentation/schema/property/OptimizedModelPropertiesProviderSpec.groovy
@@ -214,8 +214,8 @@ class OptimizedModelPropertiesProviderSpec extends Specification implements Sche
         emptySet())
 
     when:
-    inputContext.seen(typeResolver.resolve(Category))
-    returnContext.seen(typeResolver.resolve(Category))
+    inputContext.processed(typeResolver.resolve(Category))
+    returnContext.processed(typeResolver.resolve(Category))
 
     and:
     def inputValue = sut.propertiesFor(type, inputContext)

--- a/springfox-spi/src/main/java/springfox/documentation/spi/schema/contexts/ModelContext.java
+++ b/springfox-spi/src/main/java/springfox/documentation/spi/schema/contexts/ModelContext.java
@@ -43,6 +43,7 @@ public class ModelContext {
 
   private final ModelContext parentContext;
   private final Set<ResolvedType> seenTypes = new HashSet<>();
+  private final Set<ResolvedType> processedTypes = new HashSet<>();
   private final springfox.documentation.builders.ModelBuilder modelBuilder;
   private final ModelSpecificationBuilder modelSpecificationBuilder;
   private final AlternateTypeProvider alternateTypeProvider;
@@ -282,27 +283,22 @@ public class ModelContext {
    * @param resolvedType - type to check
    * @return true or false
    */
+  public boolean isProcessed(ResolvedType resolvedType) {
+    return processedTypes.contains(resolvedType)
+        || processedTypes.contains(new TypeResolver().resolve(resolvedType.getErasedType()))
+        || Optional.ofNullable(parentContext).stream()
+        .anyMatch(parentContext -> parentContext.isProcessed(resolvedType));
+  }
+
   public boolean hasSeenBefore(ResolvedType resolvedType) {
     return seenTypes.contains(resolvedType)
         || seenTypes.contains(new TypeResolver().resolve(resolvedType.getErasedType()))
-        || parentHasSeenBefore(resolvedType);
+        || Optional.ofNullable(parentContext).stream()
+        .anyMatch(parentContext -> parentContext.hasSeenBefore(resolvedType));
   }
 
   public DocumentationType getDocumentationType() {
     return documentationType;
-  }
-
-  /**
-   * Answers the question, has the given type been processed by its parent context?
-   *
-   * @param resolvedType - type to check
-   * @return true or false
-   */
-  private boolean parentHasSeenBefore(ResolvedType resolvedType) {
-    if (parentContext == null) {
-      return false;
-    }
-    return parentContext.hasSeenBefore(resolvedType);
   }
 
   public GenericTypeNamingStrategy getGenericNamingStrategy() {
@@ -326,8 +322,15 @@ public class ModelContext {
     return modelSpecificationBuilder;
   }
 
+  public void processed(ResolvedType resolvedType) {
+    processedTypes.add(resolvedType);
+  }
+
   public void seen(ResolvedType resolvedType) {
     seenTypes.add(resolvedType);
+    if (parentContext != null) {
+      parentContext.seen(resolvedType);
+    }
   }
 
   @Override

--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/scanners/ApiModelReader.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/scanners/ApiModelReader.java
@@ -653,7 +653,7 @@ public class ApiModelReader {
       ModelContext modelContext) {
 
     for (Class ignorableParameterType : ignorableParameterTypes) {
-      modelContext.seen(typeResolver.resolve(ignorableParameterType));
+      modelContext.processed(typeResolver.resolve(ignorableParameterType));
     }
   }
 

--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/scanners/ApiModelSpecificationReader.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/scanners/ApiModelSpecificationReader.java
@@ -48,7 +48,7 @@ public class ApiModelSpecificationReader {
       ModelContext modelContext) {
 
     for (Class ignorableParameterType : ignorableParameterTypes) {
-      modelContext.seen(resolver.resolve(ignorableParameterType));
+      modelContext.processed(resolver.resolve(ignorableParameterType));
     }
   }
 


### PR DESCRIPTION
#### What's this PR do/fix?
This PR fixes recursive infinite loop (and memory leak) when there are a lot of schemas depending on each other.

#### Are there unit tests? If not how should this be manually tested?
Use multiple models where 
A depends on B and C
C depends on D
D depends on B 
etc ...

#### Any background context you want to provide?
The problem was we have to distinguish the read phase of resolvedType into modelContexts and the processed phase.
We should not create many instances of ResolvedType for the same model if it is a dependency of multiple other models.

Work :
- `seen` method has been renamed to `processed`
-  `hasSeenBefore` method has been renamed to `isProcessed`
- new methods seen / hasSeenBefore

#### What are the relevant issues?
https://github.com/springfox/springfox/issues/3224
