### PR TITLE
3804 headers in api response

### DIFF
--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/operation/OpenApiResponseReader.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/operation/OpenApiResponseReader.java
@@ -137,13 +137,15 @@ public class OpenApiResponseReader implements OperationBuilderPlugin {
                 .value(eachExample.value()).build());
           }
         }
-        headers.putAll(headers(apiResponse.headers()));
 
         type.ifPresent(t -> responseContext.responseBuilder()
             .representation(each.mediaType().isEmpty() ? MediaType.ALL : MediaType.valueOf(each.mediaType()))
             .apply(r -> r.model(
                 m -> m.copyOf(modelSpecifications.create(modelContext, t)))));
       }
+
+      headers.putAll(headers(apiResponse.headers()));
+
       responseContext.responseBuilder()
           .examples(examples)
           .description(apiResponse.description())

--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/operation/OpenApiResponseReader.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/readers/operation/OpenApiResponseReader.java
@@ -156,8 +156,9 @@ public class OpenApiResponseReader implements OperationBuilderPlugin {
 
   static boolean isSuccessful(String code) {
     try {
-      return HttpStatus.Series.SUCCESSFUL.equals(HttpStatus.Series.valueOf(code));
+      return HttpStatus.Series.SUCCESSFUL.equals(HttpStatus.Series.valueOf(Integer.parseInt(code)));
     } catch (Exception ignored) {
+      // Either couldn't parse the string to an integer, or the integer didn't match any status code series.
       return false;
     }
   }

--- a/springfox-swagger-ui/README.md
+++ b/springfox-swagger-ui/README.md
@@ -7,11 +7,11 @@ application.
 Prior versions of this library included sdoc.jsp which caused all kinds of problems on 
 spring boot. This latest version now bundles a html (swagger-ui.html) instead.
 
-The swagger ui version is specified in ./build.gradle where `swaggerUiVersion` is a git tag on the [swagger-ui repo]
-(https://github.com/swagger-api/swagger-ui).
+The swagger ui version is specified in ./build.gradle where `swaggerUiVersion` is a git tag on the 
+[swagger-ui repo](https://github.com/swagger-api/swagger-ui).
  
 - All content is served from a webjar convention, relative url taking the following form: 
 `webjars/${project.name}/${project.version}` e.g: `/webjars/springfox-swagger-ui/<YOUR-SPRINGFOX-VERSION>/swagger-ui.html`
 
-By default Spring Boot has sensible defaults for serving content from webjars. To configure vanilla spring web mvc apps to serve
- webjar content see the [webjar documentation] (http://www.webjars.org/documentation#springmvc) 
+By default Spring Boot has sensible defaults for serving content from webjars. To configure vanilla spring web mvc apps 
+to serve webjar content see the [webjar documentation](http://www.webjars.org/documentation#springmvc).


### PR DESCRIPTION
#### What's this PR do/fix?
Header annotations within an ApiResponse are ignored. 
It fixes two problems in the code.
Firstly, the `isSuccessful` method passes a String status code into Spring's `HttpStatus.Series.valueOf`, which requires an integer, so fails.
Secondly, the headers are added within the per content loop, although they are not per content. So they can be added repeatedly if there are multiple content sections, or not added at all if there is no content.
#### Are there unit tests? If not how should this be manually tested?
I couldn't see an existing test, and I didn't add one. (I'm not familiar with Spock.) Issue 3804 describes how to reproduce the error.
#### Any background context you want to provide?
#### What are the relevant issues?
#3804 