### PR TITLE
Upgrade swagger-ui version to 3.38.0 to fix XSS vulnerability

### DIFF
--- a/springfox-swagger-ui/build.gradle
+++ b/springfox-swagger-ui/build.gradle
@@ -21,7 +21,7 @@ plugins {
 }
 
 ext {
-  swaggerUiVersion = '3.26.2'
+  swaggerUiVersion = '3.38.0'
   swaggerUiDist = "build/libs/swagger-ui-dist.zip"
   swaggerUiExplodedDir = "swagger-ui-${swaggerUiVersion}/dist/"
   downloadUrl = "https://github.com/swagger-api/swagger-ui/archive/v${swaggerUiVersion}.zip"


### PR DESCRIPTION
#### What's this PR do/fix?
Swagger UI XSS vulnerability: https://www.vidocsecurity.com/blog/hacking-swagger-ui-from-xss-to-account-takeovers

#### Are there unit tests? If not how should this be manually tested?
Manually tested

