### PR TITLE
fix infinite loop (memory leak) when linked schemas

### DIFF
--- a/oas-contract-tests/src/main/java/springfox/test/contract/oas/OpenApiTestConfig.java
+++ b/oas-contract-tests/src/main/java/springfox/test/contract/oas/OpenApiTestConfig.java
@@ -8,11 +8,7 @@ import org.springframework.http.ResponseEntity;
 import reactor.core.publisher.Mono;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.schema.WildcardType;
-import springfox.documentation.service.ApiKey;
-import springfox.documentation.service.AuthorizationScope;
-import springfox.documentation.service.HttpAuthenticationScheme;
-import springfox.documentation.service.OAuth2Scheme;
-import springfox.documentation.service.SecurityScheme;
+import springfox.documentation.service.*;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
 
@@ -21,7 +17,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 
-import static springfox.documentation.schema.AlternateTypeRules.*;
+import static springfox.documentation.schema.AlternateTypeRules.newRule;
 
 @Configuration
 public class OpenApiTestConfig {
@@ -40,6 +36,7 @@ public class OpenApiTestConfig {
             .and(PathSelectors.regex(".*/error").negate())
             .and(PathSelectors.regex(".*/bugs/.*").negate())
             .and(PathSelectors.regex(".*/features/.*").negate())
+            .and(PathSelectors.regex(".*/linked-models(/.*)?").negate())
             .and(PathSelectors.regex(".*/profile").negate()))
         .build()
         .enableUrlTemplating(false)
@@ -123,7 +120,26 @@ public class OpenApiTestConfig {
             newRule(resolver.resolve(Mono.class,
                 resolver.resolve(ResponseEntity.class, InputStreamResource.class)),
                 resolver.resolve(File.class)))
-        .host("bugs.springfox.io")
+        .host("features.springfox.io")
+        .protocols(new HashSet<>(Arrays.asList(
+            "http",
+            "https")));
+  }
+
+  @Bean
+  public Docket linkedModels() {
+    return new Docket(DocumentationType.OAS_30)
+        .groupName("linked-models")
+        .useDefaultResponseMessages(false)
+        .produces(new HashSet<String>() {{
+          add("application/json");
+        }})
+        .select()
+        .paths(PathSelectors.regex(".*/linked-models(/.*)?")
+            .and(PathSelectors.regex(".*/error").negate())
+            .and(PathSelectors.regex(".*/profile").negate()))
+        .build()
+        .host("linked-models.springfox.io")
         .protocols(new HashSet<>(Arrays.asList(
             "http",
             "https")));

--- a/oas-contract-tests/src/main/java/springfox/test/contract/oas/linkdedmodels/LinkedModelsController.java
+++ b/oas-contract-tests/src/main/java/springfox/test/contract/oas/linkdedmodels/LinkedModelsController.java
@@ -1,0 +1,18 @@
+package springfox.test.contract.oas.linkdedmodels;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import springfox.test.contract.oas.linkdedmodels.model.Model;
+
+@RestController
+@RequestMapping("/linked-models")
+public class LinkedModelsController {
+
+    @GetMapping
+    public ResponseEntity<Model> linkedModels() {
+        return null;
+    }
+
+}

--- a/oas-contract-tests/src/main/java/springfox/test/contract/oas/linkdedmodels/model/Model.java
+++ b/oas-contract-tests/src/main/java/springfox/test/contract/oas/linkdedmodels/model/Model.java
@@ -1,0 +1,77 @@
+package springfox.test.contract.oas.linkdedmodels.model;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.constraints.NotNull;
+import java.util.Objects;
+
+import static com.fasterxml.jackson.annotation.JsonSubTypes.Type;
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.As.EXISTING_PROPERTY;
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME;
+
+
+@JsonTypeInfo(use = NAME, include = EXISTING_PROPERTY, property = "name", visible = true)
+@JsonSubTypes({
+        @Type(value = Model01.class, name = "Model01"),
+        @Type(value = Model02.class, name = "Model02"),
+        @Type(value = Model03.class, name = "Model03"),
+        @Type(value = Model04.class, name = "Model04"),
+        @Type(value = Model05.class, name = "Model05"),
+        @Type(value = Model06.class, name = "Model06"),
+        @Type(value = Model07.class, name = "Model07"),
+        @Type(value = Model08.class, name = "Model08"),
+        @Type(value = Model09.class, name = "Model09"),
+        @Type(value = Model10.class, name = "Model10"),
+        @Type(value = Model11.class, name = "Model11"),
+        @Type(value = Model12.class, name = "Model12"),
+        @Type(value = Model13.class, name = "Model13"),
+        @Type(value = Model14.class, name = "Model14"),
+        @Type(value = Model15.class, name = "Model15"),
+        @Type(value = Model16.class, name = "Model15"),
+        @Type(value = Model17.class, name = "Model17"),
+        @Type(value = Model18.class, name = "Model18"),
+        @Type(value = Model19.class, name = "Model19"),
+        @Type(value = Model20.class, name = "Model20")
+})
+public abstract class Model   {
+
+  @ApiModelProperty(required = true)
+  @NotNull
+  private String name;
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Model model = (Model) o;
+    return Objects.equals(name, model.name);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name);
+  }
+
+  @Override
+  public String toString() {
+    return "Model{" +
+            "name='" + name + '\'' +
+            '}';
+  }
+
+}
+

--- a/oas-contract-tests/src/main/java/springfox/test/contract/oas/linkdedmodels/model/Model01.java
+++ b/oas-contract-tests/src/main/java/springfox/test/contract/oas/linkdedmodels/model/Model01.java
@@ -1,0 +1,42 @@
+package springfox.test.contract.oas.linkdedmodels.model;
+
+import java.util.Objects;
+
+public class Model01 extends Model  {
+
+  private Model02 next;
+
+  public Model02 getNext() {
+    return next;
+  }
+
+  public void setNext(Model02 next) {
+    this.next = next;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Model01 model01 = (Model01) o;
+    return Objects.equals(next, model01.next) &&
+        super.equals(o);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(next, super.hashCode());
+  }
+
+  @Override
+  public String toString() {
+    return "Model01{" +
+            "next=" + next +
+            '}';
+  }
+}
+

