### PR TITLE
request mapping    If the property of rquestmpping is empty, set the default value

### DIFF
--- a/springfox-spring-webmvc/src/main/java/springfox/documentation/spring/web/WebMvcRequestHandler.java
+++ b/springfox-spring-webmvc/src/main/java/springfox/documentation/spring/web/WebMvcRequestHandler.java
@@ -52,7 +52,7 @@ public class WebMvcRequestHandler implements RequestHandler {
       HandlerMethod handlerMethod) {
     this.contextPath = contextPath;
     this.methodResolver = methodResolver;
-    this.requestMapping = requestMapping;
+    this.requestMapping =  new RequestMappingInfo(requestMapping, requestMapping.getCustomCondition());
     this.handlerMethod = handlerMethod;
   }
 


### PR DESCRIPTION
  If the property of rquestmpping is empty, set the default value.
 
When using spring cloud version 2021.0.1 and spring boot version 2.6.3, the null pointer exception is caused because the attribute of rquestmpping is null.
example:
springfox.documentation.spring.web.WebMvcRequestHandler#key 

