### PR TITLE
fix noopValidator loggerName

### DIFF
--- a/springfox-core/src/main/java/springfox/documentation/builders/NoopValidator.java
+++ b/springfox-core/src/main/java/springfox/documentation/builders/NoopValidator.java
@@ -10,7 +10,7 @@ import java.util.stream.Collectors;
 import static org.slf4j.LoggerFactory.*;
 
 public class NoopValidator<T> implements Validator<T> {
-  private static final Logger LOGGER = getLogger("Validator");
+  private static final Logger LOGGER = getLogger(NoopValidator.class);
 
   @Override
   public List<ValidationResult> validate(T builder) {


### PR DESCRIPTION
this was preventing NoopValidator logger from being configured with all springfox classes

#### fixes #3785
