### PR TITLE
Add json media type for EntitySaveExtractor

### DIFF
--- a/springfox-data-rest/src/main/java/springfox/documentation/spring/data/rest/EntityFindOneExtractor.java
+++ b/springfox-data-rest/src/main/java/springfox/documentation/spring/data/rest/EntityFindOneExtractor.java
@@ -35,19 +35,15 @@ class EntityFindOneExtractor implements EntityOperationsExtractor {
 
     context.crudMethods().getFindOneMethod()
         .map(method -> new HandlerMethod(context.getRepositoryInstance(), method))
-        .ifPresent(handler -> {
-
-          entityAction(context, handler)
-              .path(String.format("%s%s/{id}",
-                                  context.basePath(),
-                                  context.resourcePath()))
-              .supportsMethod(GET)
-              .parameterType(ParameterType.ID)
-              .build()
-              .map(get -> new SpringDataRestRequestHandler(context, get))
-              .ifPresent(handlers::add);
-
-        });
+        .flatMap(handler -> entityAction(context, handler)
+                .path(String.format("%s%s/{id}",
+                        context.basePath(),
+                        context.resourcePath()))
+                .supportsMethod(GET)
+                .parameterType(ParameterType.ID)
+                .build())
+        .map(get -> new SpringDataRestRequestHandler(context, get))
+        .ifPresent(handlers::add);
 
     return handlers;
   }

--- a/springfox-data-rest/src/main/java/springfox/documentation/spring/data/rest/EntitySaveExtractor.java
+++ b/springfox-data-rest/src/main/java/springfox/documentation/spring/data/rest/EntitySaveExtractor.java
@@ -19,6 +19,7 @@
 package springfox.documentation.spring.data.rest;
 
 import org.springframework.web.method.HandlerMethod;
+import org.springframework.http.MediaType;
 import springfox.documentation.RequestHandler;
 import springfox.documentation.spring.data.rest.SpecificationBuilder.*;
 
@@ -43,6 +44,7 @@ class EntitySaveExtractor implements EntityOperationsExtractor {
                                   context.resourcePath()))
               .supportsMethod(PUT)
               .supportsMethod(PATCH)
+              .produces(MediaType.APPLICATION_JSON)
               .parameterType(ParameterType.ID)
               .parameterType(ParameterType.RESOURCE)
               .build()