--- a/oas-contract-tests/src/main/java/springfox/test/contract/oas/linkdedmodels/model/Model02.java
+++ b/oas-contract-tests/src/main/java/springfox/test/contract/oas/linkdedmodels/model/Model02.java
@@ -1,0 +1,55 @@
+package springfox.test.contract.oas.linkdedmodels.model;
+
+import java.util.Objects;
+
+public class Model02 extends Model  {
+
+  private Model01 previous;
+
+  private Model03 next;
+
+  public Model01 getPrevious() {
+    return previous;
+  }
+
+  public void setPrevious(Model01 previous) {
+    this.previous = previous;
+  }
+
+  public Model03 getNext() {
+    return next;
+  }
+
+  public void setNext(Model03 next) {
+    this.next = next;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Model02 model02 = (Model02) o;
+    return Objects.equals(previous, model02.previous) &&
+        Objects.equals(next, model02.next) &&
+        super.equals(o);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(previous, next, super.hashCode());
+  }
+
+  @Override
+  public String toString() {
+    return "Model02{" +
+            "previous=" + previous +
+            ", next=" + next +
+            '}';
+  }
+
+}
+

--- a/oas-contract-tests/src/main/java/springfox/test/contract/oas/linkdedmodels/model/Model03.java
+++ b/oas-contract-tests/src/main/java/springfox/test/contract/oas/linkdedmodels/model/Model03.java
@@ -1,0 +1,55 @@
+package springfox.test.contract.oas.linkdedmodels.model;
+
+import java.util.Objects;
+
+
+public class Model03 extends Model  {
+
+  private Model02 previous;
+
+  private Model04 next;
+
+  public Model02 getPrevious() {
+    return previous;
+  }
+
+  public void setPrevious(Model02 previous) {
+    this.previous = previous;
+  }
+
+  public Model04 getNext() {
+    return next;
+  }
+
+  public void setNext(Model04 next) {
+    this.next = next;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Model03 model03 = (Model03) o;
+    return Objects.equals(previous, model03.previous) &&
+        Objects.equals(next, model03.next) &&
+        super.equals(o);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(previous, next, super.hashCode());
+  }
+
+  @Override
+  public String toString() {
+    return "Model03{" +
+            "previous=" + previous +
+            ", next=" + next +
+            '}';
+  }
+}
+

--- a/oas-contract-tests/src/main/java/springfox/test/contract/oas/linkdedmodels/model/Model04.java
+++ b/oas-contract-tests/src/main/java/springfox/test/contract/oas/linkdedmodels/model/Model04.java
@@ -1,0 +1,55 @@
+package springfox.test.contract.oas.linkdedmodels.model;
+
+import java.util.Objects;
+
+
+public class Model04 extends Model  {
+
+  private Model03 previous;
+
+  private Model05 next;
+
+  public Model03 getPrevious() {
+    return previous;
+  }
+
+  public void setPrevious(Model03 previous) {
+    this.previous = previous;
+  }
+
+  public Model05 getNext() {
+    return next;
+  }
+
+  public void setNext(Model05 next) {
+    this.next = next;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Model04 model04 = (Model04) o;
+    return Objects.equals(previous, model04.previous) &&
+        Objects.equals(next, model04.next) &&
+        super.equals(o);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(previous, next, super.hashCode());
+  }
+
+  @Override
+  public String toString() {
+    return "Model04{" +
+            "previous=" + previous +
+            ", next=" + next +
+            '}';
+  }
+}
+

--- a/oas-contract-tests/src/main/java/springfox/test/contract/oas/linkdedmodels/model/Model05.java
+++ b/oas-contract-tests/src/main/java/springfox/test/contract/oas/linkdedmodels/model/Model05.java
@@ -1,0 +1,55 @@
+package springfox.test.contract.oas.linkdedmodels.model;
+
+import java.util.Objects;
+
+
+public class Model05 extends Model  {
+
+  private Model04 previous;
+
+  private Model06 next;
+
+  public Model04 getPrevious() {
+    return previous;
+  }
+
+  public void setPrevious(Model04 previous) {
+    this.previous = previous;
+  }
+
+  public Model06 getNext() {
+    return next;
+  }
+
+  public void setNext(Model06 next) {
+    this.next = next;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Model05 model05 = (Model05) o;
+    return Objects.equals(previous, model05.previous) &&
+        Objects.equals(next, model05.next) &&
+        super.equals(o);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(previous, next, super.hashCode());
+  }
+
+  @Override
+  public String toString() {
+    return "Model05{" +
+            "previous=" + previous +
+            ", next=" + next +
+            '}';
+  }
+}
+

--- a/oas-contract-tests/src/main/java/springfox/test/contract/oas/linkdedmodels/model/Model06.java
+++ b/oas-contract-tests/src/main/java/springfox/test/contract/oas/linkdedmodels/model/Model06.java
@@ -1,0 +1,55 @@
+package springfox.test.contract.oas.linkdedmodels.model;
+
+import java.util.Objects;
+
+
+public class Model06 extends Model  {
+
+  private Model05 previous;
+
+  private Model07 next;
+
+  public Model05 getPrevious() {
+    return previous;
+  }
+
+  public void setPrevious(Model05 previous) {
+    this.previous = previous;
+  }
+
+  public Model07 getNext() {
+    return next;
+  }
+
+  public void setNext(Model07 next) {
+    this.next = next;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Model06 model06 = (Model06) o;
+    return Objects.equals(previous, model06.previous) &&
+        Objects.equals(next, model06.next) &&
+        super.equals(o);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(previous, next, super.hashCode());
+  }
+
+  @Override
+  public String toString() {
+    return "Model06{" +
+            "previous=" + previous +
+            ", next=" + next +
+            '}';
+  }
+}
+

