### PR TITLE
3470 unwrap info extensions map

### DIFF
--- a/springfox-oas/src/main/java/springfox/documentation/oas/configuration/OpenApiJacksonModule.java
+++ b/springfox-oas/src/main/java/springfox/documentation/oas/configuration/OpenApiJacksonModule.java
@@ -19,6 +19,7 @@
 
 package springfox.documentation.oas.configuration;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -48,6 +49,8 @@ import springfox.documentation.spring.web.json.JacksonModuleRegistrar;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.*;
 
+import java.util.Map;
+
 public class OpenApiJacksonModule extends SimpleModule implements JacksonModuleRegistrar {
 
   public void maybeRegisterModule(ObjectMapper mapper) {
@@ -64,7 +67,7 @@ public class OpenApiJacksonModule extends SimpleModule implements JacksonModuleR
   public void setupModule(SetupContext context) {
     super.setupModule(context);
     context.setMixInAnnotations(OpenAPI.class, NonEmptyMixin.class);
-    context.setMixInAnnotations(Info.class, NonEmptyMixin.class);
+    context.setMixInAnnotations(Info.class, UnwrapExtensionsMapMixin.class);
     context.setMixInAnnotations(License.class, NonEmptyMixin.class);
     context.setMixInAnnotations(Schema.class, NonEmptyMixin.class);
     context.setMixInAnnotations(PathItem.class, NonEmptyMixin.class);
@@ -91,5 +94,12 @@ public class OpenApiJacksonModule extends SimpleModule implements JacksonModuleR
   @JsonAutoDetect
   @JsonInclude(value = Include.NON_EMPTY)
   private class NonEmptyMixin {
+  }
+
+  @JsonAutoDetect
+  @JsonInclude(value = Include.NON_EMPTY)
+  private interface UnwrapExtensionsMapMixin {
+    @JsonAnyGetter
+    Map<String, Object> getExtensions();
   }
 }

--- a/springfox-oas/src/main/java/springfox/documentation/oas/mappers/SchemaMapper.java
+++ b/springfox-oas/src/main/java/springfox/documentation/oas/mappers/SchemaMapper.java
@@ -147,9 +147,8 @@ public abstract class SchemaMapper {
     source.getReference()
         .ifPresent(r -> {
           if (emptyToNull(r.getKey().getQualifiedModelName().getName()) != null) { //TODO: Find out why
-            ObjectSchema refModel = new ObjectSchema();
-            refModel.type(null);
-            refModel.set$ref(namesRegistry.nameByKey(r.getKey())
+            model.type(null);
+            model.set$ref(namesRegistry.nameByKey(r.getKey())
                 .orElse("ERROR - " + r.getKey().getQualifiedModelName()));
           }
         });
@@ -348,6 +347,7 @@ public abstract class SchemaMapper {
           .map(cm -> new ReferenceModelSpecificationToSchemaConverter(modelNamesRegistry)
               .convert(cm))
           .orElse(null);
+      // TODO mjp
     }
 
     if (schema != null) {

--- a/springfox-swagger-ui/build.gradle
+++ b/springfox-swagger-ui/build.gradle
@@ -21,7 +21,7 @@ plugins {
 }
 
 ext {
-  swaggerUiVersion = '3.26.2'
+  swaggerUiVersion = '3.52.3'
   swaggerUiDist = "build/libs/swagger-ui-dist.zip"
   swaggerUiExplodedDir = "swagger-ui-${swaggerUiVersion}/dist/"
   downloadUrl = "https://github.com/swagger-api/swagger-ui/archive/v${swaggerUiVersion}.zip"
@@ -36,10 +36,10 @@ dependencies {
 }
 
 node {
-  version = '12.16.2' // LTS
-  npmVersion = '6.4.1'
-  distBaseUrl = 'https://nodejs.org/dist'
-  download = true
+//  version = '12.16.2' // LTS
+//  npmVersion = '6.4.1'
+//  distBaseUrl = 'https://nodejs.org/dist'
+//  download = true
   workDir = file("${project.buildDir}/nodejs")
   npmWorkDir = file("${project.buildDir}/npm")
   nodeModulesDir = file("${project.projectDir}/src/web")

--- a/springfox-swagger-ui/src/web/package-lock.json
+++ b/springfox-swagger-ui/src/web/package-lock.json
@@ -6968,9 +6968,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "path-to-regexp": {

--- a/springfox-swagger-ui/src/web/package-lock.json
+++ b/springfox-swagger-ui/src/web/package-lock.json
@@ -6968,9 +6968,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
     "path-to-regexp": {


### PR DESCRIPTION
#### What's this PR do/fix?
The 'info' section in the generated JSON spec has a superfluous 'extensions' section. See [issue 3470](https://github.com/springfox/springfox/issues/3470)
#### Are there unit tests? If not how should this be manually tested?
No unit tests. See Issue 3470 for instructions to reproduce.
#### Any background context you want to provide?
#### What are the relevant issues?
3470
