### PR TITLE
Added property file replacement for several annotation parameters

### DIFF
--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/operation/OpenApiResponseReader.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/operation/OpenApiResponseReader.java
@@ -41,6 +41,7 @@ import springfox.documentation.spi.schema.contexts.ModelContext;
 import springfox.documentation.spi.service.OperationBuilderPlugin;
 import springfox.documentation.spi.service.contexts.OperationContext;
 import springfox.documentation.spi.service.contexts.ResponseContext;
+import springfox.documentation.spring.web.DescriptionResolver;
 import springfox.documentation.spring.web.plugins.DocumentationPluginsManager;
 import springfox.documentation.swagger.common.SwaggerPluginSupport;
 
@@ -67,15 +68,18 @@ public class OpenApiResponseReader implements OperationBuilderPlugin {
   private final TypeResolver typeResolver;
   private final ModelSpecificationFactory modelSpecifications;
   private final DocumentationPluginsManager documentationPlugins;
+  private final DescriptionResolver descriptions;
 
   @Autowired
   public OpenApiResponseReader(
       TypeResolver typeResolver,
       ModelSpecificationFactory modelSpecifications,
-      DocumentationPluginsManager documentationPlugins) {
+      DocumentationPluginsManager documentationPlugins, DescriptionResolver descriptions
+  ) {
     this.typeResolver = typeResolver;
     this.modelSpecifications = modelSpecifications;
     this.documentationPlugins = documentationPlugins;
+    this.descriptions = descriptions;
   }
 
   @Override
@@ -134,7 +138,7 @@ public class OpenApiResponseReader implements OperationBuilderPlugin {
                 .description(eachExample.description())
                 .summary(eachExample.summary())
                 .id(eachExample.name())
-                .value(eachExample.value()).build());
+                .value(descriptions.resolve(eachExample.value())).build());
           }
         }
         headers.putAll(headers(apiResponse.headers()));

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/operation/OperationImplicitParameterReader.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/operation/OperationImplicitParameterReader.java
@@ -116,7 +116,7 @@ public class OperationImplicitParameterReader implements OperationBuilderPlugin 
             .parameterAccess(param.access())
             .order(SWAGGER_PLUGIN_ORDER)
             .scalarExample(param.example())
-            .complexExamples(examples(param.examples()))
+            .complexExamples(examples(descriptions, param.examples()))
             .collectionFormat(param.collectionFormat())
             .build(),
         new RequestParameterBuilder()
@@ -134,7 +134,7 @@ public class OperationImplicitParameterReader implements OperationBuilderPlugin 
                         .orElse(null))))
             .precedence(SWAGGER_PLUGIN_ORDER)
             .example(new ExampleBuilder().value(param.example()).build())