--- a/oas-contract-tests/src/main/java/springfox/test/contract/oas/linkdedmodels/model/Model07.java
+++ b/oas-contract-tests/src/main/java/springfox/test/contract/oas/linkdedmodels/model/Model07.java
@@ -1,0 +1,55 @@
+package springfox.test.contract.oas.linkdedmodels.model;
+
+import java.util.Objects;
+
+
+public class Model07 extends Model  {
+
+  private Model06 previous;
+
+  private Model08 next = null;
+
+  public Model06 getPrevious() {
+    return previous;
+  }
+
+  public void setPrevious(Model06 previous) {
+    this.previous = previous;
+  }
+
+  public Model08 getNext() {
+    return next;
+  }
+
+  public void setNext(Model08 next) {
+    this.next = next;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Model07 model07 = (Model07) o;
+    return Objects.equals(previous, model07.previous) &&
+        Objects.equals(next, model07.next) &&
+        super.equals(o);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(previous, next, super.hashCode());
+  }
+
+  @Override
+  public String toString() {
+    return "Model07{" +
+            "previous=" + previous +
+            ", next=" + next +
+            '}';
+  }
+}
+

--- a/oas-contract-tests/src/main/java/springfox/test/contract/oas/linkdedmodels/model/Model08.java
+++ b/oas-contract-tests/src/main/java/springfox/test/contract/oas/linkdedmodels/model/Model08.java
@@ -1,0 +1,55 @@
+package springfox.test.contract.oas.linkdedmodels.model;
+
+import java.util.Objects;
+
+
+public class Model08 extends Model  {
+
+  private Model07 previous;
+
+  private Model09 next;
+
+  public Model07 getPrevious() {
+    return previous;
+  }
+
+  public void setPrevious(Model07 previous) {
+    this.previous = previous;
+  }
+
+  public Model09 getNext() {
+    return next;
+  }
+
+  public void setNext(Model09 next) {
+    this.next = next;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Model08 model08 = (Model08) o;
+    return Objects.equals(previous, model08.previous) &&
+        Objects.equals(next, model08.next) &&
+        super.equals(o);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(previous, next, super.hashCode());
+  }
+
+  @Override
+  public String toString() {
+    return "Model08{" +
+            "previous=" + previous +
+            ", next=" + next +
+            '}';
+  }
+}
+

--- a/oas-contract-tests/src/main/java/springfox/test/contract/oas/linkdedmodels/model/Model09.java
+++ b/oas-contract-tests/src/main/java/springfox/test/contract/oas/linkdedmodels/model/Model09.java
@@ -1,0 +1,55 @@
+package springfox.test.contract.oas.linkdedmodels.model;
+
+import java.util.Objects;
+
+
+public class Model09 extends Model  {
+
+  private Model08 previous;
+
+  private Model10 next;
+
+  public Model08 getPrevious() {
+    return previous;
+  }
+
+  public void setPrevious(Model08 previous) {
+    this.previous = previous;
+  }
+
+  public Model10 getNext() {
+    return next;
+  }
+
+  public void setNext(Model10 next) {
+    this.next = next;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Model09 model09 = (Model09) o;
+    return Objects.equals(previous, model09.previous) &&
+        Objects.equals(next, model09.next) &&
+        super.equals(o);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(previous, next, super.hashCode());
+  }
+
+  @Override
+  public String toString() {
+    return "Model09{" +
+            "previous=" + previous +
+            ", next=" + next +
+            '}';
+  }
+}
+

--- a/oas-contract-tests/src/main/java/springfox/test/contract/oas/linkdedmodels/model/Model10.java
+++ b/oas-contract-tests/src/main/java/springfox/test/contract/oas/linkdedmodels/model/Model10.java
@@ -1,0 +1,55 @@
+package springfox.test.contract.oas.linkdedmodels.model;
+
+import java.util.Objects;
+
+
+public class Model10 extends Model  {
+
+  private Model09 previous;
+
+  private Model11 next;
+
+  public Model09 getPrevious() {
+    return previous;
+  }
+
+  public void setPrevious(Model09 previous) {
+    this.previous = previous;
+  }
+
+  public Model11 getNext() {
+    return next;
+  }
+
+  public void setNext(Model11 next) {
+    this.next = next;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Model10 model10 = (Model10) o;
+    return Objects.equals(previous, model10.previous) &&
+        Objects.equals(next, model10.next) &&
+        super.equals(o);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(previous, next, super.hashCode());
+  }
+
+  @Override
+  public String toString() {
+    return "Model10{" +
+            "previous=" + previous +
+            ", next=" + next +
+            '}';
+  }
+}
+

--- a/oas-contract-tests/src/main/java/springfox/test/contract/oas/linkdedmodels/model/Model11.java
+++ b/oas-contract-tests/src/main/java/springfox/test/contract/oas/linkdedmodels/model/Model11.java
@@ -1,0 +1,55 @@
+package springfox.test.contract.oas.linkdedmodels.model;
+
+import java.util.Objects;
+
+
+public class Model11 extends Model  {
+
+  private Model10 previous;
+
+  private Model12 next;
+
+  public Model10 getPrevious() {
+    return previous;
+  }
+
+  public void setPrevious(Model10 previous) {
+    this.previous = previous;
+  }
+
+  public Model12 getNext() {
+    return next;
+  }
+
+  public void setNext(Model12 next) {
+    this.next = next;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Model11 model11 = (Model11) o;
+    return Objects.equals(previous, model11.previous) &&
+        Objects.equals(next, model11.next) &&
+        super.equals(o);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(previous, next, super.hashCode());
+  }
+
+  @Override
+  public String toString() {
+    return "Model11{" +
+            "previous=" + previous +
+            ", next=" + next +
+            '}';
+  }
+}
+

