### PR TITLE
fix Api annotation 's unused value

### DIFF
--- a/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/SwaggerApiListingReader.java
+++ b/springfox-swagger-common/src/main/java/springfox/documentation/swagger/web/SwaggerApiListingReader.java
@@ -60,6 +60,9 @@ public class SwaggerApiListingReader implements ApiListingBuilderPlugin {
       if (oasTags.isEmpty()) {
         tagSet.addAll(apiAnnotation.map(tags())
             .orElse(new TreeSet<>()));
+        if (tagSet.isEmpty() && apiAnnotation.map(Api::value).isPresent()) {
+          tagSet.add(apiAnnotation.map(Api::value).get());
+        }
         if (tagSet.isEmpty()) {
           tagSet.add(apiListingContext.getResourceGroup().getGroupName());
         }


### PR DESCRIPTION
PR fix
fix Api annotation 's unused value
"If tags() is not used, this value will be used to set the tag for the operations described by this resource. Otherwise, the value will be ignored."