-            .examples(examples(param.examples()).entrySet().stream()
+            .examples(examples(descriptions, param.examples()).entrySet().stream()
                 .flatMap(e -> e.getValue().stream())
                 .collect(Collectors.toList()))
             .build()

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/operation/SwaggerResponseMessageReader.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/operation/SwaggerResponseMessageReader.java
@@ -42,6 +42,7 @@ import springfox.documentation.spi.schema.contexts.ModelContext;
 import springfox.documentation.spi.service.OperationBuilderPlugin;
 import springfox.documentation.spi.service.contexts.OperationContext;
 import springfox.documentation.spi.service.contexts.ResponseContext;
+import springfox.documentation.spring.web.DescriptionResolver;
 import springfox.documentation.spring.web.plugins.DocumentationPluginsManager;
 import springfox.documentation.swagger.common.SwaggerPluginSupport;
 
@@ -72,6 +73,7 @@ public class SwaggerResponseMessageReader implements OperationBuilderPlugin {
   private final TypeResolver typeResolver;
   private final ModelSpecificationFactory modelSpecifications;
   private final DocumentationPluginsManager documentationPlugins;
+  private final DescriptionResolver descriptions;
 
   @Autowired
   public SwaggerResponseMessageReader(
@@ -79,12 +81,14 @@ public class SwaggerResponseMessageReader implements OperationBuilderPlugin {
       TypeNameExtractor typeNameExtractor,
       TypeResolver typeResolver,
       ModelSpecificationFactory modelSpecifications,
-      DocumentationPluginsManager documentationPlugins) {
+      DocumentationPluginsManager documentationPlugins, DescriptionResolver descriptions
+  ) {
     this.enumTypeDeterminer = enumTypeDeterminer;
     this.typeNameExtractor = typeNameExtractor;
     this.typeResolver = typeResolver;
     this.modelSpecifications = modelSpecifications;
     this.documentationPlugins = documentationPlugins;
+    this.descriptions = descriptions;
   }
 
   @Override
@@ -168,7 +172,7 @@ public class SwaggerResponseMessageReader implements OperationBuilderPlugin {
             examples.add(new ExampleBuilder()
                 .mediaType(mediaType)
                 .id("example-" + index++)
-                .value(exampleProperty.value())
+                .value(descriptions.resolve(exampleProperty.value()))
                 .build());
           }
         }
@@ -177,7 +181,7 @@ public class SwaggerResponseMessageReader implements OperationBuilderPlugin {
 
         responseMessages.add(new springfox.documentation.builders.ResponseMessageBuilder()
             .code(apiResponse.code())
-            .message(apiResponse.message())
+            .message(descriptions.resolve(apiResponse.message()))
             .responseModel(responseModel.orElse(null))
             .examples(examples)
             .headersWithDescription(headers)
@@ -192,7 +196,7 @@ public class SwaggerResponseMessageReader implements OperationBuilderPlugin {
                         .apply(r -> r.model(m -> m.copyOf(model)))));
         responseContext.responseBuilder()
             .examples(examples)
-            .description(apiResponse.message())
+            .description(descriptions.resolve(apiResponse.message()))
             .headers(headers.values())
             .code(String.valueOf(apiResponse.code()));
         responses.add(documentationPlugins.response(responseContext));

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/parameter/ApiParamParameterBuilder.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/parameter/ApiParamParameterBuilder.java
@@ -97,7 +97,7 @@ public class ApiParamParameterBuilder implements ParameterBuilderPlugin {
           .allowEmptyValue(annotation.allowEmptyValue())
           .required(annotation.required())
           .scalarExample(example)
-          .complexExamples(examples(annotation.examples()))
+          .complexExamples(examples(descriptions, annotation.examples()))
           .hidden(annotation.hidden())
           .collectionFormat(annotation.collectionFormat())
           .order(SWAGGER_PLUGIN_ORDER);
@@ -115,7 +115,7 @@ public class ApiParamParameterBuilder implements ParameterBuilderPlugin {
                   .allowEmptyValue(annotation.allowEmptyValue())
           )
           .example(example)
-          .examples(allExamples(annotation.examples()));
+          .examples(allExamples(descriptions, annotation.examples()));
     }
   }
 

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/parameter/Examples.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/parameter/Examples.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import springfox.documentation.spring.web.DescriptionResolver;
 
 import static org.springframework.util.StringUtils.*;
 
@@ -37,54 +38,64 @@ public class Examples {
     throw new UnsupportedOperationException();
   }
 
-  public static Map<String, List<Example>> examples(io.swagger.annotations.Example example) {
+  public static Map<String, List<Example>> examples(
+      DescriptionResolver descriptions,
+      io.swagger.annotations.Example example
+  ) {
     Map<String, List<Example>> examples = new HashMap<>();
     for (ExampleProperty each : example.value()) {
       if (!isEmpty(each.value())) {
         examples.putIfAbsent(each.mediaType(), new LinkedList<>());
         examples.get(each.mediaType()).add(new ExampleBuilder()
             .mediaType(each.mediaType())
-            .value(each.value())
+            .value(descriptions.resolve(each.value()))
             .build());
       }
     }
     return examples;
   }
 
-  public static List<Example> allExamples(io.swagger.annotations.Example example) {
+  public static List<Example> allExamples(DescriptionResolver descriptions, io.swagger.annotations.Example example) {
     List<Example> examples = new ArrayList<>();
     for (ExampleProperty each : example.value()) {
       if (!isEmpty(each.value())) {
         examples.add(new ExampleBuilder()
             .mediaType(each.mediaType())
-            .value(each.value())
+            .value(descriptions.resolve(each.value()))
             .build());
       }
     }
     return examples;
   }
 
-  public static Map<String, List<Example>> examples(String mediaType, ExampleObject[] exampleObjects) {
+  public static Map<String, List<Example>> examples(
+      DescriptionResolver descriptions,
+      String mediaType,
+      ExampleObject[] exampleObjects
+  ) {
     Map<String, List<Example>> examples = new HashMap<>();
     for (ExampleObject each : exampleObjects) {
       if (!isEmpty(each.value())) {
         examples.putIfAbsent(mediaType, new LinkedList<>());
         examples.get(mediaType).add(new ExampleBuilder()
                                                .mediaType(mediaType)
-                                               .value(each.value())
+                                               .value(descriptions.resolve(each.value()))
                                                .build());
       }
     }
     return examples;
   }
 
-  public static List<Example> allExamples(String mediaType, ExampleObject[] exampleObjects) {
+  public static List<Example> allExamples(
+      DescriptionResolver descriptions,
+      String mediaType, ExampleObject[] exampleObjects
+  ) {
     List<Example> examples = new ArrayList<>();
     for (ExampleObject each : exampleObjects) {
       if (!isEmpty(each.value())) {
         examples.add(new ExampleBuilder()
                          .mediaType(mediaType)
-                         .value(each.value())
+                         .value(descriptions.resolve(each.value()))
                          .build());
       }
     }

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/parameter/OpenApiParameterBuilder.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/parameter/OpenApiParameterBuilder.java
@@ -92,7 +92,7 @@ public class OpenApiParameterBuilder implements ParameterBuilderPlugin {
                   .explode(translateExplodeOption(annotation.explode()))
                   .style(translateStyle(annotation.style())))
           .example(example)
-          .examples(allExamples("", annotation.examples()))
+          .examples(allExamples(descriptions, "", annotation.examples()))
           .examples(contentExamples(annotation.content()));
     }
   }
@@ -110,7 +110,7 @@ public class OpenApiParameterBuilder implements ParameterBuilderPlugin {
 
   private Collection<Example> contentExamples(Content[] contents) {
     return Arrays.stream(contents)
-        .flatMap(c -> allExamples(c.mediaType(), c.examples()).stream())
+        .flatMap(c -> allExamples(descriptions, c.mediaType(), c.examples()).stream())
         .collect(Collectors.toList());
   }
 

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/parameter/SwaggerExpandedParameterBuilder.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/parameter/SwaggerExpandedParameterBuilder.java
@@ -95,7 +95,7 @@ public class SwaggerExpandedParameterBuilder implements ExpandedParameterBuilder
            .parameterAccess(apiParam.access())
            .hidden(apiParam.hidden())
            .scalarExample(apiParam.example())
-           .complexExamples(examples(apiParam.examples()))
+           .complexExamples(examples(descriptions, apiParam.examples()))
            .order(SWAGGER_PLUGIN_ORDER)
            .build();
 

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/schema/ApiModelBuilder.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/schema/ApiModelBuilder.java
@@ -32,6 +32,7 @@ import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spi.schema.EnumTypeDeterminer;
 import springfox.documentation.spi.schema.ModelBuilderPlugin;
 import springfox.documentation.spi.schema.contexts.ModelContext;
+import springfox.documentation.spring.web.DescriptionResolver;
 import springfox.documentation.swagger.common.SwaggerPluginSupport;
 
 import java.util.ArrayList;
@@ -48,17 +49,20 @@ public class ApiModelBuilder implements ModelBuilderPlugin {
   private final TypeNameExtractor typeNameExtractor;
   private final EnumTypeDeterminer enumTypeDeterminer;
   private final ModelSpecificationFactory modelSpecifications;
+  private final DescriptionResolver descriptions;
 
   @Autowired
   public ApiModelBuilder(
       TypeResolver typeResolver,
       TypeNameExtractor typeNameExtractor,
       EnumTypeDeterminer enumTypeDeterminer,
-      ModelSpecificationFactory modelSpecifications) {
+      ModelSpecificationFactory modelSpecifications, DescriptionResolver descriptions
+  ) {
     this.typeResolver = typeResolver;
     this.typeNameExtractor = typeNameExtractor;
     this.enumTypeDeterminer = enumTypeDeterminer;
     this.modelSpecifications = modelSpecifications;
+    this.descriptions = descriptions;
   }
 
   @Override
@@ -77,11 +81,11 @@ public class ApiModelBuilder implements ModelBuilderPlugin {
             .ifPresent(subclassKeys::add);
       }
       context.getBuilder()
-             .description(annotation.description())
+             .description(descriptions.resolve(annotation.description()))
              .discriminator(annotation.discriminator())
              .subTypes(modelRefs);
       context.getModelSpecificationBuilder()
-             .facets(f -> f.description(annotation.description()))
+             .facets(f -> f.description(descriptions.resolve(annotation.description())))
              .compoundModel(cm -> cm.discriminator(annotation.discriminator())
                                     .subclassReferences(subclassKeys));
     }

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/mixins/SwaggerPluginsSupport.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/mixins/SwaggerPluginsSupport.groovy
@@ -77,7 +77,8 @@ trait SwaggerPluginsSupport {
             resolver,
             typeNameExtractor,
             enumTypeDeterminer,
-            new ModelSpecificationFactory(typeNameExtractor, enumTypeDeterminer))])
+            new ModelSpecificationFactory(typeNameExtractor, enumTypeDeterminer),
+            descriptions)])
 
     PluginRegistry<ViewProviderPlugin, DocumentationType> viewProviderRegistry =
         of([new JacksonJsonViewProvider(new TypeResolver())])

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/operation/SwaggerResponseMessageReaderSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/readers/operation/SwaggerResponseMessageReaderSpec.groovy
@@ -62,7 +62,7 @@ class SwaggerResponseMessageReaderSpec extends DocumentationContextSpec implemen
         enumTypeDeterminer,
         typeNameExtractor,
         resolver,
-        new ModelSpecificationFactory(typeNameExtractor, enumTypeDeterminer), defaultWebPlugins())
+        new ModelSpecificationFactory(typeNameExtractor, enumTypeDeterminer), defaultWebPlugins(), descriptions)
         .apply(operationContext)
 
     and:
@@ -112,7 +112,7 @@ class SwaggerResponseMessageReaderSpec extends DocumentationContextSpec implemen
         enumTypeDeterminer,
         typeNameExtractor,
         resolver,
-        new ModelSpecificationFactory(typeNameExtractor, enumTypeDeterminer), defaultWebPlugins())
+        new ModelSpecificationFactory(typeNameExtractor, enumTypeDeterminer), defaultWebPlugins(), descriptions)
         .apply(operationContext)
 
     and:
@@ -161,7 +161,7 @@ class SwaggerResponseMessageReaderSpec extends DocumentationContextSpec implemen
     new SwaggerResponseMessageReader(enumTypeDeterminer,
         typeNameExtractor,
         resolver,
-        new ModelSpecificationFactory(typeNameExtractor, enumTypeDeterminer), defaultWebPlugins())
+        new ModelSpecificationFactory(typeNameExtractor, enumTypeDeterminer), defaultWebPlugins(), descriptions)
         .apply(operationContext)
 
     and:
@@ -232,7 +232,7 @@ class SwaggerResponseMessageReaderSpec extends DocumentationContextSpec implemen
         new JacksonEnumTypeDeterminer(),
         typeNameExtractor,
         resolver,
-        new ModelSpecificationFactory(typeNameExtractor, enumTypeDeterminer), defaultWebPlugins())
+        new ModelSpecificationFactory(typeNameExtractor, enumTypeDeterminer), defaultWebPlugins(), descriptions)
 
     then:
     !sut.supports(DocumentationType.SPRING_WEB)