--- a/oas-contract-tests/src/main/java/springfox/test/contract/oas/linkdedmodels/model/Model12.java
+++ b/oas-contract-tests/src/main/java/springfox/test/contract/oas/linkdedmodels/model/Model12.java
@@ -1,0 +1,55 @@
+package springfox.test.contract.oas.linkdedmodels.model;
+
+import java.util.Objects;
+
+
+public class Model12 extends Model  {
+
+  private Model11 previous;
+
+  private Model13 next;
+
+  public Model11 getPrevious() {
+    return previous;
+  }
+
+  public void setPrevious(Model11 previous) {
+    this.previous = previous;
+  }
+
+  public Model13 getNext() {
+    return next;
+  }
+
+  public void setNext(Model13 next) {
+    this.next = next;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Model12 model12 = (Model12) o;
+    return Objects.equals(previous, model12.previous) &&
+        Objects.equals(next, model12.next) &&
+        super.equals(o);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(previous, next, super.hashCode());
+  }
+
+  @Override
+  public String toString() {
+    return "Model12{" +
+            "previous=" + previous +
+            ", next=" + next +
+            '}';
+  }
+}
+

--- a/oas-contract-tests/src/main/java/springfox/test/contract/oas/linkdedmodels/model/Model13.java
+++ b/oas-contract-tests/src/main/java/springfox/test/contract/oas/linkdedmodels/model/Model13.java
@@ -1,0 +1,55 @@
+package springfox.test.contract.oas.linkdedmodels.model;
+
+import java.util.Objects;
+
+
+public class Model13 extends Model  {
+
+  private Model12 previous;
+
+  private Model14 next;
+
+  public Model12 getPrevious() {
+    return previous;
+  }
+
+  public void setPrevious(Model12 previous) {
+    this.previous = previous;
+  }
+
+  public Model14 getNext() {
+    return next;
+  }
+
+  public void setNext(Model14 next) {
+    this.next = next;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Model13 model13 = (Model13) o;
+    return Objects.equals(previous, model13.previous) &&
+        Objects.equals(next, model13.next) &&
+        super.equals(o);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(previous, next, super.hashCode());
+  }
+
+  @Override
+  public String toString() {
+    return "Model13{" +
+            "previous=" + previous +
+            ", next=" + next +
+            '}';
+  }
+}
+

--- a/oas-contract-tests/src/main/java/springfox/test/contract/oas/linkdedmodels/model/Model14.java
+++ b/oas-contract-tests/src/main/java/springfox/test/contract/oas/linkdedmodels/model/Model14.java
@@ -1,0 +1,54 @@
+package springfox.test.contract.oas.linkdedmodels.model;
+
+import java.util.Objects;
+
+
+public class Model14 extends Model  {
+
+  private Model13 previous;
+
+  private Model15 next;
+
+  public Model13 getPrevious() {
+    return previous;
+  }
+
+  public void setPrevious(Model13 previous) {
+    this.previous = previous;
+  }
+
+  public Model15 getNext() {
+    return next;
+  }
+
+  public void setNext(Model15 next) {
+    this.next = next;
+  }
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Model14 model14 = (Model14) o;
+    return Objects.equals(previous, model14.previous) &&
+        Objects.equals(next, model14.next) &&
+        super.equals(o);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(previous, next, super.hashCode());
+  }
+
+  @Override
+  public String toString() {
+    return "Model14{" +
+            "previous=" + previous +
+            ", next=" + next +
+            '}';
+  }
+}
+

--- a/oas-contract-tests/src/main/java/springfox/test/contract/oas/linkdedmodels/model/Model15.java
+++ b/oas-contract-tests/src/main/java/springfox/test/contract/oas/linkdedmodels/model/Model15.java
@@ -1,0 +1,54 @@
+package springfox.test.contract.oas.linkdedmodels.model;
+
+import java.util.Objects;
+
+
+public class Model15 extends Model {
+    private Model14 previous;
+
+    private Model16 next;
+
+    public Model14 getPrevious() {
+        return previous;
+    }
+
+    public void setPrevious(Model14 previous) {
+        this.previous = previous;
+    }
+
+    public Model16 getNext() {
+        return next;
+    }
+
+    public void setNext(Model16 next) {
+        this.next = next;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Model15 model15 = (Model15) o;
+        return Objects.equals(previous, model15.previous) &&
+                Objects.equals(next, model15.next) &&
+                super.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(previous, next, super.hashCode());
+    }
+
+    @Override
+    public String toString() {
+        return "Model15{" +
+                "previous=" + previous +
+                ", next=" + next +
+                '}';
+    }
+}
+

--- a/oas-contract-tests/src/main/java/springfox/test/contract/oas/linkdedmodels/model/Model16.java
+++ b/oas-contract-tests/src/main/java/springfox/test/contract/oas/linkdedmodels/model/Model16.java
@@ -1,0 +1,55 @@
+package springfox.test.contract.oas.linkdedmodels.model;
+
+import java.util.Objects;
+
+
+public class Model16 extends Model {
+
+    private Model15 previous;
+
+    private Model17 next;
+
+    public Model15 getPrevious() {
+        return previous;
+    }
+
+    public void setPrevious(Model15 previous) {
+        this.previous = previous;
+    }
+
+    public Model17 getNext() {
+        return next;
+    }
+
+    public void setNext(Model17 next) {
+        this.next = next;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Model16 model16 = (Model16) o;
+        return Objects.equals(previous, model16.previous) &&
+                Objects.equals(next, model16.next) &&
+                super.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(previous, next, super.hashCode());
+    }
+
+    @Override
+    public String toString() {
+        return "Model16{" +
+                "previous=" + previous +
+                ", next=" + next +
+                '}';
+    }
+}
+