@@ -51,6 +53,7 @@ class EntitySaveExtractor implements EntityOperationsExtractor {
 
           entityAction(context, handler)
               .supportsMethod(POST)
+              .produces(MediaType.APPLICATION_JSON)
               .parameterType(ParameterType.RESOURCE)
               .build()
               .map(post -> new SpringDataRestRequestHandler(context, post))

--- a/springfox-data-rest/src/main/java/springfox/documentation/spring/data/rest/EntitySaveExtractor.java
+++ b/springfox-data-rest/src/main/java/springfox/documentation/spring/data/rest/EntitySaveExtractor.java
@@ -18,12 +18,13 @@
  */
 package springfox.documentation.spring.data.rest;
 
+import org.springframework.data.rest.core.annotation.RestResource;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.http.MediaType;
 import springfox.documentation.RequestHandler;
-import springfox.documentation.spring.data.rest.SpecificationBuilder.*;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.springframework.web.bind.annotation.RequestMethod.*;
@@ -35,6 +36,11 @@ class EntitySaveExtractor implements EntityOperationsExtractor {
     List<RequestHandler> handlers = new ArrayList<>();
 
     context.crudMethods().getSaveMethod()
+        .filter(method ->
+            Arrays.stream(method.getDeclaredAnnotations())
+                    .filter((rr) -> rr instanceof RestResource)
+                    .allMatch (rr -> ((RestResource) rr).exported())
+        )
         .map(method -> new HandlerMethod(context.getRepositoryInstance(), method))
         .ifPresent(handler -> {
 

--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/parameter/ParameterDataTypeReader.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/parameter/ParameterDataTypeReader.java
@@ -37,6 +37,7 @@ import springfox.documentation.schema.ScalarType;
 import springfox.documentation.schema.TypeNameExtractor;
 import springfox.documentation.schema.plugins.SchemaPluginsManager;
 import springfox.documentation.schema.property.ModelSpecificationFactory;
+import springfox.documentation.service.ParameterStyle;
 import springfox.documentation.service.ResolvedMethodParameter;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spi.schema.EnumTypeDeterminer;
@@ -133,8 +134,7 @@ public class ParameterDataTypeReader implements ParameterBuilderPlugin {
         && context.getDocumentationType() == DocumentationType.OAS_30) {
       modelRef = new springfox.documentation.schema.ModelRef("string");
       context.requestParameterBuilder()
-          .query(q -> q.model(m -> m.collectionModel(cm -> cm.collectionType(CollectionType.LIST).model(m2 -> m2.scalarModel(collectionItemScalarType(parameterModel)))))
-              .explode(true));
+          .query(q -> q.style(ParameterStyle.FORM).explode(false).model(m -> m.collectionModel(cm -> cm.collectionType(CollectionType.LIST).model(m2 -> m2.scalarModel(collectionItemScalarType(parameterModel))))));
     } else {
       String typeName = springfox.documentation.schema.Types.typeNameFor(parameterType.getErasedType());
       if (builtInScalarType(parameterType).isPresent()) {

--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/parameter/ParameterDataTypeReader.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/parameter/ParameterDataTypeReader.java
@@ -29,6 +29,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
+import springfox.documentation.schema.CollectionType;
 import springfox.documentation.schema.ModelReference;
 import springfox.documentation.schema.ModelSpecification;
 import springfox.documentation.schema.ScalarModelSpecification;
@@ -132,7 +133,7 @@ public class ParameterDataTypeReader implements ParameterBuilderPlugin {
         && context.getDocumentationType() == DocumentationType.OAS_30) {
       modelRef = new springfox.documentation.schema.ModelRef("string");
       context.requestParameterBuilder()
-          .query(q -> q.model(m -> m.scalarModel(collectionItemScalarType(parameterModel)))
+          .query(q -> q.model(m -> m.collectionModel(cm -> cm.collectionType(CollectionType.LIST).model(m2 -> m2.scalarModel(collectionItemScalarType(parameterModel)))))
               .explode(true));
     } else {
       String typeName = springfox.documentation.schema.Types.typeNameFor(parameterType.getErasedType());


### PR DESCRIPTION
#### What's this PR do/fix?

When using JPA and the `EntitySaveExtractor` to generate documentation, the `produces` field is not set causing `SwaggerResponseMessageReader` not to generate a proper response for this type. The side-effect of this is that `@ApiResponse` directives are ignored. Note: I am assuming from the [spring data rest docs](https://docs.spring.io/spring-data/rest/docs/current/reference/html/#repository-resources) that it is okay to hard-code the media type as `application/json`, but happy to be proven wrong

#### Are there unit tests? If not how should this be manually tested?

No unit tests, but can add some. To verify, put a custom `ApiResponse` directive on a JPARepository

```
public interface SkillRepository extends JpaRepository<Skill, Long> {
  @Override
  @ApiResponses({@ApiResponse(code = 201, message = "Created", response = EntityModelSkill.class)})
  <S extends Skill> S save(S user);

  class EntityModelSkill extends EntityModel<Skill> {

  }
}
```

Without these changes, the ApiResponse directive is ignored, whereas with them the response type is correctly declared in the resulting schema, on PUT, POST, and PATCH.

#### Any background context you want to provide?

Thought process is documented on my comment on this issue: https://github.com/springfox/springfox/issues/3503#issuecomment-884230856

I don't believe this solves the issue outright, but does fix a critical piece of functionality when using JPA. Next up is to figure out why 201 responses on POST don't declare the return type by default, but declaring the `ApiResponse` with the class above manually is a good enough work-around in the meantime.

#### What are the relevant issues?

 https://github.com/springfox/springfox/issues/3503