### PR TITLE
fix : @ApiOperation attribute summary to value

### DIFF
--- a/docs/asciidoc/current-documentation.adoc
+++ b/docs/asciidoc/current-documentation.adoc
@@ -156,9 +156,9 @@ Currently supported list of annotations are in order of priority within the anno
 | e.g. `@ApiOperation(notes="${operation1.description}")`
 
 | ApiOperation
-| summary
-| Operation#summary
-| e.g. `@ApiOperation(value="${operation1.summary}")`
+| value
+| Operation#value
+| e.g. `@ApiOperation(value="${operation1.value}")`
 
 | RequestParam
 | defaultValue


### PR DESCRIPTION
#### What's this PR do/fix?
I'm looking at the [document](https://springfox.github.io/springfox/docs/current/#overriding-descriptions-via-properties), and the contents of the document are different from the existing usage, so I'm requesting correction.

```
@ApiOperation(value = "Find Members", notes = "Find All Members api")
```

#### Are there unit tests? If not how should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?