--- a/oas-contract-tests/src/main/java/springfox/test/contract/oas/linkdedmodels/model/Model17.java
+++ b/oas-contract-tests/src/main/java/springfox/test/contract/oas/linkdedmodels/model/Model17.java
@@ -1,0 +1,55 @@
+package springfox.test.contract.oas.linkdedmodels.model;
+
+import java.util.Objects;
+
+
+public class Model17 extends Model {
+
+    private Model16 previous;
+
+    private Model18 next;
+
+    public Model16 getPrevious() {
+        return previous;
+    }
+
+    public void setPrevious(Model16 previous) {
+        this.previous = previous;
+    }
+
+    public Model18 getNext() {
+        return next;
+    }
+
+    public void setNext(Model18 next) {
+        this.next = next;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Model17 model17 = (Model17) o;
+        return Objects.equals(previous, model17.previous) &&
+                Objects.equals(next, model17.next) &&
+                super.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(previous, next, super.hashCode());
+    }
+
+    @Override
+    public String toString() {
+        return "Model17{" +
+                "previous=" + previous +
+                ", next=" + next +
+                '}';
+    }
+}
+

--- a/oas-contract-tests/src/main/java/springfox/test/contract/oas/linkdedmodels/model/Model18.java
+++ b/oas-contract-tests/src/main/java/springfox/test/contract/oas/linkdedmodels/model/Model18.java
@@ -1,0 +1,55 @@
+package springfox.test.contract.oas.linkdedmodels.model;
+
+import java.util.Objects;
+
+
+public class Model18 extends Model {
+
+    private Model17 previous;
+
+    private Model19 next;
+
+    public Model17 getPrevious() {
+        return previous;
+    }
+
+    public void setPrevious(Model17 previous) {
+        this.previous = previous;
+    }
+
+    public Model19 getNext() {
+        return next;
+    }
+
+    public void setNext(Model19 next) {
+        this.next = next;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Model18 model18 = (Model18) o;
+        return Objects.equals(previous, model18.previous) &&
+                Objects.equals(next, model18.next) &&
+                super.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(previous, next, super.hashCode());
+    }
+
+    @Override
+    public String toString() {
+        return "Model18{" +
+                "previous=" + previous +
+                ", next=" + next +
+                '}';
+    }
+}
+

--- a/oas-contract-tests/src/main/java/springfox/test/contract/oas/linkdedmodels/model/Model19.java
+++ b/oas-contract-tests/src/main/java/springfox/test/contract/oas/linkdedmodels/model/Model19.java
@@ -1,0 +1,55 @@
+package springfox.test.contract.oas.linkdedmodels.model;
+
+import java.util.Objects;
+
+
+public class Model19 extends Model {
+
+    private Model18 previous;
+
+    private Model20 next;
+
+    public Model18 getPrevious() {
+        return previous;
+    }
+
+    public void setPrevious(Model18 previous) {
+        this.previous = previous;
+    }
+
+    public Model20 getNext() {
+        return next;
+    }
+
+    public void setNext(Model20 next) {
+        this.next = next;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Model19 model19 = (Model19) o;
+        return Objects.equals(previous, model19.previous) &&
+                Objects.equals(next, model19.next) &&
+                super.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(previous, next, super.hashCode());
+    }
+
+    @Override
+    public String toString() {
+        return "Model19{" +
+                "previous=" + previous +
+                ", next=" + next +
+                '}';
+    }
+}
+

--- a/oas-contract-tests/src/main/java/springfox/test/contract/oas/linkdedmodels/model/Model20.java
+++ b/oas-contract-tests/src/main/java/springfox/test/contract/oas/linkdedmodels/model/Model20.java
@@ -1,0 +1,43 @@
+package springfox.test.contract.oas.linkdedmodels.model;
+
+import java.util.Objects;
+
+
+public class Model20 extends Model {
+
+    private Model19 previous;
+
+    public Model19 getPrevious() {
+        return previous;
+    }
+
+    public void setPrevious(Model19 previous) {
+        this.previous = previous;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Model20 model20 = (Model20) o;
+        return Objects.equals(previous, model20.previous) &&
+                super.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(previous, super.hashCode());
+    }
+
+    @Override
+    public String toString() {
+        return "Model20{" +
+                "previous=" + previous +
+                '}';
+    }
+}
+

--- a/oas-contract-tests/src/test/groovy/springfox/test/contract/oas/OpenApiContractSpec.groovy
+++ b/oas-contract-tests/src/test/groovy/springfox/test/contract/oas/OpenApiContractSpec.groovy
@@ -38,9 +38,9 @@ import spock.lang.Specification
 import springfox.documentation.schema.AlternateTypeRuleConvention
 import springfox.documentation.spring.web.plugins.JacksonSerializerConvention
 
