### PR TITLE
Attempting to fix spring upgrade to 5.3.13

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -19,13 +19,13 @@ ext {
   slf4j = "1.7.25"
   snakeyaml = '1.26'
   spock = "1.3-groovy-2.5"
-  spring = "5.2.7.RELEASE"
-  springIntegration = "5.2.6.RELEASE"
+  spring = "5.3.13"
+  springIntegration = "5.5.6"
   springHateoas = "1.1.0.RELEASE"
   springDataRest = "3.3.0.RELEASE"
   springPluginVersion = "2.0.0.RELEASE"
   swagger2Core = "1.5.20"
-  springBoot = "2.3.1.RELEASE"
+  springBoot = "2.6.1"
   springfoxRfc6570Version = "1.0.0"
   undercouch = "4.0.4"
   validationApiVersion = '2.0.1.Final'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/oas-contract-tests/build.gradle
+++ b/oas-contract-tests/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   ext {
-    springBootVersion = '2.3.1.RELEASE'
+    springBootVersion = '2.6.1'
   }
   repositories {
     mavenCentral()

--- a/oas-contract-tests/src/main/java/springfox/test/contract/oas/repository/HashMapRepository.java
+++ b/oas-contract-tests/src/main/java/springfox/test/contract/oas/repository/HashMapRepository.java
@@ -55,7 +55,7 @@ public abstract class HashMapRepository<T, ID> implements CrudRepository<T, ID> 
     return entity;
   }
 
-  public void deleteAllById(Iterable<? extends Long> ids) {
+  public void deleteAllById(Iterable<ID> ids) {
   }
 
 

--- a/oas-contract-tests/src/main/java/springfox/test/contract/oas/repository/HashMapRepository.java
+++ b/oas-contract-tests/src/main/java/springfox/test/contract/oas/repository/HashMapRepository.java
@@ -55,7 +55,7 @@ public abstract class HashMapRepository<T, ID> implements CrudRepository<T, ID> 
     return entity;
   }
 
-  void deleteAllById(Iterable<? extends Long> ids) {
+  public void deleteAllById(Iterable<? extends Long> ids) {
   }
 
 

--- a/oas-contract-tests/src/main/java/springfox/test/contract/oas/repository/HashMapRepository.java
+++ b/oas-contract-tests/src/main/java/springfox/test/contract/oas/repository/HashMapRepository.java
@@ -55,7 +55,7 @@ public abstract class HashMapRepository<T, ID> implements CrudRepository<T, ID> 
     return entity;
   }
 
-  public void deleteAllById(Iterable<ID> ids) {
+  public void deleteAllById(Iterable<? extends ID> ids) {
   }
 
 

--- a/oas-contract-tests/src/main/java/springfox/test/contract/oas/repository/HashMapRepository.java
+++ b/oas-contract-tests/src/main/java/springfox/test/contract/oas/repository/HashMapRepository.java
@@ -55,6 +55,10 @@ public abstract class HashMapRepository<T, ID> implements CrudRepository<T, ID> 
     return entity;
   }
 
+  void deleteAllById(Iterable<? extends Long> ids) {
+  }
+
+
   @Override
   public <S extends T> java.util.List<S> saveAll(Iterable<S> entities) {
     Assert.notNull(entities, "entities cannot be null");

--- a/springfox-boot-starter/build.gradle
+++ b/springfox-boot-starter/build.gradle
@@ -18,6 +18,6 @@ dependencies {
   compileOnly libs.springBootProvided
   compileOnly libs.clientProvided
   compileOnly "javax.servlet:javax.servlet-api:$servlet"
-  annotationProcessor "org.springframework.boot:spring-boot-configuration-processor:2.3.1.RELEASE"
+  annotationProcessor "org.springframework.boot:spring-boot-configuration-processor:2.6.1"
 
 }

--- a/springfox-data-rest/src/main/java/springfox/documentation/spring/data/rest/SpringDataRestRequestHandler.java
+++ b/springfox-data-rest/src/main/java/springfox/documentation/spring/data/rest/SpringDataRestRequestHandler.java
@@ -74,7 +74,8 @@ class SpringDataRestRequestHandler implements RequestHandler {
   public PatternsRequestCondition getPatternsCondition() {
     return new WebMvcPatternsRequestConditionWrapper(
         contextPath,
-        new org.springframework.web.servlet.mvc.condition.PathPatternsRequestCondition(new PathPatternParser(), actionSpecification.getPath())
+        new org.springframework.web.servlet.mvc.condition.PathPatternsRequestCondition(new PathPatternParser(),
+                                                                                       actionSpecification.getPath())
     );
   }
 

--- a/springfox-data-rest/src/main/java/springfox/documentation/spring/data/rest/SpringDataRestRequestHandler.java
+++ b/springfox-data-rest/src/main/java/springfox/documentation/spring/data/rest/SpringDataRestRequestHandler.java
@@ -23,6 +23,8 @@ import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.util.pattern.PathPatternParser;
+
 import springfox.documentation.RequestHandler;
 import springfox.documentation.RequestHandlerKey;
 import springfox.documentation.service.ResolvedMethodParameter;
@@ -72,7 +74,7 @@ class SpringDataRestRequestHandler implements RequestHandler {
   public PatternsRequestCondition getPatternsCondition() {
     return new WebMvcPatternsRequestConditionWrapper(
         contextPath,
-        new org.springframework.web.servlet.mvc.condition.PatternsRequestCondition(actionSpecification.getPath())
+        new org.springframework.web.servlet.mvc.condition.PathPatternsRequestCondition(new PathPatternParser(), actionSpecification.getPath())
     );
   }
 

--- a/springfox-spring-webmvc/src/main/java/springfox/documentation/spring/web/WebMvcPatternsRequestConditionWrapper.java
+++ b/springfox-spring-webmvc/src/main/java/springfox/documentation/spring/web/WebMvcPatternsRequestConditionWrapper.java
@@ -19,6 +19,7 @@
 
 package springfox.documentation.spring.web;
 
+import org.springframework.web.servlet.mvc.condition.PathPatternsRequestCondition;
 import org.springframework.web.servlet.mvc.condition.PatternsRequestCondition;
 
 import java.util.Set;
@@ -30,11 +31,11 @@ public class WebMvcPatternsRequestConditionWrapper
     implements springfox.documentation.spring.wrapper.PatternsRequestCondition<PatternsRequestCondition> {
 
   private final String contextPath;
-  private final PatternsRequestCondition condition;
+  private final PathPatternsRequestCondition condition;
 
   public WebMvcPatternsRequestConditionWrapper(
       String contextPath,
-      PatternsRequestCondition condition) {
+      PathPatternsRequestCondition condition) {
 
     this.contextPath = contextPath;
     this.condition = condition;
@@ -54,7 +55,7 @@ public class WebMvcPatternsRequestConditionWrapper
   @Override
   public Set<String> getPatterns() {
     return this.condition.getPatterns().stream()
-        .map(p -> String.format("%s/%s", maybeChompTrailingSlash(contextPath),  maybeChompLeadingSlash(p)))
+        .map(p -> String.format("%s/%s", maybeChompTrailingSlash(contextPath),  maybeChompLeadingSlash(p.toString())))
         .collect(Collectors.toSet());
   }
 

--- a/springfox-spring-webmvc/src/main/java/springfox/documentation/spring/web/WebMvcRequestHandler.java
+++ b/springfox-spring-webmvc/src/main/java/springfox/documentation/spring/web/WebMvcRequestHandler.java
@@ -129,7 +129,9 @@ public class WebMvcRequestHandler implements RequestHandler {
   @Override
   public RequestHandlerKey key() {
     return new RequestHandlerKey(
-        requestMapping.getPathPatternsCondition().getPatterns().stream().map(PathPattern::toString).collect(Collectors.toSet()),
+        requestMapping.getPathPatternsCondition().getPatterns().stream()
+                      .map(PathPattern::toString)
+                      .collect(Collectors.toSet()),
         requestMapping.getMethodsCondition().getMethods(),
         requestMapping.getConsumesCondition().getConsumableMediaTypes(),
         requestMapping.getProducesCondition().getProducibleMediaTypes());

--- a/springfox-spring-webmvc/src/main/java/springfox/documentation/spring/web/WebMvcRequestHandler.java
+++ b/springfox-spring-webmvc/src/main/java/springfox/documentation/spring/web/WebMvcRequestHandler.java
@@ -24,6 +24,8 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
+import org.springframework.web.util.pattern.PathPattern;
+
 import springfox.documentation.RequestHandler;
 import springfox.documentation.RequestHandlerKey;
 import springfox.documentation.service.ResolvedMethodParameter;
@@ -36,6 +38,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.StringJoiner;
+import java.util.stream.Collectors;
 
 import static java.util.Optional.*;
 
@@ -80,7 +83,7 @@ public class WebMvcRequestHandler implements RequestHandler {
   public PatternsRequestCondition getPatternsCondition() {
     return new WebMvcPatternsRequestConditionWrapper(
         contextPath,
-        requestMapping.getPatternsCondition());
+        requestMapping.getPathPatternsCondition());
   }
 
   @Override
@@ -126,7 +129,7 @@ public class WebMvcRequestHandler implements RequestHandler {
   @Override
   public RequestHandlerKey key() {
     return new RequestHandlerKey(
-        requestMapping.getPatternsCondition().getPatterns(),
+        requestMapping.getPathPatternsCondition().getPatterns().stream().map(PathPattern::toString).collect(Collectors.toSet()),
         requestMapping.getMethodsCondition().getMethods(),
         requestMapping.getConsumesCondition().getConsumableMediaTypes(),
         requestMapping.getProducesCondition().getProducibleMediaTypes());

--- a/swagger-contract-tests-webflux/build.gradle
+++ b/swagger-contract-tests-webflux/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   ext {
-    springBootVersion = '2.3.1.RELEASE'
+    springBootVersion = '2.6.1'
   }
   repositories {
     mavenCentral()

--- a/swagger-contract-tests/build.gradle
+++ b/swagger-contract-tests/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   ext {
-    springBootVersion = '2.3.1.RELEASE'
+    springBootVersion = '2.6.1'
   }
   repositories {
     mavenCentral()

--- a/swagger-contract-tests/src/main/java/springfox/test/contract/swagger/BugsController.java
+++ b/swagger-contract-tests/src/main/java/springfox/test/contract/swagger/BugsController.java
@@ -149,7 +149,7 @@ public class BugsController {
 
   @RequestMapping(value = "1440", method = GET)
   public EntityModel<String> issue1440() {
-    return new EntityModel<>("1420");
+    return new EntityModel<String>("1420");
   }
 
   @RequestMapping(value = "1475", method = GET)

--- a/swagger-contract-tests/src/main/java/springfox/test/contract/swagger/BugsController.java
+++ b/swagger-contract-tests/src/main/java/springfox/test/contract/swagger/BugsController.java
@@ -149,7 +149,7 @@ public class BugsController {
 
   @RequestMapping(value = "1440", method = GET)
   public EntityModel<String> issue1440() {
-    return new EntityModel<String>("1420");
+    return EntityModel.of("1420");
   }
 
   @RequestMapping(value = "1475", method = GET)

--- a/swagger-contract-tests/src/main/java/springfox/test/contract/swagger/data/rest/BasePathConfigurer.java
+++ b/swagger-contract-tests/src/main/java/springfox/test/contract/swagger/data/rest/BasePathConfigurer.java
@@ -22,14 +22,14 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.rest.core.config.RepositoryRestConfiguration;
 import org.springframework.data.rest.webmvc.config.RepositoryRestConfigurer;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 
 @Configuration
 public class BasePathConfigurer {
   @Bean
   public RepositoryRestConfigurer repositoryRestConfigurer() {
     return new RepositoryRestConfigurer() {
-      @Override
-      public void configureRepositoryRestConfiguration(RepositoryRestConfiguration config) {
+      public void configureRepositoryRestConfiguration(RepositoryRestConfiguration config, CorsRegistry cors) {
         config.setBasePath("/rest");
       }
     };


### PR DESCRIPTION
#### What's this PR do/fix?
Attempting to upgrade spring framework to the latest and spring boot

#### Are there unit tests? If not how should this be manually tested?
No I haven't done any yet but not sure if they are required as current tests might cover this change.

#### Any background context you want to provide?
Latest springframework is deprecating `PatternsRequestCondition` and it's no longer the default https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.6-Release-Notes#pathpattern-based-path-matching-strategy-for-spring-mvc

#### What are the relevant issues?
springfox swagger won't load when using the latest springframework or spring-boot