### PR TITLE
fix documentation type in webflux controller

### DIFF
--- a/springfox-oas/src/main/java/springfox/documentation/oas/web/OpenApiControllerWebFlux.java
+++ b/springfox-oas/src/main/java/springfox/documentation/oas/web/OpenApiControllerWebFlux.java
@@ -88,7 +88,7 @@ public class OpenApiControllerWebFlux {
     OpenAPI oas = mapper.mapDocumentation(documentation);
     OpenApiTransformationContext<ServerHttpRequest> context
         = new OpenApiTransformationContext<>(oas, serverRequest);
-    List<WebFluxOpenApiTransformationFilter> filters = transformations.getPluginsFor(DocumentationType.SWAGGER_2);
+    List<WebFluxOpenApiTransformationFilter> filters = transformations.getPluginsFor(DocumentationType.OAS_30);
     for (WebFluxOpenApiTransformationFilter each : filters) {
       context = context.next(each.transform(context));
     }


### PR DESCRIPTION
#### What's this PR do/fix?
It changes the documentation type from SWAGGER_2 to OAS_30 for Webflux controller in `springfox-oas` module.

#### Any background context you want to provide?
Without this change plugins configured for OAS_30 are ignored with WebFlux with OAS3 mode (for example WebFluxBasePathAndHostnameTransformationFilter).