-import static java.nio.charset.StandardCharsets.*
-import static org.skyscreamer.jsonassert.JSONCompareMode.*
-import static org.springframework.boot.test.context.SpringBootTest.*
+import static java.nio.charset.StandardCharsets.UTF_8
+import static org.skyscreamer.jsonassert.JSONCompareMode.NON_EXTENSIBLE
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, classes = OpenApiApplication)
 class OpenApiContractSpec extends Specification implements FileAccess {
@@ -91,10 +91,11 @@ class OpenApiContractSpec extends Specification implements FileAccess {
             NON_EXTENSIBLE)
 
     where:
-    contractFile    | groupName
-    'petstore.json' | 'petstore'
-    'bugs.json'     | 'bugs'
-    'features.json' | 'features'
+    contractFile         | groupName
+    'petstore.json'      | 'petstore'
+    'bugs.json'          | 'bugs'
+    'features.json'      | 'features'
+    'linked-models.json' | 'linked-models'
   }
 
   def "should list swagger resources for open api 3.0"() {
@@ -125,6 +126,11 @@ class OpenApiContractSpec extends Specification implements FileAccess {
       it.name == 'petstore' &&
           it.url == "/v3/api-docs?group=petstore" &&
           it.swaggerVersion == '3.0.3'
+    }
+    result.find {
+      it.name == 'linked-models' &&
+              it.url == "/v3/api-docs?group=linked-models" &&
+              it.swaggerVersion == '3.0.3'
     }
     result.find {
       it.name == 'default' &&

--- a/oas-contract-tests/src/test/resources/contracts/linked-models.json
+++ b/oas-contract-tests/src/test/resources/contracts/linked-models.json
@@ -1,0 +1,793 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Api Documentation",
+    "description": "Api Documentation",
+    "termsOfService": "urn:tos",
+    "contact": {},
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0"
+    },
+    "version": "1.0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost:__PORT__",
+      "description": "Inferred Url"
+    }
+  ],
+  "tags": [
+    {
+      "name": "linked-models-controller",
+      "description": "Linked Models Controller"
+    }
+  ],
+  "paths": {
+    "/linked-models": {
+      "get": {
+        "tags": [
+          "linked-models-controller"
+        ],
+        "summary": "linkedModels",
+        "operationId": "linkedModelsUsingGET",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Model"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Model": {
+        "title": "Model",
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "Model01": {
+        "title": "Model01",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "next": {
+            "$ref": "#/components/schemas/Model02"
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Model"
+          },
+          {
+            "title": "Model01",
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "next": {
+                "$ref": "#/components/schemas/Model02"
+              }
+            }
+          }
+        ]
+      },
+      "Model02": {
+        "title": "Model02",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "next": {
+            "$ref": "#/components/schemas/Model03"
+          },
+          "previous": {
+            "$ref": "#/components/schemas/Model01"
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Model"
+          },
+          {
+            "title": "Model02",
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "next": {
+                "$ref": "#/components/schemas/Model03"
+              },
+              "previous": {
+                "$ref": "#/components/schemas/Model01"
+              }
+            }
+          }
+        ]
+      },
+      "Model03": {
+        "title": "Model03",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "next": {
+            "$ref": "#/components/schemas/Model04"
+          },
+          "previous": {
+            "$ref": "#/components/schemas/Model02"
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Model"
+          },
+          {
+            "title": "Model03",
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "next": {
+                "$ref": "#/components/schemas/Model04"
+              },
+              "previous": {
+                "$ref": "#/components/schemas/Model02"
+              }
+            }
+          }
+        ]
+      },
+      "Model04": {
+        "title": "Model04",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "next": {
+            "$ref": "#/components/schemas/Model05"
+          },
+          "previous": {
+            "$ref": "#/components/schemas/Model03"
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Model"
+          },
+          {
+            "title": "Model04",
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "next": {
+                "$ref": "#/components/schemas/Model05"
+              },
+              "previous": {
+                "$ref": "#/components/schemas/Model03"
+              }
+            }
+          }
+        ]
+      },
+      "Model05": {
+        "title": "Model05",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "next": {
+            "$ref": "#/components/schemas/Model06"
+          },
+          "previous": {
+            "$ref": "#/components/schemas/Model04"
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Model"
+          },
+          {
+            "title": "Model05",
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "next": {
+                "$ref": "#/components/schemas/Model06"
+              },
+              "previous": {
+                "$ref": "#/components/schemas/Model04"
+              }
+            }
+          }
+        ]
+      },
+      "Model06": {
+        "title": "Model06",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "next": {
+            "$ref": "#/components/schemas/Model07"
+          },
+          "previous": {
+            "$ref": "#/components/schemas/Model05"
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Model"
+          },
+          {
+            "title": "Model06",
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "next": {
+                "$ref": "#/components/schemas/Model07"
+              },
+              "previous": {
+                "$ref": "#/components/schemas/Model05"
+              }
+            }
+          }
+        ]
+      },
+      "Model07": {
+        "title": "Model07",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "next": {
+            "$ref": "#/components/schemas/Model08"
+          },
+          "previous": {
+            "$ref": "#/components/schemas/Model06"
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Model"
+          },
+          {
+            "title": "Model07",
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "next": {
+                "$ref": "#/components/schemas/Model08"
+              },
+              "previous": {
+                "$ref": "#/components/schemas/Model06"
+              }
+            }
+          }
+        ]
+      },
+      "Model08": {
+        "title": "Model08",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "next": {
+            "$ref": "#/components/schemas/Model09"
+          },
+          "previous": {
+            "$ref": "#/components/schemas/Model07"
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Model"
+          },
+          {
+            "title": "Model08",
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "next": {
+                "$ref": "#/components/schemas/Model09"
+              },
+              "previous": {
+                "$ref": "#/components/schemas/Model07"
+              }
+            }
+          }
+        ]
+      },
+      "Model09": {
+        "title": "Model09",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "next": {
+            "$ref": "#/components/schemas/Model10"
+          },
+          "previous": {
+            "$ref": "#/components/schemas/Model08"
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Model"
+          },
+          {
+            "title": "Model09",
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "next": {
+                "$ref": "#/components/schemas/Model10"
+              },
+              "previous": {
+                "$ref": "#/components/schemas/Model08"
+              }
+            }
+          }
+        ]
+      },
+      "Model10": {
+        "title": "Model10",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "next": {
+            "$ref": "#/components/schemas/Model11"
+          },
+          "previous": {
+            "$ref": "#/components/schemas/Model09"
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Model"
+          },
+          {
+            "title": "Model10",
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "next": {
+                "$ref": "#/components/schemas/Model11"
+              },
+              "previous": {
+                "$ref": "#/components/schemas/Model09"
+              }
+            }
+          }
+        ]
+      },
+      "Model11": {
+        "title": "Model11",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "next": {
+            "$ref": "#/components/schemas/Model12"
+          },
+          "previous": {
+            "$ref": "#/components/schemas/Model10"
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Model"
+          },
+          {
+            "title": "Model11",
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "next": {
+                "$ref": "#/components/schemas/Model12"
+              },
+              "previous": {
+                "$ref": "#/components/schemas/Model10"
+              }
+            }
+          }
+        ]
+      },
+      "Model12": {
+        "title": "Model12",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "next": {
+            "$ref": "#/components/schemas/Model13"
+          },
+          "previous": {
+            "$ref": "#/components/schemas/Model11"
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Model"
+          },
+          {
+            "title": "Model12",
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "next": {
+                "$ref": "#/components/schemas/Model13"
+              },
+              "previous": {
+                "$ref": "#/components/schemas/Model11"
+              }
+            }
+          }
+        ]
+      },
+      "Model13": {
+        "title": "Model13",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "next": {
+            "$ref": "#/components/schemas/Model14"
+          },
+          "previous": {
+            "$ref": "#/components/schemas/Model12"
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Model"
+          },
+          {
+            "title": "Model13",
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "next": {
+                "$ref": "#/components/schemas/Model14"
+              },
+              "previous": {
+                "$ref": "#/components/schemas/Model12"
+              }
+            }
+          }
+        ]
+      },
+      "Model14": {
+        "title": "Model14",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "next": {
+            "$ref": "#/components/schemas/Model15"
+          },
+          "previous": {
+            "$ref": "#/components/schemas/Model13"
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Model"
+          },
+          {
+            "title": "Model14",
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "next": {
+                "$ref": "#/components/schemas/Model15"
+              },
+              "previous": {
+                "$ref": "#/components/schemas/Model13"
+              }
+            }
+          }
+        ]
+      },
+      "Model15": {
+        "title": "Model15",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "next": {
+            "$ref": "#/components/schemas/Model16"
+          },
+          "previous": {
+            "$ref": "#/components/schemas/Model14"
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Model"
+          },
+          {
+            "title": "Model15",
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "next": {
+                "$ref": "#/components/schemas/Model16"
+              },
+              "previous": {
+                "$ref": "#/components/schemas/Model14"
+              }
+            }
+          }
+        ]
+      },
+      "Model16": {
+        "title": "Model16",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "next": {
+            "$ref": "#/components/schemas/Model17"
+          },
+          "previous": {
+            "$ref": "#/components/schemas/Model15"
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Model"
+          },
+          {
+            "title": "Model16",
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "next": {
+                "$ref": "#/components/schemas/Model17"
+              },
+              "previous": {
+                "$ref": "#/components/schemas/Model15"
+              }
+            }
+          }
+        ]
+      },
+      "Model17": {
+        "title": "Model17",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "next": {
+            "$ref": "#/components/schemas/Model18"
+          },
+          "previous": {
+            "$ref": "#/components/schemas/Model16"
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Model"
+          },
+          {
+            "title": "Model17",
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "next": {
+                "$ref": "#/components/schemas/Model18"
+              },
+              "previous": {
+                "$ref": "#/components/schemas/Model16"
+              }
+            }
+          }
+        ]
+      },
+      "Model18": {
+        "title": "Model18",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "next": {
+            "$ref": "#/components/schemas/Model19"
+          },
+          "previous": {
+            "$ref": "#/components/schemas/Model17"
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Model"
+          },
+          {
+            "title": "Model18",
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "next": {
+                "$ref": "#/components/schemas/Model19"
+              },
+              "previous": {
+                "$ref": "#/components/schemas/Model17"
+              }
+            }
+          }
+        ]
+      },
+      "Model19": {
+        "title": "Model19",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "next": {
+            "$ref": "#/components/schemas/Model20"
+          },
+          "previous": {
+            "$ref": "#/components/schemas/Model18"
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Model"
+          },
+          {
+            "title": "Model19",
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "next": {
+                "$ref": "#/components/schemas/Model20"
+              },
+              "previous": {
+                "$ref": "#/components/schemas/Model18"
+              }
+            }
+          }
+        ]
+      },
+      "Model20": {
+        "title": "Model20",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "previous": {
+            "$ref": "#/components/schemas/Model19"
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Model"
+          },
+          {
+            "title": "Model20",
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "previous": {
+                "$ref": "#/components/schemas/Model19"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/springfox-schema/src/main/java/springfox/documentation/schema/DefaultModelDependencyProvider.java
+++ b/springfox-schema/src/main/java/springfox/documentation/schema/DefaultModelDependencyProvider.java
@@ -77,7 +77,6 @@ public class DefaultModelDependencyProvider implements ModelDependencyProvider {
   @Override
   public Set<ResolvedType> dependentModels(ModelContext modelContext) {
     return Stream.concat(resolvedDependencies(modelContext).stream()
-            .filter(ignorableTypes(modelContext))
             .filter(baseTypes(modelContext).negate()),
         schemaPluginsManager.dependencies(modelContext).stream())
         .collect(toSet());
@@ -91,12 +90,6 @@ public class DefaultModelDependencyProvider implements ModelDependencyProvider {
     String typeName = nameExtractor.typeName(modelContext);
     return Types.isBaseType(typeName);
   }
-
-  private Predicate<ResolvedType> ignorableTypes(final ModelContext modelContext) {
-    return input -> !modelContext.hasSeenBefore(input);
-  }
-
-
   private Set<ResolvedType> resolvedDependencies(ModelContext modelContext) {
     ResolvedType resolvedType = modelContext.alternateEvaluatedType();
     if (isBaseType(ModelContext.fromParent(modelContext, resolvedType))) {

--- a/springfox-schema/src/main/java/springfox/documentation/schema/DefaultModelProvider.java
+++ b/springfox-schema/src/main/java/springfox/documentation/schema/DefaultModelProvider.java
@@ -83,7 +83,7 @@ public class DefaultModelProvider implements ModelProvider {
         || isMapType(propertiesHost)
         || enumTypeDeterminer.isEnum(propertiesHost.getErasedType())
         || springfox.documentation.schema.Types.isBaseType(propertiesHost)
-        || modelContext.hasSeenBefore(propertiesHost)) {
+        || modelContext.isProcessed(propertiesHost)) {
       LOG.debug(
           "Skipping model of type {} as its either a container type, map, enum or base type, or its already "
               + "been handled",
@@ -166,7 +166,7 @@ public class DefaultModelProvider implements ModelProvider {
   private Optional<Model> mapModel(
       ModelContext parentContext,
       ResolvedType resolvedType) {
-    if (isMapType(resolvedType) && !parentContext.hasSeenBefore(resolvedType)) {
+    if (isMapType(resolvedType) && !parentContext.isProcessed(resolvedType)) {
       String typeName = typeNameExtractor.typeName(parentContext);
 
       return Optional.of(parentContext.getBuilder()

--- a/springfox-schema/src/main/java/springfox/documentation/schema/DefaultModelSpecificationProvider.java
+++ b/springfox-schema/src/main/java/springfox/documentation/schema/DefaultModelSpecificationProvider.java
@@ -85,7 +85,7 @@ public class DefaultModelSpecificationProvider implements ModelSpecificationProv
         || isMapType(propertiesHost)
         || enumTypeDeterminer.isEnum(propertiesHost.getErasedType())
         || ScalarTypes.builtInScalarType(propertiesHost).isPresent()
-        || modelContext.hasSeenBefore(propertiesHost)) {
+        || modelContext.isProcessed(propertiesHost)) {
       LOG.debug(
           "Skipping model of type {} as its either a container type, map, enum or base type, or its already "
               + "been handled",
@@ -166,7 +166,7 @@ public class DefaultModelSpecificationProvider implements ModelSpecificationProv
   private Optional<ModelSpecification> mapModel(
       ModelContext mapContext,
       ResolvedType resolvedType) {
-    if (isMapType(resolvedType) && !mapContext.hasSeenBefore(resolvedType)) {
+    if (isMapType(resolvedType) && !mapContext.isProcessed(resolvedType)) {
       ResolvedType keyType = resolver.resolve(String.class);
       ModelContext keyContext = ModelContext.fromParent(
           mapContext,

--- a/springfox-schema/src/test/groovy/springfox/documentation/schema/ModelProviderSpec.groovy
+++ b/springfox-schema/src/test/groovy/springfox/documentation/schema/ModelProviderSpec.groovy
@@ -56,7 +56,7 @@ class ModelProviderSpec extends Specification implements ModelProviderSupport {
         alternateTypeProvider(),
         namingStrategy,
         emptySet())
-    context.seen(new TypeResolver().resolve(HttpHeaders))
+    context.processed(new TypeResolver().resolve(HttpHeaders))
     def dependentTypeNames = sut.dependencies(context).values().stream()
         .collect(Collectors.toMap(getNames,
             Function.identity()))

--- a/springfox-schema/src/test/groovy/springfox/documentation/schema/property/OptimizedModelPropertiesProviderSpec.groovy
+++ b/springfox-schema/src/test/groovy/springfox/documentation/schema/property/OptimizedModelPropertiesProviderSpec.groovy
@@ -214,8 +214,8 @@ class OptimizedModelPropertiesProviderSpec extends Specification implements Sche
         emptySet())
 
     when:
-    inputContext.seen(typeResolver.resolve(Category))
-    returnContext.seen(typeResolver.resolve(Category))
+    inputContext.processed(typeResolver.resolve(Category))
+    returnContext.processed(typeResolver.resolve(Category))
 
     and:
     def inputValue = sut.propertiesFor(type, inputContext)

--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/scanners/ApiModelReader.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/scanners/ApiModelReader.java
@@ -653,7 +653,7 @@ public class ApiModelReader {
       ModelContext modelContext) {
 
     for (Class ignorableParameterType : ignorableParameterTypes) {
-      modelContext.seen(typeResolver.resolve(ignorableParameterType));
+      modelContext.processed(typeResolver.resolve(ignorableParameterType));
     }
   }
 

--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/scanners/ApiModelSpecificationReader.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/scanners/ApiModelSpecificationReader.java
@@ -48,7 +48,7 @@ public class ApiModelSpecificationReader {
       ModelContext modelContext) {
 
     for (Class ignorableParameterType : ignorableParameterTypes) {
-      modelContext.seen(resolver.resolve(ignorableParameterType));
+      modelContext.processed(resolver.resolve(ignorableParameterType));
     }
   }
 


### PR DESCRIPTION
**What's this PR do/fix?**
This PR fixes recursive infinite loop (and memory leak) when there are a lot of schemas depending on each other.
It occurs when there are multiple linked models where
A depends on B and C
C depends on D
D depends on B
etc ...

**Are there unit tests? If not how should this be manually tested?**
I have added a case into `oas-contract-tests` with linked models.
Without the fix, an infinite loop occurs on master branch on this case (you can verify it on master branch doing `git cherry-pick -n 03b3c6d1`, then running `oas-contract-tests` tests)

**Any background context you want to provide?**
The problem was we have to distinguish the read phase of resolvedType into modelContexts and the processed phase.
We should not create many instances of ResolvedType for the same model and we should reuse it when possible!

**What are the relevant issues?**
#3224