@@ -262,7 +262,8 @@ class SwaggerResponseMessageReaderSpec extends DocumentationContextSpec implemen
         typeNameExtractor,
         resolver,
         new ModelSpecificationFactory(typeNameExtractor, Mock(EnumTypeDeterminer)),
-        defaultWebPlugins())
+        defaultWebPlugins(),
+        descriptions)
         .apply(operationContext)
 
     and:

--- a/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/schema/ApiModelBuilderSpec.groovy
+++ b/springfox-swagger-common/src/test/groovy/springfox/documentation/swagger/schema/ApiModelBuilderSpec.groovy
@@ -41,7 +41,8 @@ class ApiModelBuilderSpec extends Specification {
           resolver,
           Mock(TypeNameExtractor),
           Mock(EnumTypeDeterminer),
-          Mock(ModelSpecificationFactory))
+          Mock(ModelSpecificationFactory),
+          descriptions)
     expect:
       !sut.supports(DocumentationType.SPRING_WEB)
       sut.supports(DocumentationType.SWAGGER_12)
@@ -54,7 +55,8 @@ class ApiModelBuilderSpec extends Specification {
           resolver,
           Mock(TypeNameExtractor),
           Mock(EnumTypeDeterminer),
-          Mock(ModelSpecificationFactory))
+          Mock(ModelSpecificationFactory),
+          descriptions)
       ModelContext context = ModelContext.inputParam(
           "0",
           "group",


### PR DESCRIPTION
#### What's this PR do/fix?

This extends the capability of getting texts from property files for certain annotations. In particular

- `@ApiResponse#message()`
- `@ApiModel#description()`
- `@ExampleProperty#value()`
- `@ExampleObject#value()`

I didn't know if there are any other annotations which may benefit from this. If you know any other feel free to tell me and I'll include this into this PR. 

#### Are there unit tests? If not how should this be manually tested?

I looked for unit tests that do similar things but couldn't find any, thus I didn't add any either. But I checked this out in a side project. To test it manually simply create a properties file with messages and use them for the above listed annotation parameters as described in http://springfox.github.io/springfox/docs/current/#property-file-lookup.

#### What are the relevant issues?

https://github.com/springfox/springfox/issues/2389
