### PR TITLE
2957 refresh csrf token before each request

### DIFF
--- a/springfox-swagger-ui/src/web/js/csrf.js
+++ b/springfox-swagger-ui/src/web/js/csrf.js
@@ -5,18 +5,13 @@
  */
 export default async function patchRequestInterceptor(baseUrl) {
   try {
-    const result = await getCsrf(baseUrl);
-
-    if (result) {
-      window.ui.getConfigs().requestInterceptor = request => {
-        request.headers[result.headerName] = result.token;
-        // console.debug(request);
-        return request;
-      };
-      console.debug('Successfully added csrf header for all requests');
-    } else {
-      console.debug('No csrf token can be found');
-    }
+    window.ui.getConfigs().requestInterceptor = request => {
+      const result = getCsrf(request.baseUrl);
+      request.headers[result.headerName] = result.token;
+      // console.debug(request);
+      return request;
+    };
+    console.debug('Successfully configured csrf interceptor for all requests');
   } catch (e) {
     console.error('Add csrf header encounter error', e)
   }
@@ -31,8 +26,8 @@ export default async function patchRequestInterceptor(baseUrl) {
  */
 export async function getCsrf(baseUrl) {
   return await getCsrfFromMeta(baseUrl)
-  .then(v => v ? v : getCsrfFromEndpoint(baseUrl))
-  .then(v => v ? v : getCsrfFromCookie());
+    .then(v => v ? v : getCsrfFromEndpoint(baseUrl))
+    .then(v => v ? v : getCsrfFromCookie());
 }
 
 /**
@@ -41,7 +36,7 @@ export async function getCsrf(baseUrl) {
  * @returns {Promise<{headerName: string, token: string}> | undefined}
  */
 async function getCsrfFromMeta(baseUrl) {
-  const htmlResponse = await fetch(`${baseUrl}/`, {credentials: 'same-origin'});
+  const htmlResponse = await fetch(`${baseUrl}/`, { credentials: 'same-origin' });
   if (htmlResponse.status !== 200) return;
 
   const html = await htmlResponse.text();
@@ -49,7 +44,7 @@ async function getCsrfFromMeta(baseUrl) {
   dummy.innerHTML = html;
   const headerDom = dummy.querySelector('meta[name="_csrf_header"]');
   const csrfDom = dummy.querySelector('meta[name="_csrf"]');
-  if (headerDom !== null && csrfDom !== null ) {
+  if (headerDom !== null && csrfDom !== null) {
     const headerName = headerDom.getAttribute('content');
     const token = csrfDom.getAttribute('content');
     if (headerName !== null && token !== null) {
@@ -64,7 +59,7 @@ async function getCsrfFromMeta(baseUrl) {
  * @returns {Promise<{headerName: string, token: string}> | undefined}
  */
 async function getCsrfFromEndpoint(baseUrl) {
-  const jsonResponse = await fetch(`${baseUrl}/csrf`, {credentials: 'same-origin'});
+  const jsonResponse = await fetch(`${baseUrl}/csrf`, { credentials: 'same-origin' });
   if (jsonResponse.status !== 200) return;
 
   const json = await jsonResponse.json();

--- a/springfox-swagger-ui/src/web/js/csrf.js
+++ b/springfox-swagger-ui/src/web/js/csrf.js
@@ -22,9 +22,9 @@ export default async function patchRequestInterceptor(baseUrl) {
  * 2. getCsrfFromEndpoint.
  * 3. getCsrfFromCookie
  * @param baseUrl
- * @returns {Promise<{headerName: string, token: string} | undefined>}
+ * @returns {{headerName: string, token: string} | undefined}
  */
-export async function getCsrf(baseUrl) {
+export function getCsrf(baseUrl) {
   return getCsrfFromCookie() || getCsrfFromEndpoint(baseUrl)
     .then(v => v ? v : getCsrfFromMeta(baseUrl));
 }

--- a/springfox-swagger-ui/src/web/js/csrf.js
+++ b/springfox-swagger-ui/src/web/js/csrf.js
@@ -22,12 +22,11 @@ export default async function patchRequestInterceptor(baseUrl) {
  * 2. getCsrfFromEndpoint.
  * 3. getCsrfFromCookie
  * @param baseUrl
- * @returns {Promise<{headerName: string, token: string} | undefined>}
+ * @returns {{headerName: string, token: string} | undefined}
  */
-export async function getCsrf(baseUrl) {
-  return await getCsrfFromMeta(baseUrl)
-    .then(v => v ? v : getCsrfFromEndpoint(baseUrl))
-    .then(v => v ? v : getCsrfFromCookie());
+export function getCsrf(baseUrl) {
+  return getCsrfFromCookie() || getCsrfFromEndpoint(baseUrl)
+    .then(v => v ? v : getCsrfFromMeta(baseUrl));
 }
 
 /**

--- a/springfox-swagger-ui/src/web/js/csrf.js
+++ b/springfox-swagger-ui/src/web/js/csrf.js
@@ -25,9 +25,8 @@ export default async function patchRequestInterceptor(baseUrl) {
  * @returns {Promise<{headerName: string, token: string} | undefined>}
  */
 export async function getCsrf(baseUrl) {
-  return await getCsrfFromMeta(baseUrl)
-    .then(v => v ? v : getCsrfFromEndpoint(baseUrl))
-    .then(v => v ? v : getCsrfFromCookie());
+  return getCsrfFromCookie() || getCsrfFromEndpoint(baseUrl)
+    .then(v => v ? v : getCsrfFromMeta(baseUrl));
 }
 
 /**

--- a/springfox-swagger-ui/src/web/js/csrf.test.js
+++ b/springfox-swagger-ui/src/web/js/csrf.test.js
@@ -1,5 +1,5 @@
 import 'babel-polyfill';
-import patchRequestInterceptor, {getCsrf} from './csrf';
+import patchRequestInterceptor, { getCsrf } from './csrf';
 import fetchMock from 'fetch-mock';
 import { FetchError } from 'node-fetch';
 
@@ -13,10 +13,10 @@ afterEach(() => {
   fetchMock.restore();
   // clear cookie
   document.cookie
-      .split(";")
-      .forEach((c) => {
-        document.cookie = c.replace(/^ +/, "").replace(/=.*/, "=;expires=" + new Date().toUTCString() + ";path=/");
-      });
+    .split(";")
+    .forEach((c) => {
+      document.cookie = c.replace(/^ +/, "").replace(/=.*/, "=;expires=" + new Date().toUTCString() + ";path=/");
+    });
 });
 
 async function expectOk() {

--- a/springfox-swagger-ui/src/web/js/csrf.test.js
+++ b/springfox-swagger-ui/src/web/js/csrf.test.js
@@ -26,13 +26,15 @@ async function expectOk() {
 }
 
 /*
- * 1 2 3: get from meta, get from endpoint, get from cookie
+ * 1 2 3: get from cookie, get from endpoint, get from meta
  * x: mock csrf not found
  * o: mock found!
  * ?: mock not define
  */
 
 test('x x x', async () => {
+  document.cookie = 'first=hi';
+  document.cookie = 'last=hi';
   fetchMock.mock(`${baseUrl}/`, 404);
   fetchMock.mock(`${baseUrl}/csrf`, 404);
 
@@ -41,27 +43,26 @@ test('x x x', async () => {
 });
 
 test('o ? ?', async () => {
-  fetchMock.mock(`${baseUrl}/`, `<html><head><title>Title</title>
-  <meta name="_csrf" content="${token}">
-  <meta name="_csrf_header" content="${headerName}">
-</head><body></body></html>`);
+  document.cookie = 'first=hi';
+  document.cookie = `${cookieName}=${token}`;
+  document.cookie = 'last=hi';
 
   await expectOk();
 });
 
 test('x o ?', async () => {
-  fetchMock.mock(`${baseUrl}/`, `<html><head><title>No Meta</title></head><body></body></html>`);
+  document.cookie = 'first=hi';
+  document.cookie = 'last=hi';
   fetchMock.mock(`${baseUrl}/csrf`, { headerName, token });
 
   await expectOk();
 });
 
 test('x x o', async () => {
-  fetchMock.mock(`${baseUrl}/`, 404);
-  fetchMock.mock(`${baseUrl}/csrf`, 404);
   document.cookie = 'first=hi';
-  document.cookie = `${cookieName}=${token}`;
   document.cookie = 'last=hi';
+  fetchMock.mock(`${baseUrl}/csrf`, 404);
+  fetchMock.mock(`${baseUrl}/`, `<html><head><title>Title</title><meta name="_csrf" content="${token}"><meta name="_csrf_header" content="${headerName}"></head><body></body></html>`);
   await expectOk();
 });
 

--- a/springfox-swagger-ui/src/web/js/csrf.test.js
+++ b/springfox-swagger-ui/src/web/js/csrf.test.js
@@ -86,6 +86,12 @@ test('x invalid-json ?', async () => {
     error = e;
   }
   expect(error).toBeInstanceOf(FetchError);
+});
+
+
+test('interceptor initialization', async () => {
+  window.ui = {};
+  window.ui.getConfigs = () => { return {} };
 
   // Make sure this function will not throw exception.
   await patchRequestInterceptor(baseUrl);


### PR DESCRIPTION
#### What's this PR do/fix?

PR #2957 Refresh CSRF token before each request

#### Are there unit tests? If not how should this be manually tested?

It should be tested manually by verifying that when csrf is enabled, the X-XSRF-TOKEN header matches the value ​​of the last received 'XSRF-TOKEN' cookie, not only for the first request but for all subsequent requests of type POST, PUT PATCH or DELETE for which the value of the cookie 'XSRF-TOKEN' is updated.

The same applies when 'XSRF-TOKEN is sent through a specific endpoint or meta : each request must be preceded by calls to get an up to date csrf token


The order of retrieving the XSRF token has been changed to lookup this token first via the cookie and therefore avoid unnecessary http calls.  has @mirceanagy reported in his comment https://github.com/springfox/springfox/issues/2957#issuecomment-487737843
