### PR TITLE
Headers in API response

### DIFF
--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/operation/OpenApiResponseReader.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/operation/OpenApiResponseReader.java
@@ -137,13 +137,15 @@ public class OpenApiResponseReader implements OperationBuilderPlugin {
                 .value(eachExample.value()).build());
           }
         }
-        headers.putAll(headers(apiResponse.headers()));
 
         type.ifPresent(t -> responseContext.responseBuilder()
             .representation(each.mediaType().isEmpty() ? MediaType.ALL : MediaType.valueOf(each.mediaType()))
             .apply(r -> r.model(
                 m -> m.copyOf(modelSpecifications.create(modelContext, t)))));
       }
+
+      headers.putAll(headers(apiResponse.headers()));
+
       responseContext.responseBuilder()
           .examples(examples)
           .description(apiResponse.description())

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/operation/OpenApiResponseReader.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/operation/OpenApiResponseReader.java
@@ -156,8 +156,9 @@ public class OpenApiResponseReader implements OperationBuilderPlugin {
 
   static boolean isSuccessful(String code) {
     try {
-      return HttpStatus.Series.SUCCESSFUL.equals(HttpStatus.Series.valueOf(code));
+      return HttpStatus.Series.SUCCESSFUL.equals(HttpStatus.Series.valueOf(Integer.parseInt(code)));
     } catch (Exception ignored) {
+      // Either couldn't parse the string to an integer, or the integer didn't match any status code series.
       return false;
     }
   }


### PR DESCRIPTION
#### What's this PR do/fix?
Header annotations within an ApiResponse are ignored. 
It fixes two problems in the code.
Firstly, the `isSuccessful` method passes a String status code into Spring's `HttpStatus.Series.valueOf`, which requires an integer, so fails.
Secondly, the headers are added within the per content loop, although they are not per content. So they can be added repeatedly if there are multiple content sections, or not added at all if there is no content.
#### Are there unit tests? If not how should this be manually tested?
I couldn't see an existing test, and I didn't add one. (I'm not familiar with Spock.) Issue 3804 describes how to reproduce the error.
#### Any background context you want to provide?
#### What are the relevant issues?
#3804 