### PR TITLE
Fix the bug that @Null does not work in 3.0

### DIFF
--- a/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/schema/IsNullAnnotationPlugin.java
+++ b/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/schema/IsNullAnnotationPlugin.java
@@ -50,7 +50,8 @@ public class IsNullAnnotationPlugin implements ModelPropertyBuilderPlugin {
   public void apply(ModelPropertyContext context) {
     Optional<Null> isNull = extractAnnotation(context);
     if (isNull.isPresent()) {
-      context.getBuilder().readOnly(isNull.isPresent());
+      context.getBuilder().readOnly(true);
+      context.getSpecificationBuilder().readOnly(true);
     }
   }
 

--- a/springfox-bean-validators/src/test/groovy/springfox/bean/validators/plugins/schema/ModelPropertyIsNullAnnotationPluginSpec.groovy
+++ b/springfox-bean-validators/src/test/groovy/springfox/bean/validators/plugins/schema/ModelPropertyIsNullAnnotationPluginSpec.groovy
@@ -53,9 +53,11 @@ class ModelPropertyIsNullAnnotationPluginSpec extends Specification {
     when:
     sut.apply(context)
     def property = context.builder.build()
+    def propertySpec = context.specificationBuilder.build()
 
     then:
     property.isReadOnly() == readOnly
+    propertySpec.getReadOnly() == readOnly
 
     where:
     propertyName    | readOnly
@@ -80,9 +82,11 @@ class ModelPropertyIsNullAnnotationPluginSpec extends Specification {
     when:
     sut.apply(context)
     def property = context.builder.build()
+    def propertySpec = context.specificationBuilder.build()
 
     then:
     property.isReadOnly() == readOnly
+    propertySpec.getReadOnly() == readOnly
 
     where:
     propertyName    | readOnly


### PR DESCRIPTION
#### What's this PR do/fix?
Fix the bug that Null annotation does not work (should produce readonly) in latest 3.0.0 schema.

#### Are there unit tests? If not how should this be manually tested?
Yes, in the commit.

#### Any background context you want to provide?
This file was left over in commit 6820a40961e4223bc0c1e9f4e8d1d3f29580edd0

#### What are the relevant issues?
No tracked issue.