### PR TITLE
Update Spring Boot dependency to 2.6.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -25,7 +25,7 @@ ext {
   springDataRest = "3.3.0.RELEASE"
   springPluginVersion = "2.0.0.RELEASE"
   swagger2Core = "1.5.20"
-  springBoot = "2.3.1.RELEASE"
+  springBoot = "2.6.0"
   springfoxRfc6570Version = "1.0.0"
   undercouch = "4.0.4"
   validationApiVersion = '2.0.1.Final'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/oas-contract-tests/build.gradle
+++ b/oas-contract-tests/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   ext {
-    springBootVersion = '2.3.1.RELEASE'
+    springBootVersion = '2.6.0'
   }
   repositories {
     mavenCentral()

--- a/oas-contract-tests/src/main/java/springfox/test/contract/oas/repository/HashMapRepository.java
+++ b/oas-contract-tests/src/main/java/springfox/test/contract/oas/repository/HashMapRepository.java
@@ -140,6 +140,12 @@ public abstract class HashMapRepository<T, ID> implements CrudRepository<T, ID> 
   }
 
   @Override
+  public void deleteAllById(Iterable<? extends ID> ids) {
+    Assert.notNull(ids, "ids cannot be null");
+    ids.forEach(id -> entities.remove(id));
+  }
+
+  @Override
   public void deleteAll() {
     entities.clear();
   }

--- a/springfox-boot-starter/build.gradle
+++ b/springfox-boot-starter/build.gradle
@@ -18,6 +18,6 @@ dependencies {
   compileOnly libs.springBootProvided
   compileOnly libs.clientProvided
   compileOnly "javax.servlet:javax.servlet-api:$servlet"
-  annotationProcessor "org.springframework.boot:spring-boot-configuration-processor:2.3.1.RELEASE"
+  annotationProcessor "org.springframework.boot:spring-boot-configuration-processor:2.6.0"
 
 }

--- a/swagger-contract-tests-webflux/build.gradle
+++ b/swagger-contract-tests-webflux/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   ext {
-    springBootVersion = '2.3.1.RELEASE'
+    springBootVersion = '2.6.0'
   }
   repositories {
     mavenCentral()

--- a/swagger-contract-tests/build.gradle
+++ b/swagger-contract-tests/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   ext {
-    springBootVersion = '2.3.1.RELEASE'
+    springBootVersion = '2.6.0'
   }
   repositories {
     mavenCentral()

--- a/swagger-contract-tests/src/main/java/springfox/test/contract/swagger/BugsController.java
+++ b/swagger-contract-tests/src/main/java/springfox/test/contract/swagger/BugsController.java
@@ -149,7 +149,7 @@ public class BugsController {
 
   @RequestMapping(value = "1440", method = GET)
   public EntityModel<String> issue1440() {
-    return new EntityModel<>("1420");
+    return EntityModel.of("1420");
   }
 
   @RequestMapping(value = "1475", method = GET)

--- a/swagger-contract-tests/src/main/java/springfox/test/contract/swagger/data/rest/BasePathConfigurer.java
+++ b/swagger-contract-tests/src/main/java/springfox/test/contract/swagger/data/rest/BasePathConfigurer.java
@@ -22,6 +22,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.rest.core.config.RepositoryRestConfiguration;
 import org.springframework.data.rest.webmvc.config.RepositoryRestConfigurer;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 
 @Configuration
 public class BasePathConfigurer {
@@ -29,7 +30,7 @@ public class BasePathConfigurer {
   public RepositoryRestConfigurer repositoryRestConfigurer() {
     return new RepositoryRestConfigurer() {
       @Override
-      public void configureRepositoryRestConfiguration(RepositoryRestConfiguration config) {
+      public void configureRepositoryRestConfiguration(RepositoryRestConfiguration config, CorsRegistry cors) {
         config.setBasePath("/rest");
       }
     };


### PR DESCRIPTION
The newest version of Spring Boot 2.6.0 changes the way in which the default strategy for matching request paths against registered Spring MVC handler mappings. This has changed from AntPathMatcher to PathPatternParser which causes an exception to be thrown when using with SpringFox v3.0.0.

This change updates the SpringFox dependency of Spring Boot to v2.6.0 and the accompanying files required to support the new